### PR TITLE
Route omp's memory to the hosted Hindsight service

### DIFF
--- a/modules/apps/hindsight-memory-validate.nix
+++ b/modules/apps/hindsight-memory-validate.nix
@@ -1,0 +1,52 @@
+# End-to-end validation flake-app for omp's Hindsight memory backend.
+#
+# Manually runnable proof that the token, the endpoint, and omp's own memory
+# lifecycle all work, against a throwaway bank and a throwaway $HOME that never
+# touch the real ~/.omp or the shared `omp` bank.
+#
+#   nix run .#hindsight-memory-validate                     # tier 0 only
+#   nix run .#hindsight-memory-validate -- --tier1          # tier 0 then tier 1
+#   nix run .#hindsight-memory-validate -- --tier1 --model anthropic/claude-sonnet-5
+#
+# Both tiers need HINDSIGHT_API_TOKEN in the environment. That token is not yet
+# in secrets.yaml, so this cannot run in CI and is not wired as a flake check;
+# it is the operator-run gate that closes out the wiring once the value lands.
+#
+# Mirrors the apm-marketplace-validate flake-app + co-located .sh sidecar
+# convention. Read-only with respect to the repo; all writes land in a scratch
+# tmpdir cleaned up on exit.
+{ ... }:
+{
+  perSystem =
+    {
+      inputs',
+      pkgs,
+      lib,
+      ...
+    }:
+    {
+      apps.hindsight-memory-validate = {
+        type = "app";
+        program = lib.getExe (
+          pkgs.writeShellApplication {
+            name = "hindsight-memory-validate";
+            runtimeInputs = [
+              pkgs.curl
+              pkgs.jq
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.cacert
+              # Tier 1 drives the same omp build the home configuration installs,
+              # so a pass here is a statement about the packaged agent rather than
+              # about whatever omp happens to be on the caller's PATH.
+              inputs'.llm-agents.packages.omp
+            ];
+            runtimeEnv = {
+              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+            };
+            text = builtins.readFile ./hindsight-memory-validate.sh;
+          }
+        );
+      };
+    };
+}

