### PR TITLE
fix(pi): stop the edit-write policy blocking atomic, and decide by recoverability

### DIFF
--- a/modules/checks/pi-agent-environment.nix
+++ b/modules/checks/pi-agent-environment.nix
@@ -2025,6 +2025,28 @@
               permissionRules = homeFileSourceIs permissionRulesTarget permissionRulesPath;
               editWritePolicy = homeFileSourceIs editWritePolicyTarget editWritePolicyPath;
             };
+            # atomic inherits ~/.pi/agent as a configuration root unconditionally
+            # and scans its extensions directory, so a file written only for pi
+            # runs under atomic unless atomic's own settings refuse it by name.
+            # Nothing else in this repository observes that coupling, and the
+            # edit/write policy reached atomic through it for three days.
+            piOnlyExtensionScope =
+              let
+                declared = homeConfig.aiAgentSettings.piOnlyExtensions;
+                forceExcludes = homeConfig.programs.atomic.settings.extensions or [ ];
+              in
+              {
+                inherit declared;
+                atomicForceExcludes = forceExcludes;
+                everyDeclaredExcluded = lib.all (
+                  extension: builtins.elem "-extensions/${extension}" forceExcludes
+                ) declared;
+                # atomic matches a force-exclude against the path relative to the
+                # scanned configuration root, never the basename, so the bare
+                # spelling loads the extension it claims to refuse.
+                noBareBasenameSpelling =
+                  !lib.any (entry: lib.any (extension: entry == "-${extension}") declared) forceExcludes;
+              };
             contextNixOwned = piConfig.context == homeConfig.programs.agents-md.settings.text;
             theme = {
               contentName = themeJson.name or null;
@@ -2120,6 +2142,12 @@
             policySourcesCheckedIn = {
               permissionRules = true;
               editWritePolicy = true;
+            };
+            piOnlyExtensionScope = {
+              declared = [ "edit-write-policy.ts" ];
+              atomicForceExcludes = [ "-extensions/edit-write-policy.ts" ];
+              everyDeclaredExcluded = true;
+              noBareBasenameSpelling = true;
             };
             contextNixOwned = true;
             theme = {

--- a/modules/checks/pi-agent-environment.nix
+++ b/modules/checks/pi-agent-environment.nix
@@ -642,41 +642,13 @@
       ];
       coreCases = map (case: { kind = "core"; } // case) [
         {
-          name = "mutable path outside repository prompts";
-          expected = "prompt";
+          name = "path outside any repository blocks as unrecoverable";
+          expected = "block";
+          reason = "outside a recognized repository";
           input = {
             operation = "edit";
-            target = {
-              kind = "mutable";
-              canonicalPath = "/workspace/note.txt";
-            };
+            target.canonicalPath = "/workspace/note.txt";
             repository.kind = "outside-repository";
-          };
-        }
-        {
-          name = "nix store target blocks";
-          expected = "block";
-          reason = "immutable";
-          input = {
-            operation = "write";
-            target = {
-              kind = "immutable";
-              canonicalPath = "/nix/store/abc-policy";
-              root = "/nix/store";
-            };
-          };
-        }
-        {
-          name = "declared immutable root blocks";
-          expected = "block";
-          reason = "immutable";
-          input = {
-            operation = "edit";
-            target = {
-              kind = "immutable";
-              canonicalPath = "/immutable/config.json";
-              root = "/immutable";
-            };
           };
         }
         {
@@ -684,10 +656,7 @@
           expected = "allow";
           input = {
             operation = "edit";
-            target = {
-              kind = "mutable";
-              canonicalPath = "/repo/file.ts";
-            };
+            target.canonicalPath = "/repo/file.ts";
             repository = {
               kind = "git";
               root = "/repo";
@@ -703,10 +672,7 @@
           expected = "allow";
           input = {
             operation = "edit";
-            target = {
-              kind = "mutable";
-              canonicalPath = "/repo/..config";
-            };
+            target.canonicalPath = "/repo/..config";
             repository = {
               kind = "git";
               root = "/repo";
@@ -718,15 +684,29 @@
           };
         }
         {
-          name = "git main blocks";
+          name = "git target outside the repository root blocks";
           expected = "block";
+          reason = "does not contain the canonical target";
+          input = {
+            operation = "write";
+            target.canonicalPath = "/elsewhere/file.ts";
+            repository = {
+              kind = "git";
+              root = "/repo";
+              head = {
+                kind = "feature";
+                branch = "feature/policy";
+              };
+            };
+          };
+        }
+        {
+          name = "git main notifies and allows";
+          expected = "notify";
           reason = "main";
           input = {
             operation = "write";
-            target = {
-              kind = "mutable";
-              canonicalPath = "/repo/file.ts";
-            };
+            target.canonicalPath = "/repo/file.ts";
             repository = {
               kind = "git";
               root = "/repo";
@@ -738,15 +718,12 @@
           };
         }
         {
-          name = "git master blocks";
-          expected = "block";
+          name = "git master notifies and allows";
+          expected = "notify";
           reason = "master";
           input = {
             operation = "edit";
-            target = {
-              kind = "mutable";
-              canonicalPath = "/repo/file.ts";
-            };
+            target.canonicalPath = "/repo/file.ts";
             repository = {
               kind = "git";
               root = "/repo";
@@ -758,15 +735,11 @@
           };
         }
         {
-          name = "invalid repository state blocks";
-          expected = "block";
-          reason = "ambiguous";
+          name = "indeterminate repository state allows";
+          expected = "allow";
           input = {
             operation = "edit";
-            target = {
-              kind = "mutable";
-              canonicalPath = "/repo/file.ts";
-            };
+            target.canonicalPath = "/repo/file.ts";
             repository = {
               kind = "invalid";
               diagnostic = "ambiguous repository identity";
@@ -898,22 +871,22 @@
         {
           scenario = "ordinary-conflict";
           probes = 5;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "ordinary-divergent-at";
           probes = 5;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "ordinary-main-at";
           probes = 5;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "ordinary-master-at";
           probes = 5;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "diamond-healthy";
@@ -937,169 +910,169 @@
         {
           scenario = "diamond-missing-wip";
           probes = 8;
-          expected = "block";
+          expected = "notify";
           reason = "wip bookmark is absent";
         }
         {
           scenario = "diamond-moved-wip";
           probes = 8;
-          expected = "block";
+          expected = "notify";
           reason = "wip bookmark is moved";
         }
         {
           scenario = "diamond-divergent-wip";
           probes = 8;
-          expected = "block";
+          expected = "notify";
           reason = "wip bookmark is divergent";
         }
         {
           scenario = "diamond-divergent-wip-without-target";
           probes = 8;
-          expected = "block";
+          expected = "notify";
           reason = "wip bookmark is divergent";
         }
         {
           scenario = "diamond-divergent-wip-malformed-resolution";
           probes = 6;
-          expected = "block";
-          reason = "malformed";
+          expected = "allow";
         }
         {
           scenario = "diamond-nonsingle-parent-wip";
           probes = 8;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "diamond-single-parent-join";
           probes = 8;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "diamond-conflicted-join";
           probes = 8;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "diamond-conflicted-immediate-parent";
           probes = 8;
-          expected = "block";
+          expected = "notify";
         }
         {
           scenario = "diamond-join-parent-count-mismatch";
           probes = 8;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "diamond-malformed-join-probe";
           probes = 7;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "diamond-failing-join-probe";
           probes = 7;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "malformed-probe";
           probes = 2;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "malformed-parent-count-probe";
           probes = 2;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "failing-probe";
           probes = 2;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "ambiguous-probe";
           probes = 2;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "failing-root-probe";
           probes = 1;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "outside-jj-contradictory-stdout";
           probes = 1;
-          expected = "block";
-          reason = "jj root";
+          expected = "allow";
         }
         {
           scenario = "outside-jj-wrong-status";
           probes = 1;
-          expected = "block";
-          reason = "jj root";
+          expected = "allow";
         }
         {
           scenario = "outside-jj-mixed-diagnostics";
           probes = 1;
           expected = "block";
-          reason = "jj root";
+          reason = "outside a recognized repository";
+        }
+        {
+          # Regression oracle for the anchored jj diagnostic. jujutsu 0.43.0
+          # appends the Hint lines below whenever the probed directory holds a
+          # .git directory, which is exactly the case that has to reach the Git
+          # branch. While the match was anchored at the end of stderr this row
+          # blocked with "jj root", so the Git arm was unreachable at the root
+          # of every ordinary Git repository.
+          scenario = "outside-jj-hint-git-main";
+          probes = 1;
+          expected = "notify";
+          reason = "main";
         }
         {
           scenario = "classification-whitespace-only";
           probes = 5;
-          expected = "block";
-          reason = "classification";
+          expected = "allow";
         }
         {
           scenario = "classification-padded";
           probes = 5;
-          expected = "block";
-          reason = "classification";
+          expected = "allow";
         }
         {
           scenario = "classification-extra-blank";
           probes = 5;
-          expected = "block";
-          reason = "classification";
+          expected = "allow";
         }
         {
           scenario = "root-padded";
           probes = 1;
-          expected = "block";
-          reason = "root";
+          expected = "allow";
         }
         {
           scenario = "current-extra-blank";
           probes = 2;
-          expected = "block";
-          reason = "current";
+          expected = "allow";
         }
         {
           scenario = "identity-padded";
           probes = 3;
-          expected = "block";
-          reason = "identity";
+          expected = "allow";
         }
         {
           scenario = "defaults-extra-blank";
           probes = 4;
-          expected = "block";
-          reason = "default bookmark";
+          expected = "allow";
         }
         {
           scenario = "resolution-padded";
           probes = 6;
-          expected = "block";
-          reason = "resolution";
+          expected = "allow";
         }
         {
           scenario = "parents-extra-blank";
           probes = 8;
-          expected = "block";
-          reason = "parent";
+          expected = "allow";
         }
         {
           scenario = "canonical-root-mismatch";
           probes = 1;
-          expected = "block";
+          expected = "allow";
         }
         {
           scenario = "target-jj-cwd-other-repository";
@@ -1122,7 +1095,7 @@
         {
           scenario = "git-protected-head";
           probes = 1;
-          expected = "block";
+          expected = "notify";
           reason = "main";
         }
         {
@@ -1138,14 +1111,12 @@
         {
           scenario = "git-malformed-head";
           probes = 1;
-          expected = "block";
-          reason = "Git head";
+          expected = "allow";
         }
         {
           scenario = "git-multiline-head";
           probes = 1;
-          expected = "block";
-          reason = "Git head";
+          expected = "allow";
         }
         {
           scenario = "colocated-healthy";
@@ -1156,8 +1127,7 @@
         {
           scenario = "colocated-divergent-roots";
           probes = 1;
-          expected = "block";
-          reason = "ambiguous";
+          expected = "allow";
           expectedGitRootDirectory = "/repo";
         }
       ];
@@ -1201,14 +1171,16 @@
           reason = "Git root";
         }
         {
-          name = "Git outside result with mixed diagnostics is invalid";
+          # Prefix match: Git appends advice after the diagnostic in some
+          # configurations, and treating that as unparseable is what made the
+          # jj analogue swallow every write at a repository root.
+          name = "Git outside result with trailing diagnostics is accepted";
           result = {
             stdout = "";
             stderr = "fatal: not a git repository (or any of the parent directories): .git\nadditional diagnostic\n";
             code = 128;
           };
-          expected = "invalid";
-          reason = "Git root";
+          expected = "outside";
         }
       ];
       adapterCases = map (case: { kind = "adapter"; } // case) [
@@ -1232,28 +1204,41 @@
           expected = "pass";
         }
         {
-          name = "adapter translates edit diagnostic block";
-          scenario = "immutable";
-          tool = "edit";
-          input.path = "/nix/store/abc";
-          expected = "block";
-          reason = "immutable";
-        }
-        {
-          name = "adapter normalizes Pi at-prefixed paths";
-          scenario = "builtin-at-prefix";
-          tool = "write";
-          input.path = "@/nix/store/abc";
-          expected = "block";
-          reason = "immutable";
-        }
-        {
-          name = "adapter translates write diagnostic block";
+          name = "adapter permits a notify decision and announces it";
           scenario = "git-main";
           tool = "write";
           input.path = "/repo/file.ts";
+          expected = "pass";
+          expectedNotification = "main";
+        }
+        {
+          name = "adapter blocks a target outside any repository";
+          scenario = "outside-repository";
+          tool = "edit";
+          input.path = "/workspace/file.ts";
           expected = "block";
-          reason = "main";
+          reason = "outside a recognized repository";
+        }
+        {
+          # Without the @ strip this resolves under cwd and lands inside the
+          # repository, so the row discriminates the normalization rather than
+          # merely exercising it.
+          name = "adapter strips a Pi at-prefix before resolving";
+          scenario = "outside-repository";
+          tool = "write";
+          input.path = "@/workspace/file.ts";
+          expected = "block";
+          reason = "outside a recognized repository";
+        }
+        {
+          # Likewise: unexpanded, "~/secret" resolves to <cwd>/~/secret, which
+          # is inside the repository and would have been permitted.
+          name = "adapter expands a leading tilde before resolving";
+          scenario = "outside-repository";
+          tool = "write";
+          input.path = "~/secret";
+          expected = "block";
+          reason = "outside a recognized repository";
         }
         {
           name = "adapter passes unrelated tools through";
@@ -1263,7 +1248,7 @@
           expected = "pass";
         }
         {
-          name = "adapter blocks malformed tool input";
+          name = "adapter blocks a non-string path";
           scenario = "git-feature";
           tool = "edit";
           input.path = 42;
@@ -1271,49 +1256,190 @@
           reason = "malformed";
         }
         {
-          name = "adapter blocks core exceptions";
+          name = "adapter blocks an empty path";
+          scenario = "git-feature";
+          tool = "write";
+          input.path = "";
+          expected = "block";
+          reason = "malformed";
+        }
+        {
+          name = "adapter blocks a whitespace-only path";
+          scenario = "git-feature";
+          tool = "write";
+          input.path = "   ";
+          expected = "block";
+          reason = "malformed";
+        }
+        {
+          name = "adapter blocks a missing path key";
+          scenario = "git-feature";
+          tool = "edit";
+          input = { };
+          expected = "block";
+          reason = "malformed";
+        }
+        {
+          # atomic's edit tool takes a single hashline string under
+          # additionalProperties: false, so no path can ever reach this adapter
+          # from that agent and every atomic edit was refused as malformed.
+          # This row records why the extension is scoped to Pi in
+          # modules/home/ai/agent-settings.nix rather than taught a second tool
+          # grammar; it is the shape the policy must never be asked to judge.
+          name = "adapter cannot read atomic hashline edit input";
+          scenario = "git-feature";
+          tool = "edit";
+          input.input = "[greeter.ts#A18E]\nreplace 1..1:\n+const x = 2;\n";
+          expected = "block";
+          reason = "malformed";
+        }
+        {
+          name = "adapter permits core exceptions";
           scenario = "core-throws";
           tool = "edit";
           input.path = "/repo/file.ts";
-          expected = "block";
-          reason = "policy evaluation failed";
+          expected = "pass";
         }
         {
-          name = "adapter blocks capability exceptions";
+          name = "adapter permits capability exceptions";
           scenario = "capability-throws";
           tool = "write";
           input.path = "/repo/file.ts";
-          expected = "block";
-          reason = "capability failed";
+          expected = "pass";
         }
         {
-          name = "adapter blocks a missing filesystem capability";
+          name = "adapter permits a missing filesystem capability";
           scenario = "capability-missing";
           tool = "edit";
           input.path = "/repo/file.ts";
-          expected = "block";
-          reason = "capability failed";
+          expected = "pass";
         }
         {
-          name = "adapter blocks a throwing capability factory";
+          name = "adapter permits a throwing capability factory";
           scenario = "capability-factory-throws";
           tool = "write";
           input.path = "/repo/file.ts";
-          expected = "block";
-          reason = "adapter failed";
+          expected = "pass";
         }
         {
-          name = "adapter blocks unavailable interaction";
-          scenario = "outside-headless";
-          tool = "edit";
-          input.path = "/workspace/file.ts";
-          expected = "block";
-          reason = "interaction unavailable";
+          name = "adapter permits a throwing notification capability";
+          scenario = "notification-throws";
+          tool = "write";
+          input.path = "/repo/file.ts";
+          expected = "pass";
+        }
+      ];
+      normalizeCases = map (case: { kind = "normalize"; } // case) [
+        {
+          name = "normalize keeps an ordinary relative path";
+          input = "src/a.ts";
+          expected = "src/a.ts";
+        }
+        {
+          name = "normalize strips a Pi at-prefix";
+          input = "@/nix/store/x/f";
+          expected = "/nix/store/x/f";
+        }
+        {
+          name = "normalize expands a bare tilde";
+          input = "~";
+          expected = "/home/tester";
+        }
+        {
+          name = "normalize expands a tilde path";
+          input = "~/secret";
+          expected = "/home/tester/secret";
+        }
+        {
+          name = "normalize expands a tilde path behind an at-prefix";
+          input = "@~/secret";
+          expected = "/home/tester/secret";
+        }
+        {
+          name = "normalize converts a file URL";
+          input = "file:///etc/hosts";
+          expected = "/etc/hosts";
+        }
+        {
+          name = "normalize folds unicode space variants";
+          input = builtins.fromJSON ''"a\u00a0b.txt"'';
+          expected = "a b.txt";
+        }
+        {
+          name = "normalize rejects a whitespace-only path";
+          input = "   ";
+          expected = "(undefined)";
+        }
+        {
+          name = "normalize rejects a bare at-prefix";
+          input = "@";
+          expected = "(undefined)";
+        }
+      ];
+      classificationCases = map (case: { kind = "classification"; } // case) [
+        {
+          name = "classification reports a malformed current probe";
+          scenario = "malformed-probe";
+          expected = "invalid";
+          reason = "jj current probe is malformed";
+        }
+        {
+          name = "classification reports a failing current probe";
+          scenario = "failing-probe";
+          expected = "invalid";
+          reason = "jj current probe failed";
+        }
+        {
+          name = "classification reports an ambiguous current probe";
+          scenario = "ambiguous-probe";
+          expected = "invalid";
+          reason = "jj current probe is ambiguous";
+        }
+        {
+          name = "classification reports a failing root probe";
+          scenario = "failing-root-probe";
+          expected = "invalid";
+          reason = "jj root probe failed";
+        }
+        {
+          name = "classification reports a malformed join probe";
+          scenario = "diamond-malformed-join-probe";
+          expected = "invalid";
+          reason = "join probe is malformed";
+        }
+        {
+          name = "classification reports a canonical root mismatch";
+          scenario = "canonical-root-mismatch";
+          expected = "invalid";
+          reason = "does not contain the canonical target";
+        }
+        {
+          name = "classification reports ambiguous Git and jj identities";
+          scenario = "colocated-divergent-roots";
+          expected = "invalid";
+          reason = "ambiguous Git and jj repository identities";
+        }
+        {
+          name = "classification reports a healthy diamond";
+          scenario = "diamond-healthy";
+          expected = "jj-diamond";
+        }
+        {
+          name = "classification reports an ordinary jj repository";
+          scenario = "ordinary-healthy";
+          expected = "jj-ordinary";
         }
       ];
       policyCases = pkgs.writeText "pi-agent-environment-policy-cases.json" (
         builtins.toJSON (
-          shellCases ++ projectCases ++ coreCases ++ repositoryCases ++ gitRootCases ++ adapterCases
+          shellCases
+          ++ projectCases
+          ++ coreCases
+          ++ repositoryCases
+          ++ gitRootCases
+          ++ adapterCases
+          ++ normalizeCases
+          ++ classificationCases
         )
       );
       # Ambient stand-ins for the only two type surfaces this sandbox cannot
@@ -1364,9 +1490,11 @@
           export function writeFileSync(path: string, data: string): void;
         }
         declare module "node:os" {
+          export function homedir(): string;
           export function tmpdir(): string;
         }
         declare module "node:url" {
+          export function fileURLToPath(url: string): string;
           export function pathToFileURL(path: string): { href: string };
         }
         declare module "bun:test" {
@@ -1389,7 +1517,7 @@
             readonly cwd: string;
             readonly hasUI: boolean;
             readonly ui: {
-              confirm(title: string, message: string): Promise<boolean>;
+              notify(message: string, type?: "info" | "warning" | "error"): void;
             };
           }
           export interface ExtensionAPI {
@@ -1479,7 +1607,7 @@
         };
         const hasPermissionPolicy = permissionModule.policyPresent === true && typeof permissionModule.default === "function";
         const hasEditPolicy = editModule.policyPresent === true && typeof editModule.decideEditWrite === "function";
-        const editPolicyKinds = new Set(["git-root", "core", "repository", "adapter"]);
+        const editPolicyKinds = new Set(["git-root", "core", "repository", "adapter", "normalize", "classification"]);
         const customConfig = hasPermissionPolicy ? permissionModule.default(helpers) : {};
 
         function classify(command: string, userCode: unknown, project: unknown) {
@@ -1697,6 +1825,15 @@
           "diamond-failing-join-probe": () => diamondFixture((slots) => {
             slots.joinProbe = processResult("", 2, "join probe failed");
           }),
+          "outside-jj-hint-git-main": () => [
+            processResult(
+              "",
+              1,
+              jjOutside.stderr +
+                "Hint: It looks like this is a git repo. You can create a jj repo backed by it by running this:\n" +
+                "jj git init\n",
+            ),
+          ],
           "target-git-cwd-jj-repository": () => diamondFixture(),
           "colocated-healthy": () => ordinary,
           "colocated-divergent-roots": () => [ordinary[0]],
@@ -1705,7 +1842,7 @@
           "capability-factory-throws": () => diamondFixture(),
         };
 
-        const withoutJjScenarios = ["immutable", "builtin-at-prefix", "outside-headless", "capability-throws"];
+        const withoutJjScenarios = ["outside-repository", "capability-throws", "notification-throws"];
         const withoutJjFixture = (scenario: string) => withoutJjScenarios.includes(scenario) || scenario.startsWith("git-");
 
         function jjOutputs(scenario: string) {
@@ -1716,7 +1853,7 @@
 
         const fixtureConsumers = new Set(
           cases
-            .filter((entry: { kind: string }) => entry.kind === "repository" || entry.kind === "adapter")
+            .filter((entry: { kind: string }) => entry.kind === "repository" || entry.kind === "adapter" || entry.kind === "classification")
             .map((entry: { scenario: string }) => entry.scenario)
             .filter((scenario: string) => scenario !== "registration" && !withoutJjFixture(scenario)),
         );
@@ -1737,24 +1874,28 @@
           jjCwds: string[],
           gitRootDirectories: string[] = [],
           gitHeadDirectories: string[] = [],
+          notifications: string[] = [],
         ) {
-          const gitScenario = scenario.startsWith("git-") || scenario === "target-git-cwd-jj-repository";
+          const gitScenario =
+              scenario.startsWith("git-") ||
+              scenario === "target-git-cwd-jj-repository" ||
+              scenario === "outside-jj-hint-git-main" ||
+              scenario === "notification-throws";
           const outputs = withoutJjFixture(scenario) ? [jjOutside] : jjOutputs(scenario);
           let jjIndex = 0;
           return {
             filesystem: {
+              homeDirectory: () => "/home/tester",
               canonicalize: async (target: string) => {
                 if (scenario === "capability-throws") throw new Error("filesystem unavailable");
-                if (scenario === "immutable") return "/nix/store/abc";
-                if (scenario === "builtin-at-prefix" && target.startsWith("@")) return "/repo/escaped-at-prefix";
                 return target;
               },
               inspectionDirectory: async (target: string) => {
                 if (target.startsWith("/target/")) return "/target";
                 if (target.startsWith("/workspace/")) return "/workspace";
+                if (target.startsWith("/home/")) return "/home/tester";
                 return "/repo";
               },
-              immutableRoots: async () => ["/nix/store", "/immutable"],
             },
             git: {
               root: async (directory: string) => {
@@ -1770,7 +1911,12 @@
               },
               head: async (root: string) => {
                 gitHeadDirectories.push(root);
-                if (scenario === "git-main" || scenario === "git-protected-head") return processResult("main\n");
+                if (
+                  scenario === "git-main" ||
+                  scenario === "git-protected-head" ||
+                  scenario === "outside-jj-hint-git-main" ||
+                  scenario === "notification-throws"
+                ) return processResult("main\n");
                 if (scenario === "git-multiline-head") return processResult("main\nfeature/policy\n");
                 if (scenario === "git-malformed-head") return processResult("feature branch\n");
                 if (scenario === "git-detached-head") return processResult("", 1, "");
@@ -1790,9 +1936,11 @@
                 return outputs[jjIndex++] ?? processResult("", 99, "unexpected jj probe");
               },
             },
-            interaction: {
-              available: scenario !== "outside-headless",
-              confirm: async () => true,
+            notification: {
+              notify: (message: string) => {
+                if (scenario === "notification-throws") throw new Error("notification unavailable");
+                notifications.push(message);
+              },
             },
           };
         }
@@ -1877,17 +2025,25 @@
               const jjCwds: string[] = [];
               const gitRootDirectories: string[] = [];
               const gitHeadDirectories: string[] = [];
+              const notifications: string[] = [];
               const capabilities = fakeCapabilities(
                 entry.scenario,
                 calls,
                 jjCwds,
                 gitRootDirectories,
                 gitHeadDirectories,
+                notifications,
               );
               const target = entry.target ?? "/repo/file.ts";
               const cwd = entry.cwd ?? "/repo";
               const input = await editModule.evaluateEditWrite("edit", target, cwd, capabilities);
               check(entry.name, input.decision, entry.expected, input.reason ?? "", entry.reason);
+              // A notify decision that announces nothing is a bare allow, which
+              // is a different decision from the one this policy declares.
+              const expectedNotifications = entry.expected === "notify" ? 1 : 0;
+              if (notifications.length !== expectedNotifications) {
+                failures.push(entry.name + ": expected " + expectedNotifications + " announcement(s), got " + JSON.stringify(notifications));
+              }
               for (const argv of calls) {
                 if (argv[0] !== "jj" || argv[1] !== "--ignore-working-copy") {
                   failures.push(entry.name + ": jj argv does not start with jj --ignore-working-copy: " + JSON.stringify(argv));
@@ -1921,6 +2077,34 @@
               }
               continue;
             }
+            if (entry.kind === "normalize") {
+              if (typeof editModule.normalizeToolPath !== "function") {
+                failures.push(entry.name + ": missing tool path normalizer");
+                continue;
+              }
+              const actual = editModule.normalizeToolPath(entry.input, "/home/tester");
+              check(entry.name, actual ?? "(undefined)", entry.expected, "");
+              continue;
+            }
+            if (entry.kind === "classification") {
+              if (typeof editModule.inspectRepository !== "function") {
+                failures.push(entry.name + ": missing repository inspector");
+                continue;
+              }
+              const calls: string[][] = [];
+              const jjCwds: string[] = [];
+              const capabilities = fakeCapabilities(entry.scenario, calls, jjCwds);
+              const target = entry.target ?? "/repo/file.ts";
+              const state = await editModule.inspectRepository(target, entry.inspectionDirectory ?? "/repo", capabilities);
+              check(
+                entry.name,
+                state.kind,
+                entry.expected,
+                state.kind === "invalid" ? state.diagnostic : "",
+                entry.reason,
+              );
+              continue;
+            }
             if (entry.kind === "adapter") {
               if (entry.scenario === "registration") {
                 const registrations: Array<{ event: string; handler: unknown }> = [];
@@ -1934,7 +2118,8 @@
                 continue;
               }
               const calls: string[][] = [];
-              const capabilities = fakeCapabilities(entry.scenario, calls, []);
+              const notifications: string[] = [];
+              const capabilities = fakeCapabilities(entry.scenario, calls, [], [], [], notifications);
               if (entry.scenario === "capability-missing") {
                 delete (capabilities as { filesystem?: unknown }).filesystem;
               }
@@ -1947,12 +2132,16 @@
               const handler = editModule.createEditWriteToolCallHandler(capabilityFactory, options);
               const context = {
                 cwd: "/repo",
-                hasUI: entry.scenario !== "outside-headless",
-                ui: { confirm: async () => true },
+                ui: { notify: (message: string) => notifications.push(message) },
               };
               const result = await handler({ toolName: entry.tool, toolCallId: "call-1", input: entry.input }, context);
               const actual = result?.block === true ? "block" : "pass";
               check(entry.name, actual, entry.expected, result?.reason ?? "", entry.reason);
+              if (entry.expectedNotification !== undefined) {
+                if (!notifications.some((message: string) => message.includes(entry.expectedNotification))) {
+                  failures.push(entry.name + ": expected an announcement containing " + JSON.stringify(entry.expectedNotification) + ", got " + JSON.stringify(notifications));
+                }
+              }
               continue;
             }
             failures.push(entry.name + ": unrecognized policy case kind " + JSON.stringify(entry.kind));

--- a/modules/home/ai/agent-settings.nix
+++ b/modules/home/ai/agent-settings.nix
@@ -109,6 +109,54 @@
             excluded extension later leaves `packages`.
           '';
         };
+
+        piOnlyExtensions = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "edit-write-policy.ts" ];
+          description = ''
+            Files in pi's own `extensions/` directory that only pi may load, named
+            relative to that directory.
+
+            These never appear in `packages`; modules/home/ai/pi/default.nix writes
+            them straight into `~/.pi/agent/extensions/`, and atomic picks them up
+            anyway. `getAgentDirs` (packages/coding-agent/src/config.ts:376) returns
+            `[~/.atomic/agent, ~/.pi/agent]` with no filesystem test -- the only
+            escapes are the ATOMIC_CODING_AGENT_DIR environment variable and atomic
+            being named pi -- and `addAutoDiscoveredResources`
+            (core/package-manager-auto-resources.ts:188) scans both roots' extension
+            directories additively. So a populated `~/.atomic/agent` does not
+            suppress the pi root, and every `.ts` file placed there runs under both
+            agents whether or not either settings file mentions it. This option is
+            the only surface on which pi-only scope can be stated.
+
+            edit-write-policy.ts reads a top-level `path` off the tool input, which
+            is pi's `edit` and `write` schema. atomic's `write` also has `path`, but
+            its `edit` takes a single hashline `input` string under
+            `additionalProperties: false`, so a `path` can never reach the policy
+            from atomic and every atomic edit was refused as malformed input.
+          '';
+        };
+
+        extensionsForAtomic = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = map (extension: "-extensions/${extension}") config.aiAgentSettings.piOnlyExtensions;
+          description = ''
+            atomic's top-level `extensions` settings key, carrying `piOnlyExtensions`
+            as `-`-prefixed force-excludes.
+
+            This is a different override channel from `packagesForAtomic`, and the
+            two are not interchangeable. A pattern in a `packages` entry is matched
+            against the package source directory, while this key is matched against
+            each scanned config root
+            (core/package-manager-auto-resources.ts:199 passes `configDir` as the
+            base), so an entry here is written relative to `~/.pi/agent` and needs
+            its `extensions/` segment. The `-` arm compares only that relative path
+            or the absolute path and never the basename
+            (core/package-manager-resource-patterns.ts matchesAnyExactPattern), so
+            the bare `-edit-write-policy.ts` spelling is a silent no-op that loads
+            the extension anyway.
+          '';
+        };
       };
     };
 }

--- a/modules/home/ai/atomic/default.nix
+++ b/modules/home/ai/atomic/default.nix
@@ -21,6 +21,13 @@
 # packagesForAtomic, which carries the extension exclusions that agent-settings
 # declares for it. The key is still written rather than dropped, because
 # merge-settings.sh can update a nix-owned key but not retract one.
+#
+# extensions is atomic's alone. It carries the force-excludes that keep pi-only
+# extensions out of atomic, which is not a redundancy with packagesForAtomic:
+# atomic inherits ~/.pi/agent as a config root unconditionally, so a file pi
+# writes into its own extensions/ directory is loaded by atomic without either
+# settings file naming it, and only this key can refuse it. See
+# aiAgentSettings.piOnlyExtensions for the mechanism.
 { ... }:
 {
   flake.modules.homeManager.ai =
@@ -65,6 +72,7 @@
           settings = {
             inherit (config.aiAgentSettings) theme enableInstallTelemetry;
             packages = config.aiAgentSettings.packagesForAtomic;
+            extensions = config.aiAgentSettings.extensionsForAtomic;
           };
         };
 

--- a/modules/home/ai/pi/policy/edit-write-policy.ts
+++ b/modules/home/ai/pi/policy/edit-write-policy.ts
@@ -1,26 +1,27 @@
 import { execFile } from "node:child_process";
 import { realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export const policyPresent = true;
 
 export type EditWriteOperation = "edit" | "write";
 
+// Decisions are classified by recoverability rather than severity: a mutation
+// version control can undo is announced and allowed, and only a mutation
+// nothing would bring back is refused. "notify" exists because Pi has no
+// permission system, so a confirmation dialog on an autonomous session can
+// have nobody to answer it and becomes an indefinite stall; announcing costs
+// no turn and cannot deadlock.
 export type PolicyDecision =
   | { readonly decision: "allow" }
-  | { readonly decision: "prompt"; readonly reason: string }
+  | { readonly decision: "notify"; readonly reason: string }
   | { readonly decision: "block"; readonly reason: string };
 
-export interface MutableTarget {
-  readonly kind: "mutable";
+export interface EditWriteTarget {
   readonly canonicalPath: string;
-}
-
-export interface ImmutableTarget {
-  readonly kind: "immutable";
-  readonly canonicalPath: string;
-  readonly root: string;
 }
 
 export interface JjCurrentState {
@@ -65,16 +66,11 @@ export type RepositoryState =
     } & JjCommonState)
   | { readonly kind: "invalid"; readonly diagnostic: string };
 
-export type EditWriteInput =
-  | {
-      readonly operation: EditWriteOperation;
-      readonly target: ImmutableTarget;
-    }
-  | {
-      readonly operation: EditWriteOperation;
-      readonly target: MutableTarget;
-      readonly repository: RepositoryState;
-    };
+export interface EditWriteInput {
+  readonly operation: EditWriteOperation;
+  readonly target: EditWriteTarget;
+  readonly repository: RepositoryState;
+}
 
 export interface ProcessResult {
   readonly stdout: string;
@@ -89,9 +85,9 @@ export type GitRootResult =
 
 export interface PolicyCapabilities {
   readonly filesystem: {
+    homeDirectory(): string;
     canonicalize(target: string, cwd: string): Promise<string>;
     inspectionDirectory(target: string): Promise<string>;
-    immutableRoots(): Promise<readonly string[]>;
   };
   readonly git: {
     root(directory: string): Promise<GitRootResult>;
@@ -100,9 +96,12 @@ export interface PolicyCapabilities {
   readonly jj: {
     run(argv: readonly string[], cwd: string): Promise<ProcessResult>;
   };
-  readonly interaction: {
-    readonly available: boolean;
-    confirm(message: string): Promise<boolean>;
+  readonly notification: {
+    // Pi's ui.notify is a no-op whenever the host has no dialog-capable UI
+    // (core/extensions/runner.ts noOpUIContext), so a print-mode session
+    // announces nothing. That is the accepted cost of never stalling: notify
+    // is fire-and-forget in every mode and can therefore never deadlock.
+    notify(message: string): void;
   };
 }
 
@@ -113,9 +112,8 @@ export interface ToolCallEvent {
 
 export interface ToolCallContext {
   readonly cwd: string;
-  readonly hasUI: boolean;
   readonly ui: {
-    confirm(title: string, message: string): Promise<boolean>;
+    notify(message: string, type?: "info" | "warning" | "error"): void;
   };
 }
 
@@ -179,6 +177,7 @@ export const JJ_READ_ARGV = {
 } as const;
 
 const block = (reason: string): PolicyDecision => ({ decision: "block", reason });
+const notify = (reason: string): PolicyDecision => ({ decision: "notify", reason });
 const allow = (): PolicyDecision => ({ decision: "allow" });
 
 const containsPath = (root: string, target: string): boolean => {
@@ -192,14 +191,17 @@ const unreachable = (state: never): never => {
   throw new Error(`unhandled repository state: ${JSON.stringify(state)}`);
 };
 
+// Containment is the one jj condition that stays refusing: it means the probe
+// resolved a repository the target does not live in, so version control is not
+// covering the file about to change.
 const validateJjCommon = (state: JjCommonState, target: string): PolicyDecision | undefined => {
   if (!containsPath(state.root, target)) {
     return block("jj repository identity does not contain the canonical target");
   }
-  if (state.at.conflicted) return block("jj current change is conflicted");
-  if (state.at.divergent) return block("jj current change identity is divergent");
+  if (state.at.conflicted) return notify("jj current change is conflicted");
+  if (state.at.divergent) return notify("jj current change identity is divergent");
   if (state.defaultBookmarksAtCurrent.length > 0) {
-    return block(
+    return notify(
       `jj current change carries protected bookmark ${state.defaultBookmarksAtCurrent.join(", ")}`,
     );
   }
@@ -207,26 +209,22 @@ const validateJjCommon = (state: JjCommonState, target: string): PolicyDecision 
 };
 
 export function decideEditWrite(input: EditWriteInput): PolicyDecision {
-  if (!("repository" in input)) {
-    return block(
-      `Target ${input.target.canonicalPath} is contained by immutable root ${input.target.root}`,
-    );
-  }
-
   const repository = input.repository;
   const target = input.target.canonicalPath;
   switch (repository.kind) {
     case "outside-repository":
-      return {
-        decision: "prompt",
-        reason: `${input.operation} targets a mutable path outside a recognized repository`,
-      };
+      // No repository holds this path, so no history would return it. This is
+      // the same hazard the containment refusals cover, reached by a different
+      // route.
+      return block(
+        `${input.operation} targets a path outside a recognized repository, where version control cannot recover it`,
+      );
     case "git":
       if (!containsPath(repository.root, target)) {
         return block("Git repository identity does not contain the canonical target");
       }
       if (repository.head.kind === "protected") {
-        return block(`Mutation on protected Git branch ${repository.head.branch} is blocked`);
+        return notify(`Mutation on protected Git branch ${repository.head.branch}`);
       }
       return allow();
     case "jj-ordinary": {
@@ -237,22 +235,29 @@ export function decideEditWrite(input: EditWriteInput): PolicyDecision {
       const unhealthy = validateJjCommon(repository, target);
       if (unhealthy !== undefined) return unhealthy;
       if (repository.wip.kind !== "healthy") {
-        return block(`diamond wip bookmark is ${repository.wip.kind}`);
+        return notify(`diamond wip bookmark is ${repository.wip.kind}`);
       }
       if (repository.at.parentCount !== 1) {
-        return block("diamond wip does not have exactly one parent");
+        return notify("diamond wip does not have exactly one parent");
       }
-      if (repository.join.conflicted) return block("diamond join is conflicted");
+      if (repository.join.conflicted) return notify("diamond join is conflicted");
       if (repository.join.parentCount < 2) {
-        return block("diamond join has fewer than two parents");
+        return notify("diamond join has fewer than two parents");
       }
       if (repository.join.parentsConflicted) {
-        return block("diamond join has a conflicted immediate parent");
+        return notify("diamond join has a conflicted immediate parent");
       }
       return allow();
     }
     case "invalid":
-      return block(`Repository inspection failed: ${repository.diagnostic}`);
+      // Fail open. A probe this policy could not parse says nothing about
+      // whether the mutation is safe, and the two defects that made this arm
+      // fire in practice -- a jj release adding a Hint line, an agent whose
+      // edit tool carries no path field -- were both environmental. Refusing
+      // on them cost every edit in the affected repositories and prevented no
+      // unsafe write. The classification still carries its diagnostic so the
+      // probe parsers stay observable to the policy check.
+      return allow();
     default:
       return unreachable(repository);
   }
@@ -398,7 +403,21 @@ const invalid = (diagnostic: string): RepositoryState => ({
   diagnostic,
 });
 
-const JJ_OUTSIDE_REPOSITORY_DIAGNOSTIC = /^Error: There is no jj repo in "[^"\r\n]+"\n$/;
+// Both diagnostics match a prefix rather than the whole of stderr, because both
+// tools append advice after the error line. jj 0.43.0 emits, whenever the probed
+// directory holds a `.git` directory:
+//
+//   Error: There is no jj repo in "."
+//   Hint: It looks like this is a git repo. You can create a jj repo backed by it by running this:
+//   jj git init
+//
+// which is precisely the case that has to fall through to the Git branch below.
+// Anchoring the match at the end of stderr made that fall-through unreachable at
+// the root of every ordinary Git repository, so the Git arm of decideEditWrite
+// was dead code exactly where it was meant to apply. The exit-code and
+// empty-stdout conjuncts are kept: they are what distinguishes this diagnostic
+// from a probe that failed some other way.
+const JJ_OUTSIDE_REPOSITORY_DIAGNOSTIC = /^Error: There is no jj repo in "[^"\r\n]+"\n/;
 const GIT_OUTSIDE_REPOSITORY_DIAGNOSTIC =
   "fatal: not a git repository (or any of the parent directories): .git\n";
 
@@ -417,7 +436,7 @@ export const parseGitRootResult = (result: ProcessResult): GitRootResult => {
   if (
     result.code === 128 &&
     result.stdout.length === 0 &&
-    result.stderr === GIT_OUTSIDE_REPOSITORY_DIAGNOSTIC
+    result.stderr.startsWith(GIT_OUTSIDE_REPOSITORY_DIAGNOSTIC)
   ) {
     return { kind: "outside" };
   }
@@ -630,6 +649,9 @@ export async function inspectRepository(
   return { kind: "outside-repository" };
 }
 
+export const MALFORMED_TOOL_INPUT_REASON =
+  "malformed edit/write tool input: path must be a nonempty string";
+
 export async function evaluateEditWrite(
   operation: EditWriteOperation,
   target: string,
@@ -639,47 +661,61 @@ export async function evaluateEditWrite(
 ): Promise<PolicyDecision> {
   let input: EditWriteInput;
   try {
-    const canonicalPath = await capabilities.filesystem.canonicalize(target, cwd);
-    const immutableRoots = await capabilities.filesystem.immutableRoots();
-    let immutableTarget: ImmutableTarget | undefined;
-    for (const declaredRoot of immutableRoots) {
-      const root = await capabilities.filesystem.canonicalize(declaredRoot, cwd);
-      if (containsPath(root, canonicalPath)) {
-        immutableTarget = { kind: "immutable", canonicalPath, root };
-        break;
-      }
-    }
-    if (immutableTarget !== undefined) {
-      input = { operation, target: immutableTarget };
-    } else {
-      const mutableTarget: MutableTarget = { kind: "mutable", canonicalPath };
-      const inspectionDirectory = await capabilities.filesystem.inspectionDirectory(canonicalPath);
-      const repository = await inspectRepository(canonicalPath, inspectionDirectory, capabilities);
-      input = { operation, target: mutableTarget, repository };
-    }
+    const normalized = normalizeToolPath(target, capabilities.filesystem.homeDirectory());
+    if (normalized === undefined) return block(MALFORMED_TOOL_INPUT_REASON);
+    const canonicalPath = await capabilities.filesystem.canonicalize(normalized, cwd);
+    const inspectionDirectory = await capabilities.filesystem.inspectionDirectory(canonicalPath);
+    const repository = await inspectRepository(canonicalPath, inspectionDirectory, capabilities);
+    input = { operation, target: { canonicalPath }, repository };
   } catch (error) {
-    return block(`policy capability failed: ${String(error)}`);
+    // Fail open, as for an unparseable probe: a capability that threw has not
+    // established that the mutation is unsafe.
+    void error;
+    return allow();
   }
 
   let decision: PolicyDecision;
   try {
     decision = decide(input);
   } catch (error) {
-    return block(`policy evaluation failed: ${String(error)}`);
+    void error;
+    return allow();
   }
 
-  if (decision.decision !== "prompt") return decision;
-  if (!capabilities.interaction.available) {
-    return block("interaction unavailable for required mutation confirmation");
-  }
+  if (decision.decision !== "notify") return decision;
   try {
-    return (await capabilities.interaction.confirm(decision.reason))
-      ? allow()
-      : block("mutation rejected by user");
+    capabilities.notification.notify(`${operation}: ${decision.reason}`);
   } catch (error) {
-    return block(`interaction capability failed: ${String(error)}`);
+    // A host that cannot display the announcement must not turn a permitted
+    // mutation into a refused one.
+    void error;
   }
+  return decision;
 }
+
+// Mirrors Pi's resolveToCwd normalization (core/tools/path-utils.ts calling
+// utils/paths.ts normalizePath with normalizeUnicodeSpaces and stripAtPrefix,
+// expandTilde defaulting on) in the same order Pi applies it. The policy has to
+// canonicalize the string Pi will actually open: resolving "~/secret" as a
+// cwd-relative path put it inside the repository and permitted a write that
+// really landed in the home directory. The Windows shell-path arm of Pi's
+// normalizePath is omitted; this policy is deployed only to darwin and linux.
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+
+export const normalizeToolPath = (target: string, homeDirectory: string): string | undefined => {
+  let normalized = target.replace(UNICODE_SPACES, " ");
+  if (normalized.startsWith("@")) normalized = normalized.slice(1);
+  if (normalized === "~") return homeDirectory;
+  if (normalized.startsWith("~/")) return join(homeDirectory, normalized.slice(2));
+  if (/^file:\/\//.test(normalized)) {
+    try {
+      return fileURLToPath(normalized);
+    } catch {
+      return undefined;
+    }
+  }
+  return normalized.trim().length > 0 ? normalized : undefined;
+};
 
 const canonicalizePath = async (target: string, cwd: string): Promise<string> => {
   const absolute = resolve(cwd, target);
@@ -733,9 +769,9 @@ const defaultGitHead = (root: string): Promise<ProcessResult> =>
 
 export const createNodePolicyCapabilities: CapabilityFactory = (context) => ({
   filesystem: {
+    homeDirectory: homedir,
     canonicalize: canonicalizePath,
     inspectionDirectory: deepestExistingDirectory,
-    immutableRoots: async () => ["/nix/store"],
   },
   git: {
     root: defaultGitRoot,
@@ -744,27 +780,27 @@ export const createNodePolicyCapabilities: CapabilityFactory = (context) => ({
   jj: {
     run: runProcess,
   },
-  interaction: {
-    available: context.hasUI,
-    confirm: (message) => context.ui.confirm("Confirm file mutation", message),
+  notification: {
+    notify: (message) => context.ui.notify(message, "warning"),
   },
 });
 
+// Extraction only; normalizeToolPath owns every rewrite of the string, so that
+// the value this policy canonicalizes and the value the tool opens are produced
+// by one implementation. The predicate rejects a whitespace-only path here
+// rather than letting resolve() map it to a directory under cwd.
+//
+// This shape is Pi's: both `edit` and `write` declare a required top-level
+// `path` string. It is deliberately not atomic's -- atomic's `edit` takes a
+// single hashline `input` string with `additionalProperties: false`, so no
+// `path` can ever reach this function from that agent. That is why
+// modules/home/ai/agent-settings.nix keeps this extension out of atomic rather
+// than teaching the adapter a second tool grammar.
 const parseToolInput = (input: unknown): string | undefined => {
   if (input === null || typeof input !== "object") return undefined;
   const path = (input as { readonly path?: unknown }).path;
   if (typeof path !== "string") return undefined;
-  // Pi's file-mention syntax hands the tool an @-prefixed path. Stripping the
-  // prefix before resolution keeps "@/nix/store/..." absolute, so it reaches the
-  // immutable-root check instead of resolving relative to cwd. Covered by the
-  // "adapter normalizes Pi at-prefixed paths" case in
-  // modules/checks/pi-agent-environment.nix.
-  const normalized = path.startsWith("@") ? path.slice(1) : path;
-  // The trim is a rejection predicate only. Returning normalized.trim() would
-  // canonicalize a different string than the tool mutates, and relaxing the
-  // predicate to normalized.length > 0 would admit "   ", which resolve() maps
-  // to a directory under cwd instead of being blocked as malformed input.
-  return normalized.trim().length > 0 ? normalized : undefined;
+  return path.trim().length > 0 ? path : undefined;
 };
 
 export function createEditWriteToolCallHandler(
@@ -774,12 +810,11 @@ export function createEditWriteToolCallHandler(
   return async (event, context) => {
     if (event.toolName !== "edit" && event.toolName !== "write") return undefined;
     const target = parseToolInput(event.input);
-    if (target === undefined) {
-      return {
-        block: true,
-        reason: "malformed edit/write tool input: path must be a nonempty string",
-      };
-    }
+    // The one refusal that survives an unreadable request rather than an
+    // unrecoverable target: a tool call whose path this policy cannot read is a
+    // call it cannot reason about at all, and letting it through would mean
+    // permitting an unexamined mutation rather than an examined one.
+    if (target === undefined) return { block: true, reason: MALFORMED_TOOL_INPUT_REASON };
 
     try {
       const decision = await evaluateEditWrite(
@@ -791,10 +826,10 @@ export function createEditWriteToolCallHandler(
       );
       return decision.decision === "block" ? { block: true, reason: decision.reason } : undefined;
     } catch (error) {
-      return {
-        block: true,
-        reason: `edit/write policy adapter failed: ${String(error)}`,
-      };
+      // Fail open on an adapter fault for the same reason the decision core
+      // does: a thrown capability has established nothing about the mutation.
+      void error;
+      return undefined;
     }
   };
 }

--- a/openspec/specs/pi-agent-environment/spec.md
+++ b/openspec/specs/pi-agent-environment/spec.md
@@ -125,32 +125,47 @@ Nix-owned permission-gate rules MUST classify dangerous commands, semantic mutat
 
 ### Requirement: Non-Bash edit and write policy
 
-A compact first-party pure decision core with a thin Pi adapter MUST evaluate non-Bash `edit` and `write` tool calls and block targets beneath `/nix/store` or another declared immutable resource root.
+A compact first-party pure decision core with a thin Pi adapter MUST evaluate non-Bash `edit` and `write` tool calls and classify each outcome as allow, notify-and-allow, or block.
+It MUST refuse only a mutation version control could not recover, and MUST announce rather than refuse every condition whose target is inside a repository.
 The exported adapter factory or handler seam MUST be directly executable as policy evidence.
 The extension is scoped to Pi, and the system MUST declare that scope to atomic rather than relying on either agent's default discovery, because atomic inherits Pi's configuration root and loads Pi's extension directory unconditionally.
+The policy MUST normalize a tool path exactly as Pi resolves it, covering the `@` prefix, a leading `~`, a `file://` URL, and Unicode space variants, so the path the policy judges is the path the tool opens.
 
 #### Scenario: Non-Bash mutation reaches policy
 
-- **WHEN** the policy harness runs pure-core rows and directly invokes the exported adapter seam with synthetic edit/write allow and block calls, an unrelated tool, malformed tool input, and core or capability exceptions
-- **THEN** the core returns the literal decisions, the adapter translates allow and block correctly, passes unrelated tools through, and converts malformed input or exceptions into diagnostic blocks without starting a Pi process per row
+- **WHEN** the policy harness runs pure-core rows and directly invokes the exported adapter seam with synthetic edit/write allow, notify, and block calls, an unrelated tool, malformed tool input, atomic's headerless `edit` input shape, and core or capability exceptions
+- **THEN** the core returns the literal decisions, the adapter translates block and passes allow and notify through, passes unrelated tools through, converts malformed input into a diagnostic block, converts exceptions into permission, and starts no Pi process per row
 
 #### Scenario: Pi-only scope is declared to atomic
 
 - **WHEN** the generated atomic settings are inspected
 - **THEN** every Pi-only extension is named as a force-exclude relative to the inherited Pi configuration root, in the spelling atomic matches against that root
 
+#### Scenario: Tool path is normalized as Pi resolves it
+
+- **WHEN** the policy normalizes `@`-prefixed, `~`-prefixed, `file://`, Unicode-space, and ordinary relative paths
+- **THEN** each result equals the path Pi's own resolution produces, and a path that normalizes to nothing is rejected as malformed
+
 ### Requirement: Git default-branch boundary
 
-The first-party policy extension MUST block non-Bash edits and writes while the target Git repository is on `main` or `master`.
+The first-party policy extension MUST announce, and allow, a non-Bash edit or write while the target Git repository is on `main` or `master`.
+It MUST block a target the identified Git repository does not contain.
+The Git branch of repository inspection MUST remain reachable when the jj probe reports an outside-repository diagnostic followed by additional advisory lines.
 
 #### Scenario: Edit is proposed on a Git branch
 
 - **WHEN** injected repository capabilities report a feature branch, `main`, or `master`
-- **THEN** feature-branch mutation is eligible to continue and default-branch mutation is blocked
+- **THEN** feature-branch mutation is eligible to continue, default-branch mutation is announced and eligible to continue, and a target outside the repository is blocked
+
+#### Scenario: Jj reports outside a repository with trailing advice
+
+- **WHEN** the jj root probe exits non-zero with the outside-repository diagnostic followed by the trailing `Hint:` lines jujutsu emits inside a Git repository
+- **THEN** inspection falls through to the Git branch rather than treating the probe as indeterminate
 
 ### Requirement: Jj diamond boundary
 
 The first-party policy extension MUST consume typed, discriminated repository state and admit both healthy ordinary and healthy diamond-managed jj repositories before non-Bash edits and writes.
+Every unhealthy jj condition other than target containment MUST be announced and allowed rather than refused, because its target is inside a repository whose history can recover it.
 Common jj health MUST require canonical repository identity and target containment; unambiguous, conflict-free `@`; a non-divergent current `@` change identity; neither `main` nor `master` pointing directly to `@`; and successful, unambiguous parsing of every read-only probe, each invoked with `jj --ignore-working-copy`.
 A separate bookmark-listing classification probe MUST report the `wip` convention, including a divergent `wip` indicator, before the repository is classified as diamond-managed.
 Only a repository already classified as diamond-managed MUST run the unique `wip`-resolution probe and admit absent, moved, or divergent `wip` failure outcomes.
@@ -163,16 +178,24 @@ Ordinary jj health MUST impose no `wip`, diamond-topology, emptiness, or working
 #### Scenario: Edit is proposed in a jj repository
 
 - **WHEN** the literal policy table evaluates ordinary healthy states, including a nonempty `@`, with no `wip` report; ordinary conflict, divergence, and protected-bookmark states; an actual healthy empty `@` `[wip]` over an empty six-parent `@-` join; healthy nonempty `[wip]` and conflict-resolved nonempty join states; classified-diamond absent, moved, or divergent unique-`wip` resolution; non-single-parent `[wip]`; single-parent or conflicted join; conflicted immediate join parent; join-parent count mismatch; and malformed or failing join probes
-- **THEN** the ordinary healthy rows and all three healthy diamond rows are eligible to continue, the ordinary no-`wip` rows never reach missing-`wip` failure, every unhealthy or indeterminate row blocks diagnostically, and every recorded read-only jj argv exactly matches the ordered `jj --ignore-working-copy` argv oracle
+- **THEN** the ordinary healthy rows and all three healthy diamond rows are eligible to continue, the ordinary no-`wip` rows never reach missing-`wip` failure, every unhealthy row is announced diagnostically and eligible to continue, every indeterminate row is eligible to continue while still classifying its diagnostic, a target the repository does not contain blocks, and every recorded read-only jj argv exactly matches the ordered `jj --ignore-working-copy` argv oracle
 
-### Requirement: Fail-closed policy
+### Requirement: Fail-open policy
 
-Parser errors, core or adapter exceptions, ambiguous repository state, missing or throwing capabilities, malformed tool input, and prompt-class decisions without usable interaction MUST block the affected tool call with a diagnostic reason.
+Parser errors, core or adapter exceptions, ambiguous repository state, and missing or throwing capabilities MUST permit the affected tool call rather than refuse it.
+None of these establishes that a mutation is unsafe, and refusing on them has cost every edit and write in an affected repository while preventing no unsafe mutation.
+Malformed tool input remains the one refusal drawn from an unreadable request rather than an unrecoverable target.
+The policy MUST NOT require an interactive answer to permit a mutation, because Pi has no permission system and an unanswerable dialog on an autonomous session stalls it indefinitely.
 
 #### Scenario: Policy cannot decide safely
 
-- **WHEN** the policy harness injects each parser, decision, adapter, repository, capability, malformed-input, or headless failure
-- **THEN** the result is a named diagnostic block rather than permission or an uncaught exception
+- **WHEN** the policy harness injects each parser, decision, adapter, repository, or capability failure
+- **THEN** the result is permission rather than a block or an uncaught exception, and the repository classification still reports its diagnostic
+
+#### Scenario: Announcement channel is unavailable
+
+- **WHEN** the notification capability is absent or throws on a notify-class decision
+- **THEN** the mutation remains permitted rather than becoming refused
 
 ### Requirement: Secret-safe direnv
 

--- a/openspec/specs/pi-agent-environment/spec.md
+++ b/openspec/specs/pi-agent-environment/spec.md
@@ -127,11 +127,17 @@ Nix-owned permission-gate rules MUST classify dangerous commands, semantic mutat
 
 A compact first-party pure decision core with a thin Pi adapter MUST evaluate non-Bash `edit` and `write` tool calls and block targets beneath `/nix/store` or another declared immutable resource root.
 The exported adapter factory or handler seam MUST be directly executable as policy evidence.
+The extension is scoped to Pi, and the system MUST declare that scope to atomic rather than relying on either agent's default discovery, because atomic inherits Pi's configuration root and loads Pi's extension directory unconditionally.
 
 #### Scenario: Non-Bash mutation reaches policy
 
 - **WHEN** the policy harness runs pure-core rows and directly invokes the exported adapter seam with synthetic edit/write allow and block calls, an unrelated tool, malformed tool input, and core or capability exceptions
 - **THEN** the core returns the literal decisions, the adapter translates allow and block correctly, passes unrelated tools through, and converts malformed input or exceptions into diagnostic blocks without starting a Pi process per row
+
+#### Scenario: Pi-only scope is declared to atomic
+
+- **WHEN** the generated atomic settings are inspected
+- **THEN** every Pi-only extension is named as a force-exclude relative to the inherited Pi configuration root, in the spelling atomic matches against that root
 
 ### Requirement: Git default-branch boundary
 


### PR DESCRIPTION
## Root cause

`modules/home/ai/pi/default.nix` writes `edit-write-policy.ts` into `~/.pi/agent/extensions/`, for pi. atomic loaded it too: `getAgentDirs` (`config.ts:376` at `0.9.13`) returns `[~/.atomic/agent, ~/.pi/agent]` with no filesystem test, and `addAutoDiscoveredResources` (`core/package-manager-auto-resources.ts:188`) scans both roots' extension directories additively. A populated `~/.atomic/agent` does not suppress the pi root, so every `.ts` file placed there runs under both agents whether or not either settings file names it.

Under atomic that produced two failures, both reproduced from the session transcript:

- **Every `edit`.** atomic's `edit` schema is `{ input: string }` with `additionalProperties: false`; there is no `path` field, and a model that emitted one would be rejected by argument validation before the hook runs. The policy reads a top-level `path`, so every atomic edit was refused as malformed input without the decision core ever running.
- **Writes at a git repository root.** jujutsu 0.43.0 appends `Hint:` lines to the outside-repository diagnostic whenever the probed directory holds a `.git` directory. The policy anchored that diagnostic at the end of stderr, so the characterization failed and inspection returned indeterminate — which the old policy refused. That is exactly the case that must fall through to the Git branch, so the entire `case "git"` arm, including the protected-branch check, was unreachable at the root of every ordinary Git repository.

Neither was visible to the oracle: every repository and adapter case is driven by injected fake capabilities, no real `jj` or `git` process ever touches the policy, and the adapter rows feed pi's schema. A case at `:1651` did construct a trailing `Hint:` line — and asserted that it should block, which `Fail-closed policy` in the spec required.

## Reclassified arms, and the principle

Decisions are now classified by **recoverability, not severity**: block only what cannot be undone, announce everything else.

| Arm | Was | Now |
|---|---|---|
| Protected git branch `main`/`master` | block | **notify-and-allow** |
| Protected jj bookmark at `@` | block | **notify-and-allow** |
| Conflicted or divergent `@` | block | **notify-and-allow** |
| Diamond topology (wip health, `@` parents, join conflicted/parents) | block | **notify-and-allow** |
| Git or jj root does not contain the target | block | block (unchanged) |
| Target in no repository at all | prompt | **block** |
| Any indeterminate probe, capability or core exception | block | **allow** |
| Malformed tool input | block | block (unchanged) |
| Target under `/nix/store` | block | **removed** |

Announcement rather than confirmation is deliberate: pi has no permission system, so a dialog on an autonomous session can have nobody to answer it — the stall pattern removed from the Claude Code `git push` and `nix run` gates. `notify` is fire-and-forget in every mode and cannot deadlock.

Two entries deserve calling out because they are judgement calls rather than transcriptions:

- **Target in no repository at all** was `prompt`, and `prompt` no longer exists. It falls in the "not protected by version control" class alongside containment, so it blocks. On an autonomous session this is not a regression — the old code already blocked it, via `interaction unavailable for required mutation confirmation`. On an interactive session it is stricter than before. Easy to flip if that reads wrong.
- **`/nix/store`** is `drwxrwxr-t root nixbld`; `touch /nix/store/probe` returns `Permission denied`. The check restated a filesystem permission rather than adding containment.

## Notification channel, and what it costs

`ctx.ui.notify(message, "warning")` on pi's `ExtensionUIContext`. In the TUI it reaches `showWarning`, which appends to `chatContainer` — persistent in the scrollback, not a transient toast. Under RPC it emits a `notify` protocol frame. It is a **no-op when the host has no dialog-capable UI** (`noOpUIContext.notify` in `core/extensions/runner.ts`), so a print-mode run announces nothing.

That hole is the accepted cost of never stalling, and it is reported rather than papered over. `ntfy`, which the `gate-dangerous-commands` NOTICE path uses, would close it, but it means a network side effect inside a synchronous tool-call gate and a new runtime dependency — a design decision beyond this change's scope. Flagging it rather than deciding it.

The check asserts delivery: a notify row that announces nothing fails, because a notify decision that discards its signal is a bare allow, which is a different decision from the one the policy declares.

## atomic deliberately retains no path-based edit/write gate

After this change atomic has no path-based edit or write policy at all. What remains for atomic is `permission-gate`'s argv classification (registered for both agents) and filesystem permissions. Nothing stops atomic editing on `main`, or in a repository whose jj join is broken.

This is deliberate, not an oversight. The alternative is teaching the adapter atomic's hashline grammar — and one `edit` call can carry several `[PATH#TAG]` sections (`grammar.lark:1` `file_patch+`; `assertUniquePreparedPaths` rejects only *duplicate* paths), so a first-header check would authorize a call that also mutates every other named file unchecked. `extractFirstHeaderPath` in atomic's own `edit.ts` is a TUI title-line renderer, not an authorization primitive. Doing it correctly means maintaining a second implementation of another project's parser inside a security check, and the evidence did not justify it: the policy's whole recorded history is fourteen refusals and zero true positives, and in the motivating session the model routed around a refusal with a `bash` heredoc and `sed -i` within one turn and completed the mutation anyway.

The `adapter cannot read atomic hashline edit input` case is kept as a forward guard, so that teaching the adapter a second tool grammar has to be a deliberate decision rather than a quiet one.

## Verification

```
nix build --no-link '.#checks.aarch64-darwin.pi-agent-environment-policy'      # 237 cases pass (was 214)
nix build --no-link '.#checks.aarch64-darwin.pi-agent-environment-structural'  # pass
```

**Severity.** New and reclassified assertions were replayed against the pre-change policy (`ce9c7800`); **8 of 9 discriminate**:

```
SEVERE  jj Hint falls through to the Git branch    before=block:Repository inspection failed  after=notify:protected Git branch main
SEVERE  protected branch announced, not refused    before=block|notified=0                   after=notify|notified=1
SEVERE  indeterminate probe permits                before=block                              after=allow
SEVERE  tilde resolves to home, not under cwd      before=block:...inspection failed          after=block:outside a recognized repository
SEVERE  file:// converted before resolution        before=(no export)                        after=/etc/hosts
SEVERE  unicode spaces folded                      before=(no export)                        after=a b.txt
SEVERE  throwing notification still permits        before=block                              after=pass
SEVERE  Git stderr with trailing advice accepted   before=invalid                            after=outside
INERT   atomic hashline edit refused as malformed  before=block                              after=block
```

The inert row is inert by construction and is reported as such rather than counted.

The structural assertion was checked the same way: replacing the force-exclude with the bare-basename spelling flips `everyDeclaredExcluded` and `noBareBasenameSpelling` to `false` and fails the check. That spelling is a silent no-op in atomic — the `-` arm compares only the root-relative or absolute path, never the basename — so the assertion pins the one detail most likely to be got wrong.

## Not done

The stale evidence anchors in `openspec/changes/archive/2026-08-15-configure-pi-agent-environment/verify.md` are left alone. They point at a 3406-line version of the check module that no longer exists, but that file records what was verified at the time; re-anchoring it to today's line numbers would make it claim a verification it never performed, and this change moves those lines again.

No `~/.atomic/` or `~/.pi/` state was touched, so atomic stays broken for editing until this lands.
