### PR TITLE
fix(hooks): gate kill by target hazard, not by the word kill

### DIFF
--- a/modules/checks/hooks.nix
+++ b/modules/checks/hooks.nix
@@ -1,0 +1,93 @@
+# Behavioral checks for the PreToolUse Bash hooks in modules/home/tools/hooks.
+#
+# The hooks are plain scripts read by writeShellApplication in the home module,
+# so a check can drive the same file directly: feed it a hook JSON payload on
+# stdin and assert whether it emits an "ask" decision or exits silently to fall
+# through to the blanket Bash allow.
+{ ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.hook-gate-dangerous-commands =
+        let
+          # Each case is "<expected> <command>", where <expected> is ask or allow.
+          cases = [
+            # Explicit-PID kill is not a gated hazard: the PID names one already
+            # identified process, unlike a pattern that can select processes the
+            # author never inspected.
+            "allow kill 1308"
+            "allow kill -TERM 1308"
+            "allow kill -9 1234"
+            "allow kill -SIGKILL 1234"
+            "allow kill -s TERM 1234"
+            "allow kill 123 456 789"
+            # kill -0 sends no signal; it only probes liveness.
+            "allow kill -0 1308"
+            "allow kill -0 $WATCHER_PID"
+            "allow ps aux | grep watcher"
+
+            # Pattern selectors stay gated in every form.
+            "ask pkill watcher"
+            "ask pkill -f 'firstmate.*watcher'"
+            "ask pkill -9 -f watcher"
+            "ask killall node"
+            "ask killall -9 node"
+            # Indirect kill targets stay gated: the target can resolve to a
+            # process the author never named.
+            "ask kill $PID"
+            "ask kill $(pgrep -f watcher)"
+            "ask kill `pgrep watcher`"
+            "ask kill -TERM $(cat /tmp/pid)"
+            "ask kill -f watcher"
+            "ask kill %1"
+            "ask kill"
+            # A safe-looking segment must not launder a later unsafe one.
+            "ask kill 1308; kill $OTHER"
+            "ask ps aux | xargs kill"
+          ];
+        in
+        pkgs.runCommand "hook-gate-dangerous-commands"
+          {
+            nativeBuildInputs = [
+              pkgs.jq
+              pkgs.gnugrep
+            ];
+            hook = ../home/tools/hooks/gate-dangerous-commands.sh;
+            caseFile = pkgs.writeText "gate-dangerous-commands-cases" (
+              builtins.concatStringsSep "\n" cases + "\n"
+            );
+          }
+          ''
+            set -uo pipefail
+            failures=0
+
+            while IFS= read -r line; do
+              [ -n "$line" ] || continue
+              expected="''${line%% *}"
+              command="''${line#* }"
+
+              payload=$(jq -Rn --arg c "$command" '{tool_input: {command: $c}}')
+              output=$(printf '%s' "$payload" | bash "$hook" 2>/dev/null || true)
+
+              if [ -n "$output" ]; then
+                actual=ask
+              else
+                actual=allow
+              fi
+
+              if [ "$actual" != "$expected" ]; then
+                echo "FAIL: expected $expected, got $actual for: $command" >&2
+                failures=$((failures + 1))
+              fi
+            done < "$caseFile"
+
+            if [ "$failures" -ne 0 ]; then
+              echo "$failures gate-dangerous-commands case(s) failed" >&2
+              exit 1
+            fi
+
+            touch $out
+          '';
+    };
+}

--- a/modules/home/tools/hooks/gate-dangerous-commands.sh
+++ b/modules/home/tools/hooks/gate-dangerous-commands.sh
@@ -65,7 +65,11 @@ Gated patterns (each returns permissionDecision "ask"):
     docker/podman push *
 
   Process management
-    kill/killall/pkill *
+    pkill * / killall *          (all forms; they select processes by pattern)
+    kill <target> where any target is not a literal numeric PID
+      (variable, command substitution, glob, job spec, -f, or a pattern)
+    xargs ... kill
+    kill [-SIG] <numeric-pid>... and kill -0 * are not gated
 
   Destructive file operations (rm bypass vectors)
     find ... -delete