--- a/modules/apps/hindsight-memory-validate.sh
+++ b/modules/apps/hindsight-memory-validate.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# end-to-end validation for omp's hindsight memory backend.
+#
+# two tiers, because they fail for different reasons and a combined pass/fail
+# would not say which half is broken.
+#
+#   tier 0  the token, the endpoint, and the bank, over plain http with no llm
+#           in the loop. retains a codeword and recalls it. this is the tier
+#           that tells you whether the credential itself works.
+#
+#   tier 1  omp's own memory lifecycle, which tier 0 cannot reach: auto-retain
+#           on session end and auto-recall before the first model turn are
+#           native to the agent (src/hindsight/backend.ts) and are not
+#           expressible as http calls. one session states a fact, a second
+#           session is asked for it back. needs a provider key for --model.
+#
+# both tiers write to bank omp-validation, never to the shared `omp` bank the
+# home configuration targets, and tier 1 runs against a scratch $HOME so the
+# real ~/.omp is neither read nor written. the bank is deleted on exit unless
+# --keep-bank is given.
+#
+# the request shapes below are taken from the service's own openapi document
+# (hindsight-docs/static/openapi.json in the upstream monorepo, the same spec
+# the rust client is generated from) rather than from prose documentation, and
+# tier 0 has been run green against the live service.
+
+set -euo pipefail
+
+api_url="${HINDSIGHT_API_URL:-https://api.hindsight.vectorize.io}"
+bank="omp-validation"
+codeword="amber-falcon-42"
+model=""
+run_tier1=0
+keep_bank=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tier1) run_tier1=1 ;;
+    --model) shift; model="${1:-}" ;;
+    --bank) shift; bank="${1:-}" ;;
+    --keep-bank) keep_bank=1 ;;
+    -h|--help)
+      # writeShellApplication prepends its own shebang and a shellcheck
+      # directive, so drop those before echoing this header back.
+      grep '^#' "$0" \
+        | grep -v -e '^#!' -e '^# shellcheck' \
+        | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ -z "${HINDSIGHT_API_TOKEN:-}" ]; then
+  echo "error: HINDSIGHT_API_TOKEN is not set." >&2
+  echo "       mint one at ui.hindsight.vectorize.io -> Organization -> Connect -> Create API Key," >&2
+  echo "       then add it to secrets.yaml as hindsight-api-token and export it here." >&2
+  exit 1
+fi
+
+base="${api_url}/v1/default/banks/${bank}"
+scratch="$(mktemp -d)"
+
+cleanup() {
+  if [ "$keep_bank" -eq 0 ]; then
+    echo "--- cleanup: deleting bank ${bank}"
+    curl -fsS -X DELETE "$base" \
+      -H "Authorization: Bearer ${HINDSIGHT_API_TOKEN}" >/dev/null 2>&1 \
+      || echo "    warning: could not delete bank ${bank}; remove it via ui.hindsight.vectorize.io" >&2
+  else
+    echo "--- cleanup: leaving bank ${bank} in place (--keep-bank)"
+  fi
+  rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+api() {
+  local method=$1 path=$2
+  shift 2
+  curl -fsS -X "$method" "${base}${path}" \
+    -H "Authorization: Bearer ${HINDSIGHT_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+echo "=== tier 0: token, endpoint, bank ==="
+echo "--- creating bank ${bank} at ${api_url}"
+# CreateBankRequest has no required fields but the body itself is required;
+# omitting it is a 422, not a default-everything create.
+api PUT "" --data "$(jq -nc --arg n "$bank" '{name: $n}')" >/dev/null
+
+echo "--- retaining the codeword"
+api POST /memories --data "$(jq -nc \
+  --arg c "The validation codeword is ${codeword}." \
+  '{async: false, items: [{content: $c}]}')" >/dev/null
+
+# server-side extraction is asynchronous even with async:false on the request,
+# so a single immediate recall can legitimately come back empty. poll rather
+# than conclude failure on the first miss.
+echo "--- recalling (polling up to 60s for asynchronous extraction)"
+found=0
+for _ in $(seq 1 20); do
+  if api POST /memories/recall \
+      --data '{"query": "validation codeword"}' \
+      | grep -q "$codeword"; then
+    found=1
+    break
+  fi
+  sleep 3
+done
+
+if [ "$found" -ne 1 ]; then
+  echo "FAIL: tier 0 recall never returned ${codeword}" >&2
+  exit 1
+fi
+echo "PASS: tier 0 retained and recalled ${codeword}"
+
+if [ "$run_tier1" -eq 0 ]; then
+  echo
+  echo "tier 1 skipped; pass --tier1 --model <provider/model> to exercise omp itself."
+  exit 0
+fi
+
+if [ -z "$model" ]; then
+  echo "error: --tier1 needs --model <provider/model>, and a provider key in the environment." >&2
+  exit 2
+fi
+
+echo
+echo "=== tier 1: omp's own retain and recall lifecycle ==="
+
+# omp derives every configuration root from $HOME, so a scratch $HOME is
+# sufficient isolation from the real ~/.omp. bankId is set here and nowhere in
+# the home configuration, which deliberately leaves it unset so that production
+# sessions land in the base bank.
+export HOME="$scratch"
+mkdir -p "$scratch/.omp/agent"
+cat > "$scratch/.omp/agent/config.yml" <<YAML
+memory:
+  backend: hindsight
+hindsight:
+  apiUrl: ${api_url}
+  bankId: ${bank}
+YAML
+
+echo "--- smoke test"
+omp --smoke-test
+
+echo "--- session 1: state the fact"
+omp -p --model "$model" \
+  "Use the retain tool to remember this exact fact: the validation codeword is ${codeword}."
+
+echo "--- session 2: ask for it back"
+answer="$(omp -p --model "$model" "What is the validation codeword?")"
+echo "$answer"
+
+if printf '%s' "$answer" | grep -q "$codeword"; then
+  echo "PASS: tier 1 second session recalled ${codeword} from the first"
+else
+  echo "FAIL: tier 1 second session did not recall ${codeword}" >&2
+  exit 1
+fi

--- a/modules/checks/pi-agent-environment.nix
+++ b/modules/checks/pi-agent-environment.nix
@@ -2254,7 +2254,7 @@
             piModulePi083References = [ ];
             piReconnaissancePresent = true;
             piReconnaissancePi083References = [ ];
-            piPackageVersion = "0.84.1";
+            piPackageVersion = "0.84.2";
             deployedPiCandidateCount = 1;
             deployedPiIsOuterWrapper = true;
             canonicalSkillImmutable = true;

--- a/modules/home/ai/omp/default.nix
+++ b/modules/home/ai/omp/default.nix
@@ -133,6 +133,27 @@
               tiny = lib.mkDefault "openai-codex/gpt-5.6-luna:medium";
               task = lib.mkDefault "anthropic/claude-sonnet-5:high";
             };
+            # Hindsight is omp's native memory backend, reached over HTTP by a
+            # hand-rolled client (src/hindsight/backend.ts) with no MCP server in
+            # the path. Only backend and apiUrl change behaviour; the remaining six
+            # restate the schema defaults omp carries at 17.3.5, declared so an
+            # upstream default change surfaces as a diff here rather than as a
+            # silent shift in what the fleet retains.
+            #
+            # bankId is deliberately left unset. Under per-project-tagged scoping
+            # that resolves to the base bank `omp` (src/hindsight/bank.ts), one
+            # shared bank whose entries are tagged with the project name, which is
+            # what recall across the fleet's repositories wants.
+            memory.backend = lib.mkDefault "hindsight";
+            hindsight = {
+              apiUrl = lib.mkDefault "https://api.hindsight.vectorize.io";
+              scoping = lib.mkDefault "per-project-tagged";
+              retainMode = lib.mkDefault "full-session";
+              autoRecall = lib.mkDefault true;
+              autoRetain = lib.mkDefault true;
+              mentalModelsEnabled = lib.mkDefault true;
+              mentalModelAutoSeed = lib.mkDefault true;
+            };
           };
 
           watchdog = {
@@ -154,6 +175,29 @@
         };
 
         home.packages = lib.mkIf cfg.enable [ cfg.package ];
