### PR TITLE
fix(atomic): stop registering the statusline extension with atomic

### DIFF
--- a/modules/checks/atomic-agent-environment.nix
+++ b/modules/checks/atomic-agent-environment.nix
@@ -1,0 +1,112 @@
+# One structural regulator for the atomic/pi extension divergence.
+#
+# The atomic analogue of modules/checks/pi-agent-environment.nix, sharing its
+# mechanism: mkStructuralCheck diffs eval-time home-manager values against a
+# literal oracle, so a failure names the violated claim as a unified diff.
+#
+# What this guards. modules/home/ai/agent-settings.nix generates one settings
+# payload for two agents, and `packages` is the single key they do not share
+# verbatim: atomic takes packagesForAtomic, which appends
+# atomicExtensionExclusions as `-`-prefixed force-excludes. The divergence is
+# deliberate and one-sided, and both halves have to hold at once — atomic must
+# exclude statusline because atomic 0.9.13's isolated interactive engine refuses
+# ctx.ui.setFooter, and pi must keep it because pi honours that call in-process.
+# Asserting only atomic's half would pass a change that silently disarmed the
+# extension for both agents.
+#
+# Falsifiability: dropping "statusline/index.ts" from atomicExtensionExclusions
+# flips atomicNegativeExtensions against the literal below; propagating the
+# exclusion to pi flips piNegativeExtensions.
+#
+# The retraction claim is why atomicDeclaresPackages is asserted separately
+# rather than inferred from the selector lists. modules/home/ai/atomic/
+# merge-settings.sh can update a nix-owned key but not retract one, so a change
+# that stopped declaring `packages` would leave whatever value last reached
+# ~/.atomic/agent/settings.json frozen there. That failure is invisible in the
+# generated payload and visible only as the key's absence.
+#
+# Evidence boundary. This claims declaration shape alone: that the two agents'
+# settings carry the selectors named below. It does not claim that atomic
+# resolves those selectors as intended at runtime, which is upstream behavior
+# (core/package-manager-resource-patterns.ts applies force-excludes last), nor
+# that the extension package's contents are what its name suggests.
+{ self, lib, ... }:
+{
+  perSystem =
+    {
+      pkgs,
+      self',
+      system,
+      ...
+    }:
+    let
+      mkCheck = self.lib.mkStructuralCheck pkgs;
+      homeConfig = self.homeConfigurations."crs58@${system}".config;
+      atomicConfig = homeConfig.programs.atomic;
+      piConfig = homeConfig.programs.pi-coding-agent;
+      extensionPackage = self'.packages.pi-agent-extensions or null;
+      extensionSource = if extensionPackage == null then null else toString extensionPackage;
+      selectorsFor =
+        settings:
+        let
+          entry = lib.findFirst (
+            candidate: builtins.isAttrs candidate && (candidate.source or null) == extensionSource
+          ) null (settings.packages or [ ]);
+        in
+        if entry == null then [ ] else entry.extensions or [ ];
+      atomicSelectors = selectorsFor atomicConfig.settings;
+      piSelectors = selectorsFor piConfig.settings;
+      positive = builtins.filter (selector: !lib.hasPrefix "-" selector);
+      negative = builtins.filter (selector: lib.hasPrefix "-" selector);
+    in
+    {
+      checks = {
+        atomic-agent-environment-structural = mkCheck {
+          name = "atomic-agent-environment";
+          actual = {
+            atomicDeclaresPackages = builtins.hasAttr "packages" atomicConfig.settings;
+            atomicPositiveExtensions = positive atomicSelectors;
+            atomicNegativeExtensions = negative atomicSelectors;
+            piPositiveExtensions = positive piSelectors;
+            piNegativeExtensions = negative piSelectors;
+            # The divergence must live in the selectors, not in a forked package:
+            # two sources would make the lists incomparable and the exclusion
+            # meaningless.
+            sharedExtensionSource = atomicSelectors != [ ] && piSelectors != [ ];
+          };
+          expected = {
+            atomicDeclaresPackages = true;
+            atomicPositiveExtensions = [
+              "direnv/index.ts"
+              "permission-gate/index.ts"
+              "questionnaire/index.ts"
+              "slow-mode/index.ts"
+              "stash/index.ts"
+              "statusline/index.ts"
+            ];
+            # statusline is force-excluded rather than removed from the positive
+            # list: atomic applies `-` entries last and unconditionally, so the
+            # exclusion survives a later change that widens the include set.
+            atomicNegativeExtensions = [
+              "-fetch/index.ts"
+              "-notify/index.ts"
+              "-statusline/index.ts"
+            ];
+            piPositiveExtensions = [
+              "direnv/index.ts"
+              "permission-gate/index.ts"
+              "questionnaire/index.ts"
+              "slow-mode/index.ts"
+              "stash/index.ts"
+              "statusline/index.ts"
+            ];
+            piNegativeExtensions = [
+              "-fetch/index.ts"
+              "-notify/index.ts"
+            ];
+            sharedExtensionSource = true;
+          };
+        };
+      };
+    };
+}

