### PR TITLE
feat(pkgs): package the atomic coding agent from its release tarball

### DIFF
--- a/modules/apps/updates.nix
+++ b/modules/apps/updates.nix
@@ -10,6 +10,11 @@
   perSystem =
     { config, ... }:
     {
+      apps.update-atomic = {
+        type = "app";
+        program = "${config.packages.atomic.updateScript}";
+      };
+
       apps.update-claude-code = {
         type = "app";
         program = "${config.packages.claude-code.updateScript}";

--- a/pkgs/by-name/atomic/manifest.json
+++ b/pkgs/by-name/atomic/manifest.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.9.13",
+  "platforms": {
+    "darwin-arm64": {
+      "checksum": "c121ac35ef9db9233f17f4932fc2f399d99dce31f887d202050009f88fc632ec"
+    },
+    "darwin-x64": {
+      "checksum": "522762a5bfc46cce6dcfad5014992992ee142748341355f659af693ca5c9e917"
+    },
+    "linux-arm64": {
+      "checksum": "dd69b47bd2a075482b9849208a114c8f97a4391f959e5137c6f314d3150c6069"
+    },
+    "linux-x64": {
+      "checksum": "f4b33b1d023d071318905f0e9d5108af8692a65035d5fc9c7834d09f25bd4175"
+    }
+  }
+}

--- a/pkgs/by-name/atomic/package.nix
+++ b/pkgs/by-name/atomic/package.nix
@@ -20,6 +20,7 @@
   makeBinaryWrapper,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+  runCommand,
   jq,
   fd,
   ripgrep,
@@ -135,7 +136,31 @@ else
 
     strictDeps = true;
 
-    passthru.updateScript = ./update.sh;
+    passthru = {
+      updateScript = ./update.sh;
+
+      # doInstallCheck runs against $out while it is still being built and
+      # still writable. This runs the same launcher against the finished,
+      # read-only store path, which is the condition the split launcher and
+      # its sidecar payload actually have to survive.
+      tests.help =
+        runCommand "atomic-test-help"
+          {
+            meta.timeout = 60;
+          }
+          ''
+            export HOME="$PWD/home"
+            mkdir -p "$HOME"
+
+            ${lib.getExe finalAttrs.finalPackage} --help > help.txt
+
+            grep -q "AI coding assistant" help.txt
+            grep -q "atomic \[options\] \[@files\.\.\.\] \[messages\.\.\.\]" help.txt
+            grep -q "Install extension source and add to settings" help.txt
+
+            touch "$out"
+          '';
+    };
 
     meta = {
       description = "Coding agent CLI with read, bash, edit, and write tools and session management";

--- a/pkgs/by-name/atomic/package.nix
+++ b/pkgs/by-name/atomic/package.nix
@@ -102,7 +102,11 @@ else
         [ -f "$pkgdir/native/pg-symlinks.json" ] || continue
         jq -r '.[] | [.source, .target] | @tsv' "$pkgdir/native/pg-symlinks.json" \
           | while IFS=$'\t' read -r source target; do
-            ln -s "$(basename "$source")" "$pkgdir$target"
+            # upstream's own script swallows an existing target, so a release
+            # that starts shipping these links stays a no-op here rather than
+            # failing the build
+            [ -e "$pkgdir$target" ] || [ -L "$pkgdir$target" ] \
+              || ln -s "$(basename "$source")" "$pkgdir$target"
           done
       done
     '';

--- a/pkgs/by-name/atomic/package.nix
+++ b/pkgs/by-name/atomic/package.nix
@@ -1,0 +1,158 @@
+# atomic is Bastani's terminal coding agent, packaged from the upstream
+# prebuilt release tarball. Each archive is produced by `bun build --compile`
+# as a split launcher: a small `atomic` executable that resolves `app.js` and a
+# prebundled node_modules relative to the directory of its own execPath. Bun
+# resolves execPath through symlinks, but the launcher is wrapped rather than
+# symlinked so the runtime tool lookups below can be satisfied. The napi
+# natives ship prebuilt in that bundle, so nothing here needs a Rust toolchain
+# and the release archive is preferred over the published npm package.
+#
+# Version and per-platform checksums live in manifest.json alongside this file
+# rather than in this expression.
+#
+# update: nix run .#update-atomic
+# source: https://github.com/bastani-inc/atomic
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  jq,
+  fd,
+  ripgrep,
+}:
+let
+  manifest = lib.importJSON ./manifest.json;
+  platforms = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    aarch64-darwin = "darwin-arm64";
+  };
+  platform = platforms.${stdenv.hostPlatform.system} or null;
+in
+# The flake forces `checks.<system>` for every system it evaluates, so a system
+# outside the map has to make this attribute absent rather than throw when the
+# derivation is forced.
+if platform == null then
+  null
+else
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "atomic";
+    inherit (manifest) version;
+
+    src = fetchurl {
+      url = "https://github.com/bastani-inc/atomic/releases/download/${finalAttrs.version}/atomic-${platform}.tar.gz";
+      sha256 = manifest.platforms.${platform}.checksum;
+    };
+
+    sourceRoot = "atomic";
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    # the launcher carries its bytecode payload past the end of the executable
+    # image, which stripping discards
+    dontStrip = true;
+
+    nativeBuildInputs = [
+      makeBinaryWrapper
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isElf [
+      autoPatchelfHook
+      jq
+    ];
+
+    buildInputs = lib.optionals stdenv.hostPlatform.isElf [
+      stdenv.cc.cc.lib
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/lib"
+      cp -R . "$out/lib/atomic"
+
+      # atomic resolves fd and rg from PATH and otherwise downloads a release
+      # binary from GitHub at first use, which cannot run against this libc.
+      # PATH is suffixed so the caller's own tools still win.
+      makeWrapper "$out/lib/atomic/atomic" "$out/bin/atomic" \
+        --set ATOMIC_SKIP_VERSION_CHECK 1 \
+        --suffix PATH : ${
+          lib.makeBinPath [
+            fd
+            ripgrep
+          ]
+        }
+
+      runHook postInstall
+    '';
+
+    # @embedded-postgres carries its shared libraries as versioned files with
+    # the SONAME links recorded in native/pg-symlinks.json, which upstream's
+    # npm postinstall recreates; a release tarball never runs that script, so
+    # the links are absent. The postgres binaries resolve their libraries
+    # through an $ORIGIN-relative rpath, so without the links autoPatchelf
+    # cannot satisfy libicuuc.so.60 and the durable-workflow database has no
+    # runtime. Upstream ships this payload in the linux-x64 archive only.
+    postInstall = lib.optionalString stdenv.hostPlatform.isElf ''
+      for pkgdir in "$out"/lib/atomic/node_modules/@embedded-postgres/*/; do
+        [ -f "$pkgdir/native/pg-symlinks.json" ] || continue
+        jq -r '.[] | [.source, .target] | @tsv' "$pkgdir/native/pg-symlinks.json" \
+          | while IFS=$'\t' read -r source target; do
+            ln -s "$(basename "$source")" "$pkgdir$target"
+          done
+      done
+    '';
+
+    # postgres's procedural-language handlers link against the interpreters of
+    # the distribution that built them. atomic loads no PL handler, and nixpkgs
+    # carries none of these interpreter versions.
+    autoPatchelfIgnoreMissingDeps = [
+      "libperl.so.5.26"
+      "libpython3.6m.so.1.0"
+      "libtcl8.6.so"
+    ];
+
+    nativeInstallCheckInputs = [
+      versionCheckHook
+      writableTmpDirAsHomeHook
+    ];
+    versionCheckKeepEnvironment = [ "HOME" ];
+    doInstallCheck = true;
+
+    # the launcher answers --version itself, before importing the sidecar
+    # bundle, so only --help proves the payload resolved
+    postInstallCheck = ''
+      "$out/bin/atomic" --help | grep -q "AI coding assistant"
+    '';
+
+    strictDeps = true;
+
+    passthru.updateScript = ./update.sh;
+
+    meta = {
+      description = "Coding agent CLI with read, bash, edit, and write tools and session management";
+      homepage = "https://github.com/bastani-inc/atomic";
+      changelog = "https://github.com/bastani-inc/atomic/releases/tag/${finalAttrs.version}";
+      # LICENSE is the MIT text plus a clause requiring a product above 100
+      # million monthly active users or $20 million monthly revenue to display
+      # 'Atomic' in its interface. That condition is not part of MIT and has no
+      # SPDX identifier, so lib.licenses.mit would misstate the terms; the
+      # repository's package.json nonetheless declares MIT and GitHub reports
+      # the license as NOASSERTION.
+      license = {
+        shortName = "MIT-with-atomic-attribution";
+        fullName = "MIT License with Atomic attribution requirement";
+        url = "https://github.com/bastani-inc/atomic/blob/main/LICENSE";
+        free = true;
+        redistributable = true;
+      };
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      mainProgram = "atomic";
+      platforms = lib.attrNames platforms;
+      maintainers = with lib.maintainers; [ cameronraysmith ];
+    };
+  })

--- a/pkgs/by-name/atomic/update.sh
+++ b/pkgs/by-name/atomic/update.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p curl jq cacert git
+# shellcheck shell=bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+MANIFEST="${REPO_ROOT}/pkgs/by-name/atomic/manifest.json"
+
+REPO="bastani-inc/atomic"
+RELEASES_API="https://api.github.com/repos/${REPO}/releases"
+DOWNLOADS="https://github.com/${REPO}/releases/download"
+
+# /releases/latest is the newest non-prerelease; atomic publishes -alpha.N tags
+# continuously between stable releases, so listing tags would track those too.
+version="$(curl -fsSL "${RELEASES_API}/latest" | jq -r '.tag_name')"
+
+# Upstream publishes a SHA256SUMS asset covering every archive in the release,
+# so the checksums are read rather than recomputed by fetching each tarball.
+manifest="$(
+  curl -fsSL "${DOWNLOADS}/${version}/SHA256SUMS" \
+    | jq -Rn --arg version "$version" '
+      {
+        $version,
+        platforms: [
+          inputs
+          | split(" ")
+          | map(select(length > 0))
+          | select(length == 2)
+          | select(.[1] | test("^atomic-(darwin|linux)-(x64|arm64)\\.tar\\.gz$"))
+          | {
+            key: (.[1] | ltrimstr("atomic-") | rtrimstr(".tar.gz")),
+            value: { checksum: .[0] }
+          }
+        ] | from_entries
+      }'
+)"
+
+if [[ "$(jq '.platforms | length' <<<"$manifest")" -eq 0 ]]; then
+  echo "error: no matching archives in SHA256SUMS for ${version}" >&2
+  exit 1
+fi
+
+echo "$manifest" > "$MANIFEST"
+echo "atomic manifest updated to ${version}"


### PR DESCRIPTION
Packages [atomic](https://github.com/bastani-inc/atomic), Bastani's terminal coding agent, as a `pkgs/by-name` derivation over the upstream prebuilt release tarball, following the `pkgs/by-name/claude-code` prebuilt-binary pattern: a `package.nix` that reads a sibling `manifest.json`, an executable sibling `update.sh` that rewrites that manifest wholesale, and a matching `nix run .#update-atomic` entry in `modules/apps/updates.nix`.

Neither nixpkgs nor `numtide/llm-agents.nix` packages atomic today, and upstream carries no nix expression, so there was no attribute to enable and no flake to consume as an input.

## Shape

Version `0.9.13` and the per-platform checksums live only in `manifest.json` and were produced by running `update.sh`, not transcribed; `update.sh` reads upstream's `SHA256SUMS` release asset rather than refetching each archive.
The platform map is the single source of truth: `meta.platforms` is derived from it, and a system outside it returns `null` before the derivation, which `pkgs-by-name-for-flake-parts` filters out of both `packages` and `checks` (the `radicle-desktop` idiom).
That guard is what keeps `checks.x86_64-linux` clean by construction rather than by luck; a bare lookup on the map would leave the attribute present and throw when it is forced.
All three fleet systems from the flake's `systems` input are in the map, since upstream ships `linux-x64`, `linux-arm64`, and `darwin-arm64`.

Three things differ from `claude-code`, all forced by the tarball layout:

The archive is unpacked and installed as a payload under `$out/lib/atomic` rather than installed as a bare binary with `installBin $src`, because each archive is built by `bun build --compile --bytecode` into a *split launcher*: a small `atomic` executable that resolves `app.js` and a prebundled `node_modules` relative to the directory of its own `execPath`.

`bin/atomic` is a `makeBinaryWrapper` shim rather than a symlink.
Bun does resolve `execPath` through symlinks — verified directly, a symlink to the extracted binary finds both `package.json` and `app.js` — so a symlink would have worked.
The wrapper is there to carry `fd` and `ripgrep` on `PATH`, because atomic otherwise resolves them from `PATH` and downloads a generic release binary from GitHub at first use, which cannot run against this libc.
`PATH` is suffixed rather than prefixed so a caller's own tools still win.
The wrapper also sets `ATOMIC_SKIP_VERSION_CHECK`, the analogue of `claude-code`'s `DISABLE_AUTOUPDATER`: atomic queries the npm registry at startup and nags toward an `atomic update self` that cannot write into a read-only store.
Nothing here sets `ATOMIC_OFFLINE`, which would also disable unrelated git-based fetches.

`claude-code`'s `__noChroot = isDarwin` is not carried over.
Nothing in the darwin build or its install check needs to escape the sandbox, and `__noChroot` fails outright on a strictly-sandboxed darwin host, so adding it would only narrow where this builds.

## Resolved while implementing

**Bun-compiled, and no darwin re-signing.** Upstream's `scripts/build-binaries.sh` compiles each non-Windows target with `bun build --compile --bytecode --target=bun-<platform>`, so these are bun standalone executables, not Node single-executables.
The darwin binary is `adhoc,linker-signed` and `codesign -v` reports it modified, because bun appends the payload after signing — yet it runs, both from a plain `tar xzf` and from the store.
The `omp` derivation in `llm-agents.nix` re-signs its bun binary; no equivalent step is needed here because nothing modifies the binary: `dontStrip = true` (the launcher carries its bytecode payload past the end of the executable image) and `autoPatchelfHook` is gated on `isElf`, so the installed darwin binary is byte-identical to upstream's, confirmed by `sha256`.

**License.** `LICENSE` is the MIT text plus a clause requiring a product above 100 million monthly active users or $20 million monthly revenue to display 'Atomic' in its interface.
That condition is not part of MIT and has no SPDX identifier, so `lib.licenses.mit` would misstate the terms; `meta.license` spells it out as a free, redistributable custom license, with the reasoning in a comment.
The metadata disagrees three ways, which is worth recording: `packages/coding-agent/package.json` declares `"license": "MIT"`, GitHub's API reports `NOASSERTION`, and the `LICENSE` text is neither.

## Embedded Postgres: preserved, and a finding worth a look

The brief flagged atomic's embedded-Postgres dependency as unsettled because its native library symlinks are rehydrated by writing into the installed package directory, which cannot work from a read-only store.
This is packaged in the capability-preserving direction, so nothing is silently lost — but what turned up is worth a decision later, and it is not what the framing assumed.

The rehydration is an npm `postinstall` (`@embedded-postgres/<platform>/scripts/hydrate-symlinks.js`), not a runtime call from atomic.
A release tarball never runs it, so the SONAME links are simply absent from the archive as shipped.
The Postgres binaries resolve their libraries through an `$ORIGIN/../lib` rpath, and the versioned files are all present, so the only thing missing is the links themselves: `postgres` needs `libicuuc.so.60` and the archive contains only `libicuuc.so.60.2`.
This derivation materializes those 14 links from the shipped `native/pg-symlinks.json` at build time, after which `autoPatchelf` resolves every `NEEDED` entry of `postgres` and `initdb` from within the output.

Two observations follow, both upstream's doing rather than this packaging's:

Upstream builds every archive on one linux-x64 runner and then prunes `@embedded-postgres` to the leaf matching each archive, so only `atomic-linux-x64.tar.gz` actually carries a Postgres payload.
`darwin-arm64` and `linux-arm64` ship an *empty* `@embedded-postgres/` directory, and the musl archives have it removed deliberately.
So durable-workflow embedded Postgres is absent from the captain's own aarch64-darwin platform regardless of what we do here, and this change makes `x86_64-linux` the only fleet platform where it works.

Because the links are missing from the tarball on every platform, upstream's own tarball install cannot start embedded Postgres either — so this is closer to repairing a capability than preserving one.

If that asymmetry is not wanted, dropping `node_modules/@embedded-postgres` on linux would delete the `postInstall` hook, the `jq` dependency, the three `autoPatchelfIgnoreMissingDeps` entries, and about 60 MB of closure, and would make all three fleet platforms behave identically.
That is a product call rather than a packaging one, so it is raised here rather than taken.

The ignored dependencies are Postgres's procedural-language handlers (`plperl`, `plpython3`, `pltcl`), which link against `libperl.so.5.26`, `libpython3.6m.so.1.0`, and `libtcl8.6.so`.
atomic loads no PL handler and nixpkgs carries none of those interpreter versions.
They are named individually rather than blanket-ignored so an upstream Postgres bump fails loudly instead of silently widening.

## Testing

Selection rationale: this change adds one package, one `passthru.tests` entry, and one flake app, so verification is scoped to exactly the checks that change creates plus targeted evaluation of the attributes it defines.
Neither `nix flake check` nor `just check-fast` was run — both are too slow to be a useful signal for a single new package, and neither would fail for a reason this diff could cause that the scoped set misses.

Scoped builds, all green:

- `nix build .#checks.x86_64-linux.package-atomic .#checks.x86_64-linux.package-atomic-test-help` — green on the remote builder. This is the system `buildbot-nix.toml` gates (`attribute = "checks.x86_64-linux"`), and the only one exercising `autoPatchelfHook`, the Postgres symlink hydration, and the ignored PL dependencies. `autoPatchelf` skipped the foreign-arch `clipboard.linux-arm64-gnu.node` by architecture, as intended, and the only unsatisfied dependencies were the nine expected PL-handler entries.
- `nix build .#checks.aarch64-darwin.package-atomic .#checks.aarch64-darwin.package-atomic-test-help` — green, and the built `bin/atomic` also starts and prints its own help outside the build sandbox entirely.
- `just lint` — clean (`gitleaks`, `treefmt`/nixfmt), run through `nix develop` since `prek` is not on the ambient `PATH`.

Targeted evaluation, on all three systems in the platform map:

- `packages.<system>.atomic.src.url` resolves to the matching upstream archive (`darwin-arm64`, `linux-x64`, `linux-arm64`), which is what proves the platform map indexes correctly.
- `meta` carries `mainProgram = "atomic"`, `platforms` derived from the map, `sourceProvenance = [ binaryNativeCode ]`, and a `free` license; `version` is `0.9.13`, read from `manifest.json`.
- `apps.<system>.update-atomic.program` resolves to an executable `update.sh` in the store.
- `checks.<system>` contains exactly `package-atomic` and `package-atomic-test-help`.

Both install checks were verified to be severe rather than decorative, by temporarily replacing an assertion with a pattern the help output does not contain and confirming the build fails in each case.

The install check is deliberately layered.
`versionCheckHook` covers `--version`, but the launcher answers that itself before importing the sidecar bundle, so it alone would not prove the payload resolved; `postInstallCheck` runs `--help`, which goes through `app.js`.
`passthru.tests.help` then runs the same thing against the *finished, read-only* store path rather than against `$out` while it is still being built and still writable — which is the condition the split launcher actually has to survive, and the one the brief's read-only-store concern was really about.

The Postgres symlink hydration is idempotent (third commit): creating a link whose target already exists would otherwise fail the build, and upstream's own `hydrate-symlinks.js` swallows that case, so a release that starts shipping these links stays a no-op here instead of breaking an unrelated version bump.
That commit changes only the linux derivation — the darwin store path is unchanged, since the hook is gated on `isElf`.

The install check is deliberately two-part.
`versionCheckHook` covers `--version`, but the launcher answers that itself before importing the sidecar bundle, so it alone would not prove the payload resolved; `postInstallCheck` runs `--help`, which goes through `app.js`.
That check was verified to be severe rather than decorative by temporarily replacing its pattern with one the help output does not contain and confirming the build fails.

Deliberately not run or not verified:

- **`nix flake check` and `just check-fast` were not run**, by direction: too slow to be a useful signal for one new package, and the scoped set above covers everything this diff can break.
- **aarch64-linux is evaluation-verified only.** It evaluates to a derivation with the correct `linux-arm64` URL, but no aarch64-linux builder is reachable from this lane (the local `rosetta-builder` VM is down), and buildbot gates `checks.x86_64-linux` only. Its build path is structurally identical to x86_64-linux minus the Postgres payload, which is empty in that archive.
- **The Postgres runtime is verified structurally, not by starting a database.** Every `NEEDED` entry of `postgres` resolves inside the patched rpath, and the 14 hydrated links are present in the output; actually starting a durable workflow is beyond what a build check can do.

## Notes

Two incidental things, neither changed here:

`packages/docs/src/content/docs/guides/adding-custom-packages.md` describes package discovery as `lib.packagesFromDirectoryRecursive` in `modules/nixpkgs/per-system.nix`.
The code actually uses the drupol `pkgs-by-name-for-flake-parts` module via `pkgsDirectory` and `pkgsNameSeparator`, and the guide's example also uses `meta = with lib; { ... }`, which is against house style.
Left alone to keep this diff to the package.

The `null` guard protects `packages` and `checks` but not `apps`: on a hypothetical future fleet system outside the platform map, `modules/apps/updates.nix` would still reference `config.packages.atomic` and fail to evaluate.
That cannot happen today — upstream ships all three systems in the flake's `systems` input — so it is recorded rather than guarded against speculatively.
The same coupling already exists for every other `update-*` app.

On darwin, `fixupPhase` prints `patchelf: command not found` three times.
That is `audit-tmpdir` finding the three linux `.node` files upstream stages into `@mariozechner/clipboard` for every archive, and failing to inspect them because darwin has no `patchelf`.
It is cosmetic; the foreign-platform blobs are upstream's and are left in place rather than removed by a name-matching rule that could silently delete the wrong one.

Enabling atomic in any user's home-manager aggregate is out of scope, as is provider credential provisioning — atomic runs on the captain's own credentials and this change introduces no secret.