+
+        # The Hindsight token reaches omp through the environment and never
+        # through settings above. omp parses config.yml as plain YAML and expands
+        # nothing, so a `${HINDSIGHT_API_TOKEN}` written into hindsight.apiToken is
+        # sent verbatim as the bearer token; docs/memory.md shows that form anyway,
+        # and it fails as a literal string whenever the variable is unset and is
+        # dead configuration whenever it is set, because the environment outranks
+        # the settings file (src/hindsight/config.ts). A real token written there
+        # would be worse still: cfg.settings renders into a world-readable store
+        # path, and merge-config.sh leaves the target at 0644.
+        #
+        # ~/.omp/.env is the fourth of the five sources omp's loader consults --
+        # process environment, project .env, ${configDir}/.env, ~/.omp/.env,
+        # ~/.env -- each filling only keys still unset, so every launch path picks
+        # the token up with no wrapper. Rendering it as a sops template keeps the
+        # plaintext out of the nix store entirely.
+        sops.templates = lib.mkIf cfg.enable {
+          omp-env = {
+            mode = "0400";
+            path = "${config.home.homeDirectory}/.omp/.env";
+            content = "HINDSIGHT_API_TOKEN=${config.sops.placeholder."hindsight-api-token"}\n";
+          };
+        };
 
         home.activation.ompMergeConfig = lib.mkIf cfg.enable (
           let

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -129,7 +129,7 @@ let
       };
 
       # sops-nix configuration for crs58/cameron user