--- a/modules/home/ai/agent-settings.nix
+++ b/modules/home/ai/agent-settings.nix
@@ -7,10 +7,15 @@
 # consumer is what stops the two files drifting the way they already did once,
 # when atomic's first-run wizard copied a snapshot of this package set across
 # and then froze it with theme "dark" against the declared catppuccin-mocha.
+#
+# Where the two agents genuinely need different values, the divergence is named
+# here as its own option rather than patched into a consumer, so that one file
+# still answers what each agent is given and why.
 { ... }:
 {
   flake.modules.homeManager.ai =
     {
+      config,
       pkgs,
       lib,
       ...
@@ -60,6 +65,49 @@
             "${pkgs.pi-openai-server-compaction}"
           ];
           description = "Extension packages registered with every pi-lineage agent, in pi's settings.json packages format.";
+        };
+
+        atomicExtensionExclusions = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "statusline/index.ts" ];
+          description = ''
+            Extensions from `packages` that atomic must not load, while pi still does.
+
+            atomic 0.9.13 runs every interactive session's extensions in an isolated
+            RPC engine child whose `ctx.ui.setFooter` is a warn-once no-op
+            (packages/coding-agent/src/modes/rpc/rpc-extension-ui.ts:232). The
+            statusline extension calls it to evict atomic's native footer, so under
+            atomic the call warns at startup and the native footer stays docked
+            beneath the extension's own bar. atomic exposes no setting that
+            suppresses the native footer and no way to disable engine isolation, so
+            not loading the extension is the only local remedy. pi runs the same
+            extension in-process, where the call is honoured.
+          '';
+        };
+
+        packagesForAtomic = lib.mkOption {
+          type = lib.types.listOf (lib.types.either lib.types.str jsonFormat.type);
+          default =
+            let
+              forceExcludes = map (extension: "-${extension}") config.aiAgentSettings.atomicExtensionExclusions;
+              excludeFrom =
+                entry:
+                if lib.isAttrs entry && entry ? extensions then
+                  entry // { extensions = entry.extensions ++ forceExcludes; }
+                else
+                  entry;
+            in
+            map excludeFrom config.aiAgentSettings.packages;
+          description = ''
+            `packages` as atomic receives it, with `atomicExtensionExclusions` appended
+            as `-`-prefixed force-excludes to every entry that selects extensions.
+
+            atomic applies force-excludes last and unconditionally
+            (packages/coding-agent/src/core/package-manager-resource-patterns.ts:143),
+            so an entry named here loses even though the same list includes it by
+            name. A pattern matching nothing is inert, so this stays correct if an
+            excluded extension later leaves `packages`.
+          '';
         };
       };
     };

--- a/modules/home/ai/atomic/default.nix
+++ b/modules/home/ai/atomic/default.nix
@@ -16,6 +16,11 @@
 # modules/home/ai/agent-settings.nix so that pi's settings.json and this one
 # cannot drift apart. auth.json and models-store.json are runtime state and are
 # not managed here.
+#
+# packages is the one key the two agents do not share verbatim: atomic takes
+# packagesForAtomic, which carries the extension exclusions that agent-settings
+# declares for it. The key is still written rather than dropped, because
+# merge-settings.sh can update a nix-owned key but not retract one.
 { ... }:
 {
   flake.modules.homeManager.ai =
@@ -58,7 +63,8 @@
           enable = lib.mkDefault true;
 
           settings = {
-            inherit (config.aiAgentSettings) theme enableInstallTelemetry packages;
+            inherit (config.aiAgentSettings) theme enableInstallTelemetry;
+            packages = config.aiAgentSettings.packagesForAtomic;
           };
         };
 


### PR DESCRIPTION
## Root cause