@@ -120,6 +124,42 @@ jj_cmd_match() {
   local flag_no_arg='--no-pager|--quiet|--verbose|--debug|--ignore-working-copy'
   local jj_opts="(\s+(${flag_arg}|${flag_no_arg}))*"
   echo "$COMMAND" | grep -qE "(^|[;&|]\s*|&&\s*|\|\|?\s*|\\\$\(\s*)jj${jj_opts}\s+$1"
+}
+
+# Return 0 only when every `kill` invocation in $COMMAND targets literal numeric
+# PIDs, optionally after one signal flag (-9, -TERM, -s TERM, --signal=TERM).
+# Anything else -- a variable, command substitution, glob, job spec, -f, or a
+# bare pattern -- returns 1, because such a target can resolve to a process the
+# author never identified. `kill -0` is exempt outright: it sends no signal and
+# only probes liveness.
+#
+# Splits on shell operators with parameter expansion rather than a regex over the
+# whole command, so a second segment (`ps ... ; kill ...`) cannot hide behind a
+# safe-looking first one. Splitting on parens too means a `kill` nested inside a
+# command substitution or subshell is inspected as its own segment, while the
+# substitution supplying its argument (`kill $(pgrep x)`) still fails the
+# literal-PID test.
+kill_targets_are_explicit_pids() {
+  local segments segment
+  segments="${COMMAND//&&/$'\n'}"
+  segments="${segments//||/$'\n'}"
+  segments="${segments//;/$'\n'}"
+  segments="${segments//|/$'\n'}"
+  segments="${segments//&/$'\n'}"
+  segments="${segments//(/$'\n'}"
+  segments="${segments//)/$'\n'}"
+  segments="${segments//\`/$'\n'}"
+
+  local sig='-[0-9]{1,2}|-(SIG)?[A-Z]+[A-Z0-9]*|-s[[:space:]]+[A-Za-z0-9]+|--signal[[:space:]]*=?[[:space:]]*[A-Za-z0-9]+'
+  local safe="^[[:space:]]*kill([[:space:]]+(${sig}))?([[:space:]]+[0-9]+)+[[:space:]]*\$"
+  local probe='^[[:space:]]*kill[[:space:]]+(-0|-s[[:space:]]+0|--signal[[:space:]]*=?[[:space:]]*0)([[:space:]]|$)'
+
+  while IFS= read -r segment; do
+    printf '%s' "$segment" | grep -qE '^[[:space:]]*kill([[:space:]]|$)' || continue
+    printf '%s' "$segment" | grep -qE "$probe" && continue
+    printf '%s' "$segment" | grep -qE "$safe" || return 1
+  done <<< "$segments"
+  return 0
 }
 
 # Fire-and-forget NOTICE via ntfy-send when a relaxed gate arm permits an action
@@ -332,8 +372,21 @@ if [ -z "$REASON" ]; then
 fi
 
 # --- Process management ---
+# pkill and killall select processes by pattern, so they can reach processes the
+# author never inspected -- on a host running sibling agent homes, that includes
+# other agents' processes. `kill 1308` with a PID read off ps selects exactly the
+# one process already identified. Gate the pattern selectors in every form, and
+# gate `kill` only when a target is not a literal numeric PID.
 if [ -z "$REASON" ]; then
-  cmd_match '(kill|killall|pkill)\s' && REASON="process termination"
+  cmd_match '(pkill|killall)\s' && REASON="pattern-matched process termination"
+fi
+if [ -z "$REASON" ]; then
+  if cmd_match 'kill(\s|$)' && ! kill_targets_are_explicit_pids; then
+    REASON="process termination with a target that is not an explicit PID"
+  fi
+fi
+if [ -z "$REASON" ]; then
+  echo "$COMMAND" | grep -qE '(^|[|;&])\s*xargs\s.*\bkill\b' && REASON="xargs kill terminates processes selected upstream"
 fi
 
 # --- Destructive file operations (rm bypass vectors) ---


### PR DESCRIPTION
## Problem

`gate-dangerous-commands.sh` gated process management with a single blanket match on `(kill|killall|pkill)\s`, drawing no distinction between hazardous and safe forms.

`pkill -f <pattern>` and `killall <name>` select processes by pattern and can reach processes the author never inspected — on this host that includes sibling firstmate homes. `kill -TERM 1308`, where the PID was just read off `ps`, selects exactly one already-identified process. The blanket rule treated them identically, so routine diagnostic work escalated to a confirmation prompt on every explicit-PID kill.

## Change

Gate the actual hazard rather than the word:

- `pkill` and `killall` stay gated in **all** forms.
- `kill` is gated only when a target is not a literal numeric PID — a variable, command substitution, backticks, glob, job spec, `-f`, or a bare pattern.
- `kill [-SIG] <numeric-pid>...` falls through unmatched.
- `kill -0` is exempt outright: it sends no signal and only probes liveness.
- New: `xargs ... kill` is gated, so a pattern-selected kill cannot reach the relaxed path via a pipeline.

The helper splits the command on shell operators and parentheses with parameter expansion rather than matching a regex over the whole string, so a safe-looking first segment cannot launder a later unsafe one (`kill 1308; kill $OTHER` still prompts) and a `kill` nested in a substitution is inspected on its own.

This strictly narrows the gate. No form that can select a process the author did not name becomes permitted.

## Verification

New flake check `hook-gate-dangerous-commands` (`modules/checks/hooks.nix`) drives the hook script over a case table covering both directions — 9 allow cases, 14 ask cases.

Severity: against the previous blanket rule the check fails on 10 cases (8 explicit-PID forms wrongly asked, plus bare `kill` and `xargs kill` wrongly allowed), so it would not pass a plausible incorrect implementation.

```
nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands   # passes
```

`shellcheck` clean, `nix fmt` clean.
