### PR TITLE
chore(deps): bump claude-code to 2.1.226

### DIFF
--- a/pkgs/by-name/claude-code/manifest.json
+++ b/pkgs/by-name/claude-code/manifest.json
@@ -1,17 +1,17 @@
 {
-  "version": "2.1.224",
+  "version": "2.1.226",
   "platforms": {
     "darwin-arm64": {
-      "checksum": "391df9d2ab04e4cf32199335720ac7715a582e91eaecfd4d2198a16f57ea59b3"
+      "checksum": "013a1cf17df5ff1dcc189d5d6fd3fdd5f097ddc3cd41aa9992e99805574febbe"
     },
     "darwin-x64": {
-      "checksum": "7ae17a768a7270c7bd6c5484587c3c650dff425b4beeeb03addc1f2a4a7d702a"
+      "checksum": "773b095876f13ddb8336bfae202a57c62e358b1882746f1d55e3680601a32c59"
     },
     "linux-arm64": {
-      "checksum": "3e50836e227868746273653e0f8115cf5fc9cb34a081847c6040c81d80812c33"
+      "checksum": "feb715ee066d02a400c9d83941592f11c8e8fa6628c1e3c14262bc529f950498"
     },
     "linux-x64": {
-      "checksum": "a2b5add7dc4bcd8eaa029f4e8bdac4df7769b4073698db7989d206baf9419c2d"
+      "checksum": "4e9bec1177ce9690e8bd988b710ac24105e70da428dd094c5adcbbe786a55555"
     }
   }
 }


### PR DESCRIPTION
Bumps the pinned claude-code version from 2.1.224 to 2.1.226.