atomic 0.9.13 runs every interactive session's extensions inside an isolated RPC engine child, and that child's `ctx.ui.setFooter` is a warn-once no-op that neither binds its argument nor has a protocol frame to forward it.
The `statusline` extension calls `setFooter` at session start to evict atomic's native footer and put everything on one line, which is what it does under pi.
Under atomic the call is refused, so it prints `ctx.ui.setFooter is unavailable in isolated interactive mode …` on every startup, and — because atomic's footer dock is single-occupancy and only an honoured `setFooter` can vacate it — the native two-line footer stays docked beneath the extension's own status bar.
The extension's branch subscription and status pump live inside the same refused factory, so they never run either: that is why `gate` appears in atomic's native footer but never in the bar, and why the bar never repaints on a branch change.
The defect is upstream and atomic exposes no local remedy — no setting suppresses the native footer, and engine isolation cannot be disabled — so this change stops registering the extension with atomic while keeping it for pi.

## Accepted trade-off

atomic loses the bar's subscription-usage and cost segments.
Everything else the bar showed is already in atomic's native footer: model, provider, cwd, branch, extension statuses, and context usage.
The consequence is that the two agents no longer render the same status line.
A shared single-line statusline across both is only reachable by fixing the refusal upstream, which this change does not attempt.

## What changed

`modules/home/ai/agent-settings.nix` generates one settings payload for both pi-lineage agents, and `packages` becomes the single key they no longer share verbatim.
The divergence is declared there as its own named option rather than patched into a consumer, so one file still answers what each agent is given and why:

- `atomicExtensionExclusions` — the extensions atomic must not load, defaulting to `statusline/index.ts`, with the reason recorded beside it.
- `packagesForAtomic` — `packages` with those exclusions appended as `-`-prefixed force-excludes to every entry that selects extensions.

atomic applies force-excludes last and unconditionally, so the `-` entry wins over the include of the same name and the shared list stays intact for pi.
The force-exclude form is preferred over deleting the include because it survives a later change that widens the include set, and because a pattern matching nothing is inert.

`modules/home/ai/atomic/default.nix` consumes `packagesForAtomic`.
It still declares `packages` rather than dropping the key: `merge-settings.sh` can update a nix-owned key but not retract one, so dropping the declaration would freeze whatever value last reached `~/.atomic/agent/settings.json`.

## New check

Nothing in the flake read `programs.atomic` at all, so this would have landed unguarded.
`modules/checks/atomic-agent-environment.nix` mirrors `modules/checks/pi-agent-environment.nix`, reusing `mkStructuralCheck` so a failure emits a unified diff naming the violated claim.

It asserts both halves of the divergence together, because either alone admits a wrong state: atomic must force-exclude `statusline`, and pi must still select it.
Asserting only atomic's half would pass a change that disarmed the extension for both agents.
`atomicDeclaresPackages` is asserted separately because the retraction failure above is invisible in the generated payload and shows only as the key's absence.

The check was verified severe rather than vacuous: emptying `atomicExtensionExclusions` fails it on `atomicNegativeExtensions`.

## Verification

Evaluated settings, `aarch64-darwin`, `crs58`:

| | `statusline/index.ts` | `-statusline/index.ts` |
|---|---|---|
| atomic | selected | **force-excluded** |
| pi | selected | absent |

`modules/home/ai/pi/` has a zero-line diff and pi's generated `packages` is byte-identical to `main`.

Runtime, against the settings this change generates, merged onto a scratch agent dir exactly as `merge-settings.sh` merges them — `atomic --no-session --approve` under a pty, rendered at 80x40:

```
                                                                0.0%/1.0M (auto)
────────────────────────────────────────────────────────────────────────────────
❯
────────────────────────────────────────────────────────────────────────────────
(zai) glm-5.3 high • ~/.treehouse/… (fm/vx-atomic-…)
 gate • ● ADHD Mode
```

Warning count `0`; one footer rather than two; no blank gap; `gate` and `ADHD Mode` still present.
The runtime keys the merge must preserve — `onboardedVersion`, `defaultModel`, `defaultProvider` — survived.

Checks built locally on `aarch64-darwin`:

```
atomic-agent-environment-structural   (new)
pi-agent-environment-structural
pi-agent-environment-policy
pi-agent-environment-smoke
home-manager-crs58
home-configurations-exposed
home-module-exports
home-module-exports-neg
naming-conventions
eval-md-format
```

Buildbot covers the remaining checks and the non-darwin systems.
