### PR TITLE
fix(hooks): re-gate the destructive git push forms

### DIFF
--- a/modules/checks/hooks.nix
+++ b/modules/checks/hooks.nix
@@ -46,18 +46,44 @@
             "ask kill 1308; kill $OTHER"
             "ask ps aux | xargs kill"
 
-            # nix run/shell and git push are ungated in every form. An "ask" is a
-            # hard stall for an agent worker launched with permissions bypassed,
-            # and both commands are unavoidable in normal work in this repository.
+            # nix run/shell is ungated in every form. An "ask" is a hard stall for
+            # an agent worker launched with permissions bypassed, and nix run is
+            # unavoidable in normal work in this repository.
             "allow nix run nixpkgs#hello"
             "allow nix run .#some-app -- --flag"
             "allow nix shell nixpkgs#jq"
+            # nix subcommands that were never gated stay ungated.
+            "allow nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands"
+
+            # Ordinary git push is ungated for the same reason, including to the
+            # default ref, which the repository's own merge helper pushes to.
             "allow git push"
             "allow git push -u origin fm/some-branch"
             "allow git -C /some/path push"
-            "allow git push --force origin main"
-            # nix subcommands that were never gated stay ungated.
-            "allow nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands"
+            "allow git push origin main"
+            "allow git push origin HEAD:main"
+            # --force-with-lease to a task branch is the rebase-then-push flow every
+            # agent worker runs, and gating it is what stalled four of them. It fails
+            # safe on its own: it refuses when the remote moved.
+            "allow git push --force-with-lease origin fm/some-branch"
+            "allow git push --force-with-lease=fm/some-branch origin fm/some-branch"
+            "allow git -C /some/path push --force-with-lease origin fm/some-branch"
+            # A branch name merely containing the default ref is not the default ref.
+            "allow git push --force origin fm/main-guards"
+
+            # The destructive push forms stay gated.
+            "ask git push --force origin main"
+            "ask git push -f origin main"
+            "ask git push --force-with-lease origin main"
+            "ask git push --force-with-lease=main origin main"
+            "ask git push --force origin master"
+            "ask git push --force origin HEAD:main"
+            "ask git -C /some/path push --force origin main"
+            "ask git push origin :some-branch"
+            "ask git push origin --delete some-branch"
+            "ask git push -d origin some-branch"
+            "ask git push --mirror origin"
+            "ask git push --all origin"
 
             # Neighbouring gates are unaffected by the two lifts above.
             "ask jj git push"

--- a/modules/home/ai/claude-code/default.nix
+++ b/modules/home/ai/claude-code/default.nix
@@ -324,6 +324,11 @@
                   # # Privilege escalation
                   # "Bash(sudo *)"
                   # # Git: destructive operations
+                  # # (push gating is conditional on the refspec, which a static
+                  # # pattern cannot express; see push_is_destructive in the hook)
+                  # "Bash(git push --mirror*)"
+                  # "Bash(git push --all*)"
+                  # "Bash(git push --delete *)"
                   # "Bash(git reset --hard*)"
                   # "Bash(git clean *)"
                   # "Bash(git checkout .)"

