### PR TITLE
feat(hooks): lift the nix run/shell and git push confirmation gates

### DIFF
--- a/modules/checks/hooks.nix
+++ b/modules/checks/hooks.nix
@@ -45,6 +45,31 @@
             # A safe-looking segment must not launder a later unsafe one.
             "ask kill 1308; kill $OTHER"
             "ask ps aux | xargs kill"
+
+            # nix run/shell and git push are ungated in every form. An "ask" is a
+            # hard stall for an agent worker launched with permissions bypassed,
+            # and both commands are unavoidable in normal work in this repository.
+            "allow nix run nixpkgs#hello"
+            "allow nix run .#some-app -- --flag"
+            "allow nix shell nixpkgs#jq"
+            "allow git push"
+            "allow git push -u origin fm/some-branch"
+            "allow git -C /some/path push"
+            "allow git push --force origin main"
+            # nix subcommands that were never gated stay ungated.
+            "allow nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands"
+
+            # Neighbouring gates are unaffected by the two lifts above.
+            "ask jj git push"
+            "ask jj git push --all-bookmarks"
+            "ask git reset --hard HEAD~1"
+            "ask git clean -fd"
+            "ask sudo systemctl restart foo"
+            "ask dd if=/dev/zero of=/dev/disk2"
+            "ask truncate -s 0 important.log"
+            "ask shred -u secrets.env"
+            "ask gh workflow run ci.yml"
+            "ask kubectl delete pod foo"
           ];
         in
         pkgs.runCommand "hook-gate-dangerous-commands"

