### PR TITLE
feat(plugins): distribute the gh-stack skill as a transitive apm dep

### DIFF
--- a/modules/apps/apm-marketplace-validate.sh
+++ b/modules/apps/apm-marketplace-validate.sh
@@ -115,7 +115,17 @@ echo ""
 # marketplace.json apm registers. the worktree files faithfully reflect the
 # --local ref (HEAD) for these committed manifests.
 mapfile -t published < <(yq -r '.marketplace.packages[].name' "${repo_root}/apm.yml" | sort)
-mapfile -t served < <(jq -r '.plugins[].name' "${repo_root}/.claude-plugin/marketplace.json" | sort)
+# read the served set from wherever apm.yml says the manifest is emitted rather
+# than a second hardcoded path, which silently went stale when the directory
+# moved. mapfile over process substitution cannot propagate a jq failure, so a
+# missing file would otherwise read as an empty served set and be reported as
+# total coverage drift.
+served_manifest="${repo_root}/$(yq -r '.marketplace.output' "${repo_root}/apm.yml")"
+if [ ! -f "${served_manifest}" ]; then
+  echo "error: marketplace manifest not found at ${served_manifest} (apm.yml marketplace.output)" >&2
+  exit 1
+fi
+mapfile -t served < <(jq -r '.plugins[].name' "${served_manifest}" | sort)
 echo "published packages (apm.yml):          ${#published[@]}"
 echo "served plugins (marketplace.json):     ${#served[@]}"
 if [ "${#published[@]}" -eq 0 ]; then

--- a/modules/home/ai/plugins/version-control-and-forge/apm.yml
+++ b/modules/home/ai/plugins/version-control-and-forge/apm.yml
@@ -11,3 +11,14 @@ dependencies:
     - git: max-sixty/worktrunk
       ref: 5175153b39d2737b4c35810fc58b0fd1a58ee609
       skills: [worktrunk, wt-switch-create]
+    # gh-stack is a Go CLI repo that also ships one agent skill under
+    # skills/gh-stack/. apm types it SKILL_BUNDLE (nested skills/<name>/SKILL.md,
+    # no plugin manifest and no apm.yml) and installs the skill directory with its
+    # references/ siblings. Same offline resolution as worktrunk above: the nix
+    # compose pre-seeds apm's git checkout cache from the flake-pinned tree, and the
+    # full 40-char SHA is required because a short ref forces a network fetch. The
+    # `gh stack` extension the skill drives is installed by
+    # modules/home/development/gh.nix.
+    - git: github/gh-stack
+      ref: 14fc42ed9b6c376a53b2f999f138d3bd26dac546
+      skills: [gh-stack]

--- a/pkgs/by-name/agent-plugins/gh-stack/package.nix
+++ b/pkgs/by-name/agent-plugins/gh-stack/package.nix
@@ -1,0 +1,7 @@
+{ fetchFromGitHub }:
+fetchFromGitHub {
+  owner = "github";
+  repo = "gh-stack";
+  rev = "14fc42ed9b6c376a53b2f999f138d3bd26dac546";
+  hash = "sha256-SBP6z6G35wGY31RMhPpsZ1QDOhmVBlLv7ktLXIA3HwI=";
+}

--- a/pkgs/by-name/apm-skills-compose/package.nix
+++ b/pkgs/by-name/apm-skills-compose/package.nix
@@ -58,6 +58,13 @@
   unslopSrc ? inputs.self.packages.${stdenv.hostPlatform.system}.agent-plugins-unslop,
   unslopRev ? unslopSrc.rev,
 
