### PR TITLE
fix(pi): declare the compaction extension Pi-only at the package level

### DIFF
--- a/pkgs/by-name/pi-openai-server-compaction/package.nix
+++ b/pkgs/by-name/pi-openai-server-compaction/package.nix
@@ -2,11 +2,51 @@
 # lazily (src/openai-ws-connection.ts) from a WebSocket transport that the
 # isDirectOpenAIResponsesModel gate makes unreachable on the Codex provider, and
 # its absence degrades to SSE rather than failing.
-{ fetchFromGitHub }:
-fetchFromGitHub {
-  name = "pi-openai-server-compaction-source";
-  owner = "algal";
-  repo = "pi-openai-server-compaction";
-  rev = "8a3de2f3b0c178fdd6f73f2f94172dfc3943e466";
-  hash = "sha256-HFzG+GMriPhoMinjji+3sklQ7Nq0yRHCz/t9Re/TksU=";
+{
+  fetchFromGitHub,
+  jq,
+  lib,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "pi-openai-server-compaction";
+  version = "0.1.0-unstable-2026-07-23";
+
+  src = fetchFromGitHub {
+    owner = "algal";
+    repo = "pi-openai-server-compaction";
+    rev = "8a3de2f3b0c178fdd6f73f2f94172dfc3943e466";
+    hash = "sha256-HFzG+GMriPhoMinjji+3sklQ7Nq0yRHCz/t9Re/TksU=";
+  };
+
+  nativeBuildInputs = [ jq ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  strictDeps = true;
+
+  # atomic reads package.json#atomic before falling back to package.json#pi
+  # (packages/coding-agent/src/core/package-manager-manifest.ts:24-27), while pi
+  # reads only package.json#pi, so an empty `atomic.extensions` makes this
+  # package contribute nothing to atomic while remaining fully active under pi.
+  # atomic 0.9.13 omits @earendil-works/pi-coding-agent from its virtualModules
+  # map and src/remote-compaction.ts imports that specifier as a value, so
+  # without this block every atomic startup is a fatal extension-load error.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -R . "$out/"
+    jq '. + {atomic: {extensions: []}}' package.json > "$out/package.json"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Pi extension for OpenAI server-side compaction with Codex-quality continuity";
+    homepage = "https://github.com/algal/pi-openai-server-compaction";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.all;
+  };
 }


### PR DESCRIPTION
## Problem

`atomic` reads `~/.pi/agent/settings.json` as a legacy config root, so it inherits every extension registered for pi.
One of them, `pi-openai-server-compaction`, imports `@earendil-works/pi-coding-agent` as a runtime value in `src/remote-compaction.ts`.
pi's jiti `virtualModules` map satisfies that specifier; atomic 0.9.13's does not, and the resolution failure is fatal on atomic's print and interactive paths:

```
Error: Failed to load extension ".../src/index.ts": Failed to load extension:
ResolveMessage: Cannot find module '@earendil-works/pi-coding-agent'
```

The other registered extensions survive only because their references to that specifier are `import type`, erased at transpile.

## Fix

atomic's manifest reader is `APP_NAME`-first with a `pi` fallback (`packages/coding-agent/src/core/package-manager-manifest.ts:24-27`) and `APP_NAME` is `"atomic"`, while pi reads only `pkg.pi`.
Injecting `{atomic: {extensions: []}}` into the package's `package.json` therefore short-circuits atomic to zero resources and is invisible to pi.

`pkgs/by-name/pi-openai-server-compaction/package.nix` becomes a `stdenvNoCC.mkDerivation` over the existing `fetchFromGitHub`, following the sibling `pi-agent-extensions` shape, and drops the `-source` suffix now that the output is no longer a bare fetch.
The `ws` runtime-dependency comment is preserved verbatim.

## Constraints held

- The package remains a separate enabled entry and still appears in `atomic list`, satisfying the OpenSpec MUST at `openspec/specs/pi-agent-environment/spec.md:74`.
- Nothing is added to `programs.pi-coding-agent.settings`, so `slowModeSettingsShape` is untouched.
- `compactionRetained` derives both sides of its comparison from `self'.packages.pi-openai-server-compaction`, so it follows the new store path.

## Verification

Ran the four checks that observe this derivation or its store path — the full set that would fail if the change were wrong. All green:

```
nix --accept-flake-config build .#checks.aarch64-darwin.package-pi-openai-server-compaction -L
nix --accept-flake-config build .#checks.aarch64-darwin.pi-agent-environment-structural -L
nix --accept-flake-config build .#checks.aarch64-darwin.pi-agent-environment-smoke -L
nix --accept-flake-config build .#checks.aarch64-darwin.home-manager-crs58 -L
```

`pi-agent-environment-smoke` is the real regression test: its fixture uses the live `packageEntries` and hard-fails on any `extension_error`.
It reported `extension_errors=0`.

Runtime behaviour was confirmed in an isolated `HOME` against scratch copies of the old and new outputs — never the captain's live config — with a marker line appended to the extension entrypoint:

| host | extension output | result |
|---|---|---|
| atomic | old (negative control) | `Cannot find module '@earendil-works/pi-coding-agent'`, exit 1 |
| atomic | new | no extension error; reaches `No API key found for the selected model.` |
| pi | old | `>>> VX_COMPACTION_EXTENSION_EVALUATED` |
| pi | new | `>>> VX_COMPACTION_EXTENSION_EVALUATED` |

The marker is positive proof that pi still *evaluates* the extension rather than merely not erroring.
`atomic list` was deliberately not used as an oracle: it renders this failure as a `Warning:` and exits 0, while the print and interactive paths render it as `Error:` and exit 1.

## Deliberately out of scope

No atomic regulator was added to the checks suite.
The gap is real — nothing in the repo could have caught this, since `pi-agent-environment-smoke` is bound to `mainProgram == "pi"` and atomic's own `--help` test runs under an empty `HOME` — but adding one is a separate decision.
Also untouched: `ATOMIC_CODING_AGENT_DIR` handling, the pi module's settings, and the deleted `node_modules` output assertion.

## Provenance

Diagnosis, fix selection, and the end-to-end verification with negative control come from the completed investigation at `data/vx-atomic-pi-config-inheritance/report.md`.