--- a/modules/home/ai/claude-code/default.nix
+++ b/modules/home/ai/claude-code/default.nix
@@ -323,8 +323,7 @@
                 ask = [
                   # # Privilege escalation
                   # "Bash(sudo *)"
-                  # # Git: push and destructive operations
-                  # "Bash(git push *)"
+                  # # Git: destructive operations
                   # "Bash(git reset --hard*)"
                   # "Bash(git clean *)"
                   # "Bash(git checkout .)"
@@ -353,9 +352,6 @@
                   # "Bash(gh release delete *)"
                   # "Bash(gh workflow run *)"
                   # "Bash(gh gist create *)"
-                  # # Nix: arbitrary code execution
-                  # "Bash(nix run *)"
-                  # "Bash(nix shell *)"
                   # # Infrastructure mutation
                   # "Bash(tofu apply*)"
                   # "Bash(tofu destroy*)"

--- a/modules/home/ai/plugins/nix-build-operations/.apm/skills/nix-flake-pr-cycle/SKILL.md
+++ b/modules/home/ai/plugins/nix-build-operations/.apm/skills/nix-flake-pr-cycle/SKILL.md
@@ -99,7 +99,8 @@ Push the bookmark to the GitHub remote.
 jj git push -b <bookmark-name>
 ```
 
-Pushes to non-default refs are auto-permitted by the `gate-dangerous-commands` hook with an ntfy NOTICE; pushes to `main` remain gated and require explicit confirmation.
+`jj git push` to a non-default bookmark is auto-permitted by the `gate-dangerous-commands` hook with an ntfy NOTICE; `jj git push` to `main` remains gated and requires explicit confirmation.
+Plain `git push` is auto-permitted with a NOTICE in every form, because an interactive prompt stalls agent workers launched with permissions bypassed.
 The NOTICE is informational rather than blocking — it surfaces the push to the user's notification stream so a foreground operator can intervene if the push was accidental, while permitting routine bookmark publication without interactive prompts.
 
 ## Phase 4 — draft pull request creation
@@ -218,7 +219,7 @@ Suppress NOTICEs during dense local iteration (rapid push-monitor-fix cycles) an
 `just check-fast` enumerates `currentSystem` only; multi-platform coverage across the fleet is buildbot's domain in CI and is not exercised by the local closure-operator invocation.
 Mergify's `author-approved` label auto-approves only for `author=cameronraysmith`; for other authors the label is inert with respect to auto-approval.
 Skill content (this SKILL.md) activates via `home-manager switch`; the working-tree path is canonical during authoring sessions, but the symlinked store path that agents read at runtime lags by one switch cycle.
-The `gate-dangerous-commands` hook auto-permits non-default-ref pushes and the canonical `gh pr create -d ... -b ""` triad; updates to the hook itself similarly lag by one switch cycle.
+The `gate-dangerous-commands` hook auto-permits `git push` in every form, `jj git push` to non-default bookmarks, and the canonical `gh pr create -d ... -b ""` triad; updates to the hook itself similarly lag by one switch cycle.
 
 The phase numbering is procedural rather than rigid — entering at Phase 3 with an already-validated chain is legitimate, as is iterating Phase 1–2 multiple times before any push.
 The numbering reflects the natural order when starting from a fresh chain and pursuing integration; it is not a sequence the agent is obligated to execute monolithically.

--- a/modules/home/tools/hooks/gate-dangerous-commands.sh
+++ b/modules/home/tools/hooks/gate-dangerous-commands.sh
@@ -26,8 +26,7 @@ Gated patterns (each returns permissionDecision "ask"):
   Privilege escalation
     sudo *
 
-  Git: push and destructive operations (matches through global options like -C, --no-pager)
-    git [-C path] [--global-opts...] push
+  Git: destructive operations (matches through global options like -C, --no-pager)
     git [-C path] [--global-opts...] reset --hard *
     git [-C path] [--global-opts...] clean *
     git [-C path] [--global-opts...] checkout [--] .
@@ -46,10 +45,6 @@ Gated patterns (each returns permissionDecision "ask"):
     gh release create/delete
     gh workflow run
     gh gist create
-
-  Nix: arbitrary code execution
-    nix run *
-    nix shell *
 
   Infrastructure mutation
     tofu/terraform apply/destroy
@@ -180,21 +175,6 @@ notify_permitted() {
   disown
 }
 
-# Inspect git push args (everything after 'push'); return 0 if safe to auto-permit.
-# Escalates on: bare push, --force/--force-with-lease, --all/--mirror/--tags,
-# delete refspec (:branch), or any token referencing main/master/default ref.
-push_is_safe() {
-  local args="$1"
-  [[ -z "${args// }" ]] && return 1
-  echo "$args" | grep -qE '(^|[[:space:]])(-f\b|--force\b|--force-with-lease\b|--all\b|--mirror\b|--tags\b)' && return 1
-  echo "$args" | grep -qE '(^|[[:space:]]):[^[:space:]]' && return 1
-  local default_ref
-  default_ref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
-  default_ref="${default_ref:-main}"
-  echo "$args" | grep -qE "(^|[[:space:]:/])(${default_ref}|main|master)([[:space:]:/]|\$)" && return 1
-  return 0
-}
-
 # Inspect jj git push args; return 0 if safe to auto-permit.
 # Escalates on: bare push, --all-bookmarks/--deleted, --force*, or bookmark
 # targeting main/master/trunk.
@@ -213,17 +193,11 @@ cmd_match 'sudo\s' && REASON="sudo requires approval"
 
 # --- Git: push and destructive operations ---
 # Uses git_cmd_match to handle global options (e.g. -C, --no-pager) between 'git' and subcommand.
-# Push to non-default refs auto-permits with a NOTICE; pushes to main/master or with
-# destructive flags continue to escalate.
+# git push auto-permits with a NOTICE in every form. Agent workers launched with
+# permissions bypassed still stall on a PreToolUse "ask", and push is unavoidable
+# in normal work here, so the confirmation is traded for a notification.
 if [ -z "$REASON" ]; then
-  if git_cmd_match 'push(\s|$)'; then
-    PUSH_ARGS=$(echo "$COMMAND" | sed -nE 's/.*\bgit\b[^|;&>]*\bpush\b[[:space:]]*([^|;&>]*).*/\1/p')
-    if push_is_safe "$PUSH_ARGS"; then
-      notify_permitted "git push (non-default ref)"
-    else
-      REASON="git push requires approval"
-    fi
-  fi
+  git_cmd_match 'push(\s|$)' && notify_permitted "git push"
 fi
 if [ -z "$REASON" ]; then
   if jj_cmd_match 'git\s+push(\s|$)'; then
@@ -304,11 +278,6 @@ if [ -z "$REASON" ]; then
 fi
 if [ -z "$REASON" ]; then
   cmd_match 'gh gist create\b' && REASON="gh gist create may expose code publicly"
-fi
-
-# --- Nix: arbitrary code execution ---
-if [ -z "$REASON" ]; then
-  cmd_match 'nix (run|shell)\s' && REASON="nix run/shell executes arbitrary code"
 fi
 
 # --- Infrastructure mutation ---


### PR DESCRIPTION
Lifts the two Claude Code hook gates the captain authorized on 2026-08-17: `nix run` and `git push`. Both returned `permissionDecision: "ask"`, which is a hard stall for an agent worker launched with permissions bypassed, and neither command is avoidable in normal work here.

## Where the gates actually live

Not in `settings.json`. Both are escalation arms inside `modules/home/tools/hooks/gate-dangerous-commands.sh`, a `writeShellApplication` on PATH that `modules/home/ai/claude-code/hooks.nix` names as a `PreToolUse:Bash` hook. The settings file only references the hook by name, so its hook wiring is unchanged by this PR.

## What changed

`git push` auto-permits in every form with an ntfy NOTICE, following the relaxation convention this file already established for non-default-ref pushes (2a2e5982), canonical `gh pr create -d` (d602b2ca), and `.zt` ssh/scp/rsync (d8e25328). That subsumes `push_is_safe`, so the helper is removed; the cases it used to escalate (force push, delete refspec, push to the default ref) now notify instead of asking.

`nix run`/`nix shell` is removed outright rather than converted to a NOTICE. It is a single arm carrying one message, `"nix run/shell executes arbitrary code"`, so lifting the gate the captain named lifts both subcommands. A notification per `nix run` would be pure noise at the rate this repo invokes it.

## Gates inventoried and deliberately left in place

Not touched, for the captain to decide separately:

| Gate | Protects against |
| --- | --- |
| `dd`, `truncate`, `shred` | raw writes and secure deletion — the `dd` gate that was observed firing |
| `sudo` | privilege escalation |
| `jj git push` | push to a default bookmark or `--all-bookmarks`/force |
| `git reset --hard`, `clean`, `checkout .`, `restore .`, `branch -D`, `stash drop`/`clear` | discarding commits or uncommitted work |
| mutating `gh api`/`pr`/`issue`/`repo`/`release`/`workflow`/`gist` | outward-facing GitHub mutation |
| `tofu`/`terraform apply`/`destroy`, `kubectl apply`/`create`/`delete`/`exec`, `helm install`/`upgrade`/`uninstall` | infrastructure and cluster mutation |
| non-`.zt` `ssh`/`scp`/`rsync` | remote access off the ZeroTier VPN |
| `docker`/`podman push` | publishing an image to a registry |
| `pkill`/`killall`, `kill` with a non-literal PID, `xargs kill` | terminating processes selected by pattern, including sibling agents |
| `find -delete`, `find -exec rm`, `xargs rm` | `rm` bypass vectors |

Companion hooks are untouched: `redirect-rm-to-rip` (denies `rm`), `gate-mutating-http` (asks on mutating curl/wget), `gate-git-worktree` and `gate-worktree-surfaces` (ask before making a plain-git worktree), `enforce-branch-before-edit` (denies edits on the default branch), `verify-diamond-before-edit` (asks on jj diamond-integrity violations).

## Obligations checked

- **Flake check binding the gates** — none. `modules/checks/hooks.nix` is the only oracle driving this script, and its case table covered only the `kill` arm, so nothing asserted the removed shape. Twenty cases added: eight pinning the lifted behavior, twelve pinning neighbouring gates that must not move.
- **OpenSpec spec mandating the gates** — none. The nearest requirement, `openspec/specs/pi-agent-environment/spec.md:117`, governs Pi's separate TypeScript policy engine (`modules/home/ai/pi/policy/permission-rules.ts`), which gates neither command. No spec delta needed.
- **Documentation** — three surfaces updated: the hook's own `--help` category list, the commented-out static ask list in `claude-code/default.nix` that is explicitly retained as documentation of gated categories, and the two places `nix-flake-pr-cycle/SKILL.md` describes push gating.
- **Generated-settings retraction trap** — does not apply, twice over. The gates are script content rather than settings keys, and Claude Code settings are installed wholesale (`install -Dm644`, `claude-code/default.nix:414-430`) rather than through `modules/home/ai/atomic/merge-settings.sh`, which is the mechanism that genuinely cannot retract a key and which only ever touches `~/.atomic/agent/settings.json`.

## Blast radius

Confined to Claude Code. `gate-dangerous-commands` is referenced only by `modules/home/ai/claude-code/hooks.nix`; no other agent consumes it. The firstmate repository's own hooks were not read or modified.

## Verification

Ran `nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands` — the one oracle covering this script — which passes with all 43 cases.

Severity was checked rather than assumed, by replaying the new cases against the pre-change script: six of the eight lifted-gate cases fail there (`nix run`, `nix shell`, bare `git push`, `git -C /p push`, `git push --force origin main`), while `git push -u origin fm/...` and `nix build` were already permitted and serve as anchors rather than regression detectors. The retained-gate cases hold on both sides.

Behavior was then confirmed against the **built derivation**, not the source and not this session, since a running session cannot pick up the change without `just activate`:

```
allow  | nix run nixpkgs#hello          ask | jj git push
allow  | nix shell nixpkgs#jq           ask | git reset --hard HEAD~1
allow  | git push                       ask | sudo systemctl restart foo
allow  | git push --force origin main   ask | dd if=/dev/zero of=/dev/disk2
allow  | git -C /p push                 ask | pkill watcher
```

Also evaluated `homeConfigurations."crs58@aarch64-darwin".activationPackage` to confirm the module edits still evaluate, and built the hook derivation directly, which runs shellcheck via `writeShellApplication` and so confirms removing `push_is_safe` left no dead function.

The full `just check-fast` suite was deliberately not run. Nothing outside this script and its own check changed behavior, and a whole-fleet check run is far wider than the diff.

## Incidental finding — not fixed

The gates pattern-match the whole Bash command string, so a gated word in a quoted string or heredoc trips them even though no such command runs. The first commit's own message contains `find -delete` in prose describing the gates left in place; replaying that commit command against the deployed hook returns `ask` with reason `find -delete removes files`. A heredoc body does not escape this because it is still part of the command — passing the message through a file with `git commit -F <file>` does, which is how the second commit was made.

The three `rm`-bypass arms are the worst affected because they `grep` the raw command with no start-of-line or shell-operator anchoring at all, unlike the `cmd_match` helper the other arms use. Narrowing them is a change to gates this task was not authorized to touch, so they are reported rather than altered.