+  # Flake-pinned github/gh-stack tree feeding apm's git checkout cache so the
+  # skill-bundle remote dep resolves with zero network. ghStackRev is the single SHA
+  # source of truth (the fetchFromGitHub rev), reconciled against the apm.yml pin by
+  # the drift guard in the build script.
+  ghStackSrc ? inputs.self.packages.${stdenv.hostPlatform.system}.agent-plugins-gh-stack,
+  ghStackRev ? ghStackSrc.rev,
+
   targets ? [
     "agent-skills"
     "claude"
@@ -199,6 +206,24 @@ runCommandLocal "apm-skills-compose"
       exit 1
     fi
 
+    # Same offline pre-seed for the gh-stack remote dep declared in
+    # version-control-and-forge/apm.yml. apm types it SKILL_BUNDLE (nested
+    # skills/<name>/SKILL.md, no plugin manifest and no apm.yml) and installs the
+    # skills/gh-stack/ directory with its references/ siblings.
+    GH_SHA=${ghStackRev}
+    SHARD_GH=$(printf '%s' 'https://github.com/github/gh-stack' | sha256sum | cut -c1-16)
+    CK_GH="$APM_CACHE_DIR/git/checkouts_v1/$SHARD_GH/$GH_SHA/full"
+    mkdir -p "$CK_GH"
+    cp -RL ${ghStackSrc}/. "$CK_GH"/
+    chmod -R u+w "$CK_GH"
+    mkdir -p "$CK_GH/.git"
+    printf '%s\n' "$GH_SHA" > "$CK_GH/.git/HEAD"
+
+    if ! grep -q "$GH_SHA" ./version-control-and-forge/apm.yml; then
+      echo "apm-skills-compose: gh-stack SHA drift — version-control-and-forge/apm.yml does not pin $GH_SHA" >&2
+      exit 1
+    fi
+
     cp ${rootConsumerManifest} ./apm.yml
     # agent-skills,claude only: the codex/hermes/opencode/droid harnesses are
     # fanned out nix-side from this composed $out in a later task, not by apm.
@@ -222,7 +247,10 @@ runCommandLocal "apm-skills-compose"
       "$out/.claude/skills/code-review/SKILL.md" \
       "$out/.claude/skills/unslop/SKILL.md" \
       "$out/.agents/skills/unslop/SKILL.md" \
-      "$out/.claude/skills/unslop/scripts/banned_phrase_scan.py"; do
+      "$out/.claude/skills/unslop/scripts/banned_phrase_scan.py" \
+      "$out/.claude/skills/gh-stack/SKILL.md" \
+      "$out/.agents/skills/gh-stack/SKILL.md" \
+      "$out/.claude/skills/gh-stack/references/commands.md"; do
       if [ ! -f "$expected" ]; then
         echo "apm-skills-compose assertion failed: missing $expected" >&2
         exit 1


### PR DESCRIPTION
Makes github/gh-stack's agent skill available to the fleet, pinned at `14fc42ed9b6c376a53b2f999f138d3bd26dac546`.

## Route taken, and the precedent it matches

The apm remote-dependency route (design.md D11), declaring gh-stack once in `modules/home/ai/plugins/version-control-and-forge/apm.yml` and keeping the nix compose hermetic by pre-seeding apm's git checkout cache from a flake-pinned `fetchFromGitHub` tree.

The specific precedent is **`max-sixty/worktrunk`, already declared in the same file** by `3c22a6ff feat(plugins): distribute worktrunk skills as transitive apm dep`. Like gh-stack, worktrunk is a CLI tool repository that happens to ship agent skills, consumed in the same `git:` / `ref:` / `skills:` object form, in the same consumer plugin. That commit touched four files; this one touches three, for the reason in "Compose option surface" below.

The premise that apm cannot consume a repository which merely ships skills is wrong, and the reason is worth recording. apm 0.28.0's classification cascade lives in `apm_cli/models/format_detection.py:367-408`, first match wins:

| # | type | trigger | gh-stack |
|---|---|---|---|
| 1 | `MARKETPLACE_PLUGIN` | `plugin.json` or `.claude-plugin/` | no |
| 2 | `HYBRID` | root `SKILL.md` **and** `apm.yml` | no |
| 3 | `CLAUDE_SKILL` | root `SKILL.md` only | no |
| 4 | `SKILL_BUNDLE` | nested `skills/<name>/SKILL.md` | **yes** |
| 5 | `APM_PACKAGE` | `apm.yml` with `.apm/` or deps | no |

gh-stack's root has no `apm.yml`, no `plugin.json`, no `.claude-plugin/`, and no root `SKILL.md` — just `skills/gh-stack/{SKILL.md,references/*.md}`. apm types it `SKILL_BUNDLE` and installs the skill directory with its `references/` siblings. That is a fourth apm package type alongside the three vanixiets already consumes (`apm_package` via srid/agency, `marketplace_plugin` via mattpocock/skills, `claude_skill` via theclaymethod/unslop), and it needs no new mechanism.

`version-control-and-forge` is the consumer plugin on subject matter — gh-stack is a stacked-PR CLI for GitHub, and the plugin is described as "Version-control and forge skills". It also already hosts the structurally identical worktrunk dep.

## What was rejected

**A nix derivation reshaping gh-stack's `skills/` tree into an `.apm/skills/` layout, synthesising `apm.yml` and `plugin.json` on upstream's behalf, registered via `aiSkills.upstreamDeps`.** Reasoned from the incorrect premise above. `aiSkills.upstreamDeps` is also the legacy additive co-ship path, superseded by D11; it defaults to `[ ]`, is assigned nowhere in the repo, and no current upstream dep reaches the tree through it. Taking it would forfeit the `resolved_commit` lock and content hashes that D11 exists to obtain.

**The `aiSkills.extraSkillDirs` bypass** — the route `tuicr` and `linear-cli` take (`modules/home/ai/tuicr/default.nix:70`, `modules/home/users/crs58/default.nix:53`). This was the closest live alternative and deserves the explicit rejection, because `pkgs.gh-stack` already exists in this repo at `modules/home/development/gh.nix:8`, so `${pkgs.gh-stack.src}/skills` would have been a one-line wiring with no new pin.

It is wrong here because its defining invariant does not hold. tuicr and linear-cli use it precisely because the skill rides the *same* `src` as the installed binary, so there is one pin and zero drift. For gh-stack that identity fails: nixpkgs packages the `gh stack` extension at tag `v0.1.0` = `a1b4a3d4`, and upstream PR #388 subsequently rewrote the skill — `SKILL.md` shrank by ~830 lines and the three `references/` files were created. `${pkgs.gh-stack.src}/skills` therefore delivers the old pre-split 950-line `SKILL.md` with no `references/`, not the revision this change was asked to pin. Accepting the stale skill or introducing a second pin both dissolve the rationale, while still paying the `extraSkillDirs` cost recorded in D10: no lock, no content hashes, and no shipping to a non-nix apm consumer.

**Vendoring gh-stack's skill content into this repository.** Not required; provenance is preserved by the pin.

## Lock files

**No lock file is required for this route, and none was written by hand.** `version-control-and-forge` carries no `apm.lock.yaml` and has not needed one for worktrunk. Plugin-level locks are published-consumer artifacts: nothing in the nix build reads them (the only code reference is `apm-skills-compose/package.nix` stripping `generated_at`/`apm_version` from its *own* lock for byte-reproducibility), and no check enforces their presence.

The lock that governs the fleet build is generated by the real `apm install` inside the compose derivation, and it now carries gh-stack:

```yaml
- repo_url: github/gh-stack
  resolved_commit: 14fc42ed9b6c376a53b2f999f138d3bd26dac546
  package_type: skill_bundle
  content_hash: sha256:a665723d62643caac4d397bb69c6c2d9b163be53c8803e641e4c7edaf04876c6
  skill_subset: [gh-stack]
```
plus per-file `deployed_file_hashes` for `SKILL.md` and all three `references/` files.

Worth surfacing rather than deciding silently: only 2 of the 18 plugins carry an `apm.lock.yaml`, and `version-control-and-forge` is not one of them even though it has declared a remote dep since July. Adding one here would also newly pin worktrunk and would need regenerating (with network, via `apm lock`) on every SHA bump, with no check to catch staleness. That is a pre-existing fleet-wide inconsistency, not something gh-stack introduces, so it is left alone; happy to do it as a follow-up if wanted.

## Compose option surface

`modules/home/ai/skills/compose.nix` is deliberately untouched. Of the five existing upstream deps, three (`superpowers`, `agency`, `worktrunk`) are surfaced there as `<name>Src` / `<name>Rev` home-manager options, and the two most recent (`mattpocock/skills` in `0d25b15a`, `unslop` in `1271dda9`) are not — they fall through to the `apm-skills-compose/package.nix` argument defaults. This follows the newer form. It also keeps the change out of `modules/home/ai/`, where another lane is working concurrently.

## Verification

Positive evidence that the skill actually resolves, not merely that the config evaluates.

Built compose output contains the skill and its references, and apm resolved it as a genuine remote dep:
```
$out/.claude/skills/gh-stack/SKILL.md
$out/.claude/skills/gh-stack/references/{commands,stack-design,troubleshooting}.md
$out/.agents/skills/gh-stack/...
```
170 skills total, `gh-stack` appearing exactly once — no collision.

It reaches every harness sink in the real home configuration (`nix eval` against `homeConfigurations."crs58@aarch64-darwin".config`):
```
claude-code.skills has gh-stack: YES -> ...-apm-skills-compose/.claude/skills/gh-stack
opencode.skills has gh-stack:    YES
home.file .factory/skills/gh-stack: YES
home.file .hermes/skills/gh-stack: YES
```
The fifth sink, `~/.agents/skills/`, is delivered by `home.activation.agentsSkillsRealFiles`; its source is asserted inside the compose. Not activated — this is build-only.

Offline resolution is genuinely load-bearing, not a silent network fetch. Since the darwin sandbox is off, I proved it directly: an isolated `apm install` with a sentinel file planted only in the pre-seeded checkout cache produced that sentinel in the installed skill, so apm read the cache and never went to the network.

Checks run (aarch64-darwin), all green:

| check | why it covers this change |
|---|---|
| `package-agent-plugins-gh-stack` | new FOD, auto-registered from `pkgs/by-name` |
| `package-apm-skills-compose` | the drift guard, the offline install, and the new output assertions |
| `home-manager-crs58`, `home-manager-cameron` | the only two users whose configs carry the ai module; verified by eval — the other four have no ai skills |
| `treefmt` | formatting (422 files, 0 changed) |
| `structure-*`, `home-configurations-exposed`, `home-module-exports`, `naming-conventions`, `eval-agents-md` | flake-shape checks, cheap and adjacent |
| `nix run .#apm-marketplace-validate -- --local` | end-to-end consumer path — see below |

`shellcheck -x` clean on the edited script. `checks.x86_64-linux.{package-apm-skills-compose,package-agent-plugins-gh-stack}` evaluate to drvPaths, so buildbot's linux attribute set is sound; the linux builds themselves are left to CI.

Deliberately not run: `cognee-agentskills` (a network-touching SaaS mutation whose corpus is scoped to first-party `.apm/skills/` trees, so a transitive remote dep is invisible to it) and the `darwin-*` full-system checks (this change is home-manager-scoped and reaches them only through the same compose the home-manager checks already build).

## Second commit: a pre-existing break in apm-marketplace-validate

`apm-marketplace-validate` is named in this task's acceptance criteria, and it exits 1 on an unmodified tree. `apm-marketplace-validate.sh:118` read the served plugin set from `.claude-plugin/marketplace.json`, a path that stopped existing when `caad1453 refactor(plugin): reuse .github` moved the manifest to `.github/plugin/marketplace.json`. `mapfile` over process substitution cannot propagate the `jq` failure under `set -euo pipefail`, so `served` silently became empty and all 18 published packages were reported as coverage drift.

Before, on this branch's parent:
```
published packages (apm.yml):          18
served plugins (marketplace.json):     0
APM-VALIDATE-COVERAGE-DRIFT: missing=[... all 18 ...] extra=[]
APM-VALIDATE-SUMMARY: passed=18 failed=0 total=18
EXIT=1
```

After:
```
published packages (apm.yml):          18
served plugins (marketplace.json):     18
APM-VALIDATE-COVERAGE-OK: 18 packages served
APM-VALIDATE-PKG-OK: version-control-and-forge (claude_skills=13 agents_skills=13)
APM-VALIDATE-SUMMARY: passed=18 failed=0 total=18
EXIT=0
```

The fix reads the path from `apm.yml`'s own `marketplace.output` rather than a second hardcoded copy, and fails loudly if the manifest is missing. It is a separate atomic commit and can be split into its own PR on request; it is here because the named acceptance check is otherwise unrunnable.

That run is also the strongest single piece of evidence for this change: `version-control-and-forge` now serves **13** skills to an external apm consumer installing from the published marketplace — 10 first-party plus `worktrunk`, `wt-switch-create`, and `gh-stack`.

## Updating gh-stack in future

A human edits two SHAs, which must stay identical:

1. `pkgs/by-name/agent-plugins/gh-stack/package.nix` — `rev`, and `hash` (set it to `lib.fakeHash`, build once, read the real value from the mismatch error)
2. `modules/home/ai/plugins/version-control-and-forge/apm.yml` — `ref`

Everything else regenerates. `ghStackRev` derives from `ghStackSrc.rev`, so the compose picks the new SHA up on its own; the cache shard hashes the URL, not the SHA, so it never changes; `$out/apm.lock.yaml` is rewritten by the in-derivation `apm install`; the delivered trees re-glob from the new output. Regenerate with:

```
nix build --no-link -L .#checks.aarch64-darwin.package-agent-plugins-gh-stack \
                       .#checks.aarch64-darwin.package-apm-skills-compose
```

The drift guard in `apm-skills-compose/package.nix` fails the build loudly if the two SHAs disagree. That matters: a disagreement degrades to a network fetch, which the sandbox would fail confusingly rather than clearly. The full 40-char SHA is mandatory for the same reason — three separate apm short-circuits (`tiered_ref_resolver.py`, `cache/git_cache.py`, `install/helpers/ref_seed.py`) key on an exact 40-hex match, and anything shorter enters a tier waterfall that issues a network call first.

One watch item: upstream tags releases, and `14fc42e` is untagged `main`. Prefer a tag at the next bump if one has landed past it.

## Skill/binary version skew: checked, none

The pinned skill is 5 days newer than the `v0.1.0` extension nixpkgs installs, which raises the fair question of whether the skill documents commands the installed binary lacks. It does not. `v0.1.0...14fc42e` is 2 commits, touching only `README.md`, `SUPPORT.md`, `docs/`, and the four skill files — **no Go source changes at all**. The pinned skill describes exactly the CLI surface of the installed binary.

Not managed by this repo, and worth a separate glance: the skill asks for `rerere.enabled true`, and states `remote.pushDefault origin` is required when a repository has more than one remote. Neither appears in the home-manager git configuration. Not a blocker for landing the skill.