--- a/modules/home/ai/plugins/nix-build-operations/.apm/skills/nix-flake-pr-cycle/SKILL.md
+++ b/modules/home/ai/plugins/nix-build-operations/.apm/skills/nix-flake-pr-cycle/SKILL.md
@@ -100,7 +100,9 @@ jj git push -b <bookmark-name>
 ```
 
 `jj git push` to a non-default bookmark is auto-permitted by the `gate-dangerous-commands` hook with an ntfy NOTICE; `jj git push` to `main` remains gated and requires explicit confirmation.
-Plain `git push` is auto-permitted with a NOTICE in every form, because an interactive prompt stalls agent workers launched with permissions bypassed.
+Plain `git push` is auto-permitted with a NOTICE in its ordinary forms — including `--force-with-lease` to a task branch and a non-force push to `main` — because an interactive prompt there stalls agent workers launched with permissions bypassed.
+The destructive forms remain gated: a force push naming `main`, `master`, or the resolved default ref, a delete refspec in either the `:branch` or the `--delete` form, and `--mirror`/`--all`.
+That gating reads the raw command bytes of the tool call, so a push performed inside a script is not seen by it.
 The NOTICE is informational rather than blocking — it surfaces the push to the user's notification stream so a foreground operator can intervene if the push was accidental, while permitting routine bookmark publication without interactive prompts.
 
 ## Phase 4 — draft pull request creation
@@ -219,7 +221,7 @@ Suppress NOTICEs during dense local iteration (rapid push-monitor-fix cycles) an
 `just check-fast` enumerates `currentSystem` only; multi-platform coverage across the fleet is buildbot's domain in CI and is not exercised by the local closure-operator invocation.
 Mergify's `author-approved` label auto-approves only for `author=cameronraysmith`; for other authors the label is inert with respect to auto-approval.
 Skill content (this SKILL.md) activates via `home-manager switch`; the working-tree path is canonical during authoring sessions, but the symlinked store path that agents read at runtime lags by one switch cycle.
-The `gate-dangerous-commands` hook auto-permits `git push` in every form, `jj git push` to non-default bookmarks, and the canonical `gh pr create -d ... -b ""` triad; updates to the hook itself similarly lag by one switch cycle.
+The `gate-dangerous-commands` hook auto-permits `git push` in every form but the destructive subset listed in Phase 3, `jj git push` to non-default bookmarks, and the canonical `gh pr create -d ... -b ""` triad; updates to the hook itself similarly lag by one switch cycle.
 
 The phase numbering is procedural rather than rigid — entering at Phase 3 with an already-validated chain is legitimate, as is iterating Phase 1–2 multiple times before any push.
 The numbering reflects the natural order when starting from a fresh chain and pursuing integration; it is not a sequence the agent is obligated to execute monolithically.

--- a/modules/home/tools/hooks/gate-dangerous-commands.sh
+++ b/modules/home/tools/hooks/gate-dangerous-commands.sh
@@ -27,6 +27,10 @@ Gated patterns (each returns permissionDecision "ask"):
     sudo *
 
   Git: destructive operations (matches through global options like -C, --no-pager)
+    git [-C path] [--global-opts...] push --force|-f|--force-with-lease  (default ref only)
+    git [-C path] [--global-opts...] push --mirror|--all
+    git [-C path] [--global-opts...] push [remote] :branch   (delete refspec)
+    git [-C path] [--global-opts...] push -d|--delete *
     git [-C path] [--global-opts...] reset --hard *
     git [-C path] [--global-opts...] clean *
     git [-C path] [--global-opts...] checkout [--] .
@@ -175,6 +179,33 @@ notify_permitted() {
   disown
 }
 
+# Inspect git push args (everything after 'push'); return 0 when the push is
+# destructive enough to require approval.
+# Escalates on: a force-flavored push (-f/--force/--force-with-lease) whose
+# refspec names main, master, or the resolved default ref; a delete refspec in
+# either the `:branch` or the `-d/--delete` form; and --mirror/--all, since
+# --mirror deletes remote refs that are absent locally.
+# Everything else auto-permits, including --force-with-lease to a task branch --
+# the rebase-then-push flow every agent worker runs, where an "ask" is a hard
+# stall -- and ordinary pushes to the default ref, which the repository's own
+# merge helper performs to fast-forward main.
+# A force-flavored push carrying no refspec is not escalated: which ref it
+# rewrites depends on push.default and the checked-out branch, neither of which
+# this hook can see.
+push_is_destructive() {
+  local args="$1"
+  echo "$args" | grep -qE '(^|[[:space:]])(--mirror|--all)([[:space:]]|$)' && return 0
+  echo "$args" | grep -qE '(^|[[:space:]])\+?:[^[:space:]]' && return 0
+  echo "$args" | grep -qE '(^|[[:space:]])(-d|--delete)([[:space:]]|$)' && return 0
+  if echo "$args" | grep -qE '(^|[[:space:]])(-f|--force|--force-with-lease)([[:space:]=]|$)'; then
+    local default_ref
+    default_ref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
+    default_ref="${default_ref:-main}"
+    echo "$args" | grep -qE "(^|[[:space:]:/=])(${default_ref}|main|master)([[:space:]:/]|\$)" && return 0
+  fi
+  return 1
+}
+
 # Inspect jj git push args; return 0 if safe to auto-permit.
 # Escalates on: bare push, --all-bookmarks/--deleted, --force*, or bookmark
 # targeting main/master/trunk.
@@ -193,11 +224,21 @@ cmd_match 'sudo\s' && REASON="sudo requires approval"
 
 # --- Git: push and destructive operations ---
 # Uses git_cmd_match to handle global options (e.g. -C, --no-pager) between 'git' and subcommand.
-# git push auto-permits with a NOTICE in every form. Agent workers launched with
-# permissions bypassed still stall on a PreToolUse "ask", and push is unavoidable
-# in normal work here, so the confirmation is traded for a notification.
+# git push auto-permits with a NOTICE except for the destructive forms
+# push_is_destructive names. Agent workers launched with permissions bypassed
+# stall on a PreToolUse "ask", and the ordinary forms are unavoidable in normal
+# work here, so for those the confirmation is traded for a notification.
+# The match is over the raw command bytes, so a push performed inside a script
+# is invisible to this arm: the tool call is the script name.
 if [ -z "$REASON" ]; then
-  git_cmd_match 'push(\s|$)' && notify_permitted "git push"
+  if git_cmd_match 'push(\s|$)'; then
+    PUSH_ARGS=$(echo "$COMMAND" | sed -nE 's/.*\bgit\b[^|;&>]*\bpush\b[[:space:]]*([^|;&>]*).*/\1/p')
+    if push_is_destructive "$PUSH_ARGS"; then
+      REASON="destructive git push requires approval"
+    else
+      notify_permitted "git push"
+    fi
+  fi
 fi
 if [ -z "$REASON" ]; then
   if jj_cmd_match 'git\s+push(\s|$)'; then


### PR DESCRIPTION
## Why

`5aadf369` lifted the `git push` confirmation gate by deleting `push_is_safe` outright, so push auto-permits in every form — including the three that can destroy published history.
The stall that motivated the lift came from one form only, `git push --force-with-lease <remote> <task-branch>`, which fails safe by design: it refuses when the remote moved.
The removal was broader than the defect it fixed.

## What changed

`push_is_destructive` restores the destructive subset rather than the original helper:

| Form | Decision |
|---|---|
| `-f` / `--force` / `--force-with-lease` naming `main`, `master`, or the resolved default ref | ask |
| delete refspec — `:branch` and `-d`/`--delete` | ask |
| `--mirror`, `--all` | ask |
| `--force-with-lease` to a task branch | auto-permit |
| any non-force push, including to `main` | auto-permit |

Two departures from the original `push_is_safe` narrow it: it escalated on *any* token naming the default ref and on `--force-with-lease` anywhere, which is exactly what stalled workers; here the default-ref test applies only in combination with a force flag.
One widens: `-d`/`--delete` auto-permitted in the original despite performing the same remote-ref deletion as the `:branch` refspec it did escalate, so both are gated as one class.
`--tags` is not restored — publishing tags destroys nothing.

A force-flavored push carrying no refspec keeps auto-permitting.
Which ref it rewrites depends on `push.default` and the checked-out branch, neither of which a PreToolUse hook can observe, and escalating it would re-stall a worker that force-with-leases its own tracked branch.

`nix run`/`nix shell` are untouched; that lift stands.

## Limitation stated rather than fixed

The gate matches the raw command bytes of the tool call, so a push performed inside a script is invisible to it — the repository's own merge helper fast-forwards `main` by pushing to it and this arm never fired, because the tool call was the script name.
The hook comment and the SKILL.md paragraph now say so instead of claiming protection the gate does not provide.
The related raw-byte behavior `5aadf369`'s PR already reports, where protected words inside quoted strings and heredocs trip other arms, is likewise out of scope here.

No OpenSpec requirement binds this hook: `openspec/specs/` contains no reference to it, and the only mention under `openspec/` is an archived task narrating a `jj git push` invocation.

## Generated artifact

Driving the `writeShellApplication` output built by `home-manager-crs58`:

```
resolved default ref here: main
git push --force origin main                       -> ask
git push -f origin main                            -> ask
git push --force-with-lease origin main            -> ask
git push --force-with-lease=main origin main       -> ask
git push --force origin master                     -> ask
git push --force origin HEAD:main                  -> ask
git -C /some/path push --force origin main         -> ask
git push origin :some-branch                       -> ask
git push origin --delete some-branch               -> ask
git push -d origin some-branch                     -> ask
git push --mirror origin                           -> ask
git push --all origin                              -> ask
git push --force-with-lease origin fm/some-branch  -> AUTO-PERMIT (no output)
git push --force origin fm/main-guards             -> AUTO-PERMIT (no output)
git push origin main                               -> AUTO-PERMIT (no output)
git push                                           -> AUTO-PERMIT (no output)
```

## Testing

`nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands` is the one oracle driving this script.
Its case table pinned "git push auto-permits in every form"; the case asserting `git push --force origin main` allows is inverted, and eighteen cases are added — twelve pinning each restored arm, six pinning what must keep auto-permitting, including `--force-with-lease` to a task branch in bare, `=<expect>`, and `git -C` forms, which is the regression guard for the defect this change must not reintroduce.

Severity was checked by replaying the push cases against both prior scripts.
All twelve escalation cases fail against `5aadf369`'s script, so they pin the restoration rather than restating it.
Eight of the auto-permit cases — the force-with-lease trio, bare push, push to `main`, `HEAD:main`, `git -C` push, and a branch merely containing "main" — fail against the pre-`5aadf369` `push_is_safe`, so the regression guard pins a real difference; the `--delete` pair fails against both.

Also built `home-manager-crs58` (the activationPackage consuming both edited nix files, which runs shellcheck over the script through `writeShellApplication`), plus `package-apm-skills-compose` and `eval-md-format` for the SKILL.md edit.
`just check-fast` was deliberately not run: nothing outside this script, its check, and the two documentation surfaces changed behavior.
