### PR TITLE
chore(quota-axi): bump to 0.1.28 via the package updater

### DIFF
--- a/pkgs/by-name/quota-axi/package-lock.json
+++ b/pkgs/by-name/quota-axi/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "quota-axi",
-  "version": "0.1.17",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quota-axi",
-      "version": "0.1.17",
+      "version": "0.1.28",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "2.1.0",
-        "axi-sdk-js": "^0.1.7"
+        "axi-sdk-js": "^0.1.10"
       },
       "bin": {
         "quota-axi": "dist/bin/quota-axi.js"

--- a/pkgs/by-name/quota-axi/package.nix
+++ b/pkgs/by-name/quota-axi/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.1.17";
+  version = "0.1.28";
 
   # The npm registry tarball carries the built dist/ tree but no lockfile, and
   # the GitHub repo carries a pnpm-lock.yaml that buildNpmPackage cannot read.
@@ -22,7 +22,7 @@ let
     tar -xzf ${
       fetchurl {
         url = "https://registry.npmjs.org/quota-axi/-/quota-axi-${version}.tgz";
-        hash = "sha256-gfH3C7n+OjX4eBoRZsfDyQnfwp8bXOr9tykVxmYkyzA=";
+        hash = "sha256-tuSk9UW/aqCKx4nTIxO+cJCUxRcn1eDZfSyS7XeSefU=";
       }
     } -C $out --strip-components=1
     jq 'del(.devDependencies, .scripts)' $out/package.json > $out/package.json.stripped
@@ -37,7 +37,7 @@ buildNpmPackage {
   nodejs = nodejs_22;
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-XUoc/3XVuOACD+KTEdw4bS9TAS851n5AFkzILLZ/EaQ=";
+  npmDepsHash = "sha256-DSKvsCFr4H1ztgne1zkjh06EU2ALbclc2fR6rI55ffM=";
 
   makeCacheWritable = true;
 


### PR DESCRIPTION
## Summary

Bumps `quota-axi` from 0.1.17 to 0.1.28, clearing Firstmate's version floor.

The floor is `FM_QUOTA_AXI_MIN=0.1.25`, read from `bin/fm-quota-axi-lib.sh` in the Firstmate home. The pin at 0.1.17 sat below it, so Firstmate reported the tool as unusable and a standing captain exception let dispatch proceed without it. The npm registry latest is 0.1.28, which is at or above the floor.

Version, src hash, `npmDepsHash`, and the `package-lock.json` sidecar were all regenerated by `pkgs/by-name/quota-axi/update.sh`, not hand-edited. The registry-tarball sourcing decision is preserved — the GitHub repo carries a `pnpm-lock.yaml` that `buildNpmPackage` cannot read.

## Note on `just update-package`

`just update-package quota-axi` does not work for the axi-family updaters. The recipe builds `.#quota-axi.updateScript` and runs it from its `/nix/store` path, but the script derives both its package directory and the npm package name from `BASH_SOURCE`, so it resolves `PKG_DIR=/nix/store` and fails with `sed: can't read /nix/store/package.nix`. Ran `./update.sh` from the package directory instead. All five axi `update.sh` copies are byte-identical and share this property; fixing the recipe is out of scope here.

## Testing

Narrowest selection that would still fail if this bump were wrong:

- `checks.aarch64-darwin.package-quota-axi` — builds the derivation this diff edits. Passes; the built binary reports `0.1.28`.
- `checks.aarch64-darwin.treefmt` — the two edited files are formatted sources. Passes.
- `checks.aarch64-darwin.home-manager-crs58` — the sole consumer, via the `ai` aggregate in `modules/home/ai/firstmate/default.nix`. Builds, and `home-path/bin/quota-axi --version` reports `0.1.28`, confirming PATH resolution from the rebuilt home configuration.

Deliberately left out: the rest of the check set (other packages, machine/darwin configurations, secrets, k8s, terraform) touches nothing this diff changes.

## Follow-up (outside this repo)

Once 0.1.28 is active on the host, the standing missing-quota-axi exception in the Firstmate home's captain preferences can be retired. That is a Firstmate-side edit, not part of this change.