-      # 15 secrets: development + ai + shell aggregates
+      # 22 secrets: development + ai + shell aggregates
       sops = {
         defaultSopsFile = flake.inputs.self + "/secrets/home-manager/users/crs58/secrets.yaml";
         secrets = {
@@ -148,6 +148,9 @@ let
           linear-workspace-personal = { };
           linear-workspace-work = { };
           context7-api-key = { };
+          # Hindsight cloud token for omp's memory backend, rendered to
+          # ~/.omp/.env by the sops template in modules/home/ai/omp.
+          hindsight-api-token = { };
           # Per-host scoped cognee X-Api-Key for the always-on cognee-memory
           # plugin and the cognee-cli wrapper. Declared here; its ciphertext is
           # added to secrets.yaml after the one-time owner-authenticated mint


### PR DESCRIPTION
Points omp's memory at the hosted Hindsight service and delivers the API token through the environment rather than through omp's settings file.

## What changes

`programs.omp.settings` gains `memory.backend` and a `hindsight` attrset. Only `backend` and `apiUrl` change behaviour; the other six restate the schema defaults omp carries at 17.3.5, declared so an upstream default change shows up as a diff here instead of silently altering what gets retained. `bankId` stays unset, which under `per-project-tagged` scoping resolves to the base bank `omp` — one shared bank whose entries are tagged with the project name.

`sops.secrets.hindsight-api-token` is declared for crs58, and the omp module renders it to `~/.omp/.env` via a sops template.

A validation flake-app is added, described below.

## Why the token is not in config.yml

omp parses `config.yml` as plain YAML and expands nothing. The `apiToken: ${HINDSIGHT_API_TOKEN}` form shown in omp's own `docs/memory.md` is therefore sent verbatim as the bearer token: a literal-string auth failure when the variable is unset, and dead configuration when it is set, because the environment outranks the settings file in omp's precedence chain. Writing a real token there would be worse still — the settings attrset renders into a world-readable store path, and `merge-config.sh` leaves the target at `0644`.

`~/.omp/.env` is omp's documented config-root env file, consulted for keys whose value is still unset, so every launch path picks the token up with no wrapper and no plaintext enters the nix store. Keeping the token out of `settings` has a second benefit: `config.yml` contains no placeholder, so the activation merge and sops-nix's unordered darwin agent never contend for the same file. Had the token gone into `settings`, that would have been a genuine race.

## Details worth a reviewer's attention

**Enum values were checked against source, not documentation.** `scoping` and `retainMode` are enums with non-obvious legal values (`global`/`per-project`/`per-project-tagged`, and `full-session`/`last-turn`). The settings option accepts any string, so a wrong value renders into `config.yml` and surfaces only at omp runtime, passing every gate in this repo. Both were verified against `settings-schema.ts` at the pinned tag.

**`mkDefault` is applied per leaf, not to the `hindsight` attrset.** This matches the existing `modelRoles` and `theme.dark` style, and it is load-bearing rather than cosmetic: wrapping the attrset makes it a single definition, so any downstream override of one key would drop its siblings.

**Rollback is not symmetric.** `merge-config.sh` can add or update a nix-owned key but cannot retract one. Removing these keys from nix later leaves them on disk. Backing this change out means setting `memory.backend` to another value, not deleting it.

**Template placement.** The template is declared in the omp module, following the precedent in `modules/home/ai/claude-code/mcp-servers.nix`, which declares `sops.templates` from the same `homeManager.ai` aggregate for four other secrets. The alternative is the crs58 user module, and there is a real argument for it: only crs58 carries the `ai` aggregate, so a generic module referencing a secret only one user declares would fail with a missing-attribute evaluation error the moment a second user gained `ai`. That coupling already exists for the four MCP secrets, so this does not introduce a new class of problem, but it is a latent issue and moving all five is a reasonable review request.

## Validation

`nix build .#checks.aarch64-darwin.home-manager-crs58` succeeds. That is the one command covering both halves of the question, and it is drvPath-identical to `homeConfigurations."crs58@aarch64-darwin".activationPackage`. It is specifically the check that matters here: sops-nix validates declared secrets against the ciphertext in a derivation `checkPhase`, not at activation, so a declared-but-absent key fails the build on every machine and in CI. This branch is rebased onto 98b5dd90, which adds the ciphertext, so that check passes; before that commit landed it failed exactly as expected, naming the missing key.

Evaluating the same configuration confirms `programs.omp.settings` renders `memory.backend` plus the seven `hindsight` keys and no `apiToken`, and that `sops.templates.omp-env` resolves to mode `0400` at `~/.omp/.env` carrying only the token placeholder.

`nix fmt` reports every touched file unchanged, and `shellcheck` is clean.

A second commit updates the `piPackageVersion` literal in `modules/checks/pi-agent-environment.nix` from `0.84.1` to `0.84.2`. That check was the only red one on this PR, and it is unrelated to the memory wiring: the `llm-agents` input was advanced deliberately and brought pi with it, and the check pins the version as a literal whose own remediation text says to update it after such a bump. It failed identically at base commit `98b5dd90` with none of this work applied, the actual-versus-expected diff named no other field, and `checks.x86_64-linux.pi-agent-environment-structural` builds green with the one-line change. It lands here rather than on the stacked PR because this is the base of the stack, so the fix reaches both.

I deliberately did not run the whole suite. The change is confined to the crs58 home configuration and one new flake app, so no machine or package check is implicated; `home-manager-crs58` is the narrowest selection that would fail if any part of this were wrong.

### End-to-end proof

Because the wiring spans a credential, an endpoint and an agent lifecycle that no build can exercise, the validation ships as a runnable flake-app in two tiers:

```
nix run .#hindsight-memory-validate              # tier 0
nix run .#hindsight-memory-validate -- --tier1 --model <provider/model>
```

Tier 0 proves the token, endpoint and bank over plain HTTP with no LLM involved. Tier 1 drives two omp sessions and checks the second recalls the first's fact. Both use a throwaway bank, deleted on exit, and tier 1 a scratch `HOME`, so neither touches the shared `omp` bank or the real `~/.omp`.

**Tier 0 has been run green against the live service**, retaining and recalling a codeword through a throwaway bank. Its request shapes were taken from the service's own OpenAPI document rather than from prose documentation, which is how a wrong bank-creation body was caught: `CreateBankRequest` has no required fields but the body itself is required, so omitting it is a 422 rather than a default create.

**Tier 1 has also been run green.** One omp session was told the codeword and a second, fresh session was asked for it back and answered `amber-falcon-42`, so omp's own auto-retain and auto-recall against the hosted service are proven end to end, not just the HTTP surface. No new secret was needed: the existing `glm-api-key` is the z.ai credential, exported as `ZAI_API_KEY`, with `zai/glm-5.3:high` — the model this module already sets as the default role.

## Operational note

Retain mode is `full-session`, so complete session transcripts go to the hosted service. On the free tier, secret hygiene there rests on regex-based credential redaction. Memories are not auto-deleted server-side, and `/memory clear` does not delete the cloud bank — the experiment is reversible by deleting the bank through the UI or API.
