### PR TITLE
Add the hindsight CLI package

### DIFF
--- a/modules/apps/updates.nix
+++ b/modules/apps/updates.nix
@@ -35,6 +35,11 @@
         program = "${config.packages.git-xet.updateScript}";
       };
 
+      apps.update-hindsight = {
+        type = "app";
+        program = "${config.packages.hindsight.updateScript}";
+      };
+
       apps.update-golem-binary = {
         type = "app";
         program = "${config.packages.golem-binary.updateScript}";

--- a/modules/home/packages/development-packages.nix
+++ b/modules/home/packages/development-packages.nix
@@ -107,6 +107,7 @@
           gemini-cli
           # from pkgs/by-name
           golem-binary
+          hindsight
           linear-cli
           ouroboros
           uncomment-bin

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -206,6 +206,29 @@ let
           '';
         };
 
+        # hindsight CLI credentials, rendered immutably from sops so the CLI
+        # works without a `hindsight configure` step.
+        #
+        # This cannot reuse the ~/.omp/.env file the omp module renders, for two
+        # independent reasons: that file is read by omp's own loader rather than
+        # exported to the shell, and the two tools spell the credential
+        # differently. The CLI reads HINDSIGHT_API_KEY and HINDSIGHT_API_URL
+        # (src/config.rs) and never HINDSIGHT_API_TOKEN, which is the name omp
+        # uses. Its resolution order is environment, then named profile, then
+        # this file, then a localhost default, so writing it here leaves the
+        # environment free to override per invocation.
+        #
+        # Read-only (0400): change the URL with --api-url or the environment,
+        # never via `hindsight configure`, which would clobber this file.
+        templates."hindsight-cli-config" = {
+          mode = "0400";
+          path = "${config.home.homeDirectory}/.hindsight/config";
+          content = ''
+            api_url = "https://api.hindsight.vectorize.io"
+            api_key = "${config.sops.placeholder."hindsight-api-token"}"
+          '';
+        };
+
         # Note: Radicle keys deployed via home.file below (not sops.templates due to pure eval path issues)
       };
 

--- a/pkgs/by-name/hindsight/package.nix
+++ b/pkgs/by-name/hindsight/package.nix
@@ -1,0 +1,97 @@
+# hindsight - CLI and TUI client for the Hindsight semantic memory system.
+#
+# Upstream's own installer at https://hindsight.vectorize.io/get-cli downloads a
+# prebuilt binary per platform from the GitHub release, and this follows it: the
+# four assets are the same artifacts the vendor ships, pinned by hash instead of
+# fetched at install time.
+#
+# Building from source is possible and was tried first, but it is a poor trade
+# here. hindsight-cli path-depends on hindsight-clients/rust, whose build.rs
+# generates that client's entire API surface with progenitor at build time and
+# locates its OpenAPI input by walking two parents up to
+# hindsight-docs/static/openapi.json. That makes the whole monorepo the build
+# input -- a 219 MB source derivation, most of it documentation -- and upstream
+# gitignores the CLI's Cargo.lock, so the resolution would have to be vendored
+# and regenerated here on every bump. The release assets cost four hashes.
+#
+# Source: https://github.com/vectorize-io/hindsight
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  openssl,
+  versionCheckHook,
+}:
+let
+  inherit (stdenv.hostPlatform) system;
+  # Upstream names its assets by its own os-arch labels rather than by target
+  # triple, and ships them as bare executables rather than archives.
+  systemToPlatform = {
+    "x86_64-linux" = {
+      asset = "linux-amd64";
+      hash = "sha256-fFzqCOfBkJ1D2gy8J95td0Q1vI7UQih0t4AUko8QTtQ=";
+    };
+    "aarch64-linux" = {
+      asset = "linux-arm64";
+      hash = "sha256-usPoOMCoYfTYDAhla294MPSSvsb3Uoq+/xSAhfjECJ8=";
+    };
+    "x86_64-darwin" = {
+      asset = "darwin-amd64";
+      hash = "sha256-UFfMM2nLJaqicLxiC9H14EK46//z4QiWXLvtFnHhJDg=";
+    };
+    "aarch64-darwin" = {
+      asset = "darwin-arm64";
+      hash = "sha256-FErBbsV8SFV8KFCcp2JYbxLJJOhXVeeq8+XzYvJLJm4=";
+    };
+  };
+  platform = systemToPlatform.${system} or (throw "hindsight: unsupported platform ${system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hindsight";
+  version = "0.9.1";
+
+  src = fetchurl {
+    url = "https://github.com/vectorize-io/hindsight/releases/download/v${finalAttrs.version}/hindsight-${platform.asset}";
+    hash = platform.hash;
+  };
+
+  # The asset is a bare executable, so there is nothing to unpack and stdenv's
+  # source-root detection has nothing to detect.
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # The Linux assets are dynamically linked, not static: reqwest resolves to
+  # native-tls, which is openssl off darwin, so the binary wants libssl.so.3 and
+  # libcrypto.so.3 plus libgcc_s.so.1. The darwin assets need nothing, native-tls
+  # using Security.framework there.
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/hindsight
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    homepage = "https://github.com/vectorize-io/hindsight";
+    description = "CLI and TUI client for the Hindsight semantic memory system (prebuilt release binary)";
+    changelog = "https://github.com/vectorize-io/hindsight/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "hindsight";
+    maintainers = with lib.maintainers; [ cameronraysmith ];
+    platforms = lib.attrNames systemToPlatform;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/hindsight/update.sh
+++ b/pkgs/by-name/hindsight/update.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p curl jq cacert nix
+# shellcheck shell=bash
+#
+# Bumps pkgs/by-name/hindsight to the latest upstream release: rewrites the
+# version and each platform's asset hash in package.nix.
+# Invoked via `nix run .#update-hindsight` (passthru.updateScript).
+
+set -euo pipefail
+
+# Resolve package.nix relative to this script so the updater edits the correct
+# file regardless of the caller's working directory (e.g. nixpkgs update
+# machinery, which does not cd into the package directory).
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PKG_NIX="${SCRIPT_DIR}/package.nix"
+
+current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
+
+# The monorepo scopes sub-component tags with a slash prefix (integrations/...,
+# tools/...) and reserves bare vMAJOR.MINOR.PATCH for whole-repo releases, which
+# is what the CLI assets are attached to, so filter to that form rather than
+# trusting releases/latest.
+latest_tag="$(curl -fsSL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/vectorize-io/hindsight/releases?per_page=100" \
+  | jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | .[0].tag_name')"
+latest_version="${latest_tag#v}"
+
+if [[ -z "$latest_version" || "$latest_version" == "null" ]]; then
+  echo "error: failed to discover a semver tag from GitHub releases" >&2
+  exit 1
+fi
+
+if [[ "$current_version" == "$latest_version" ]]; then
+  echo "hindsight is already at version ${current_version}; refreshing hashes anyway"
+else
+  echo "Updating hindsight: ${current_version} -> ${latest_version}"
+  sed -i'' -e "s/version = \"${current_version}\"/version = \"${latest_version}\"/" "$PKG_NIX"
+fi
+
+# Platform map: nix system -> upstream asset label (asset is a bare executable
+# named hindsight-<label>).
+declare -A platform_map=(
+  ["x86_64-linux"]="linux-amd64"
+  ["aarch64-linux"]="linux-arm64"
+  ["x86_64-darwin"]="darwin-amd64"
+  ["aarch64-darwin"]="darwin-arm64"
+)
+
+for platform in "${!platform_map[@]}"; do
+  asset="${platform_map[$platform]}"
+  url="https://github.com/vectorize-io/hindsight/releases/download/v${latest_version}/hindsight-${asset}"
+
+  echo "Prefetching ${platform} (hindsight-${asset})..."
+  sri_hash="$(nix store prefetch-file --json --hash-type sha256 "$url" | jq -r .hash)"
+
+  if [[ -z "$sri_hash" || "$sri_hash" == "null" ]]; then
+    echo "error: failed to compute hash for ${platform} from ${url}" >&2
+    exit 1
+  fi
+
+  # Anchor on this platform's `asset = "<label>";` line, advance to the
+  # immediately-following `hash =` line, and substitute. Each label is unique to
+  # a single block in package.nix, so exactly one hash line is rewritten.
+  sed -i'' -e "/asset = \"${asset}\";/{ n; s|hash = \"sha256-[^\"]*\"|hash = \"${sri_hash}\"|; }" "$PKG_NIX"
+
+  echo "  ${platform}: ${sri_hash}"
+done
+
+echo "Updated hindsight to ${latest_version}"


### PR DESCRIPTION
Packages the Hindsight CLI and wires its credential from sops.

**Stacked on #2736.** The base of this PR is `fm/vx-hindsight-omp-memory`, because the credential template here references `sops.secrets.hindsight-api-token`, which #2736 declares. The diff shown is only this change. Merge #2736 first — it also carries the `pi-agent-environment` version-literal fix that clears the one red check on both PRs.

## Source: prebuilt assets, not a source build

Upstream's own installer at `hindsight.vectorize.io/get-cli` resolves `uname` to one of four labels, downloads a bare executable from the GitHub release, and chmods it into place. This pins those same four artifacts by hash rather than fetching whatever is latest at install time. `git-xet` and `dbt-fusion` are the closest precedents here — prebuilt, `fetchurl`, per-platform hash table, `binaryNativeCode` provenance, `updateScript` that re-prefetches every platform.

I built it from source first, and it works — `rustPlatform.buildRustPackage` with a vendored lockfile, green on both platforms. It is still the worse option:

- `hindsight-cli` path-depends on `hindsight-clients/rust`, whose `build.rs` generates that client's entire API surface with progenitor at build time and locates its OpenAPI input by walking two parents up to `hindsight-docs/static/openapi.json`. The whole monorepo is therefore the build input: a 219 MB source derivation, most of it documentation. Pruning is possible but fiddly, since the layout itself is load-bearing.
- Upstream gitignores the CLI's `Cargo.lock` and never builds `--locked`, so the resolution would have to be vendored in this repo and regenerated on every bump. The one lockfile upstream does commit belongs to the client crate and resolves only that crate's graph.

Four hashes are cheaper to carry and cheaper to update. Happy to switch back if you would rather not ship `binaryNativeCode`; the source derivation is a known-good fallback.

The Linux assets are dynamically linked and need `openssl` and `libgcc` at runtime — `reqwest` resolves to `native-tls`, so the binary wants `libssl.so.3`, `libcrypto.so.3` and `libgcc_s.so.1`. The darwin assets need nothing, `native-tls` using `Security.framework` there.

## Credential wiring, and a name mismatch worth knowing

A sops template renders `~/.hindsight/config` so the CLI works with no `hindsight configure` step.

It cannot reuse the `~/.omp/.env` file #2736 writes, for two independent reasons. That file is read by omp's own loader rather than exported to the shell, so nothing else sees it. And the two tools spell the credential differently: the CLI reads `HINDSIGHT_API_KEY` and `HINDSIGHT_API_URL` (`hindsight-cli/src/config.rs:52,55`) and never `HINDSIGHT_API_TOKEN`, which is the name omp uses. `HINDSIGHT_API_TOKEN` appears nowhere in the CLI source. So one env file cannot serve both, even though they share one credential.

Writing the CLI's own config file puts the credential on its third resolution rung — environment, then named profile, then this file, then a localhost default — so either of the first two can still override it per invocation. This matches how `linear-credentials.toml`, `git-credentials` and `aws-credentials` are already handled: rendered read-only to the tool's native config path.

## Validation

`nix build .#checks.aarch64-darwin.package-hindsight` and `.#checks.x86_64-linux.package-hindsight` both succeed. The Linux one is the only attribute buildbot evaluates, and it is what caught the missing runtime libraries — the first Linux attempt failed auto-patchelf, naming all three. Both pass `versionCheckHook`, which runs the installed binary and confirms it reports `0.9.1`.

The packaged binary was then run against the live service, which is the vendor-documented verify:

- `hindsight bank list` with `HINDSIGHT_API_URL` and `HINDSIGHT_API_KEY` in the environment authenticates and returns an empty list.
- The same command with no env vars and a `~/.hindsight/config` written exactly as the template renders it, in a scratch `HOME`, gives the same result — so the template design is proven, not assumed.
- A deliberately invalid key was used as a control and produces an error rather than the same empty list, so "No banks found" is a real authenticated response and not a swallowed auth failure.

`nix build .#checks.aarch64-darwin.home-manager-crs58` confirms the package reaches the user profile and the new template evaluates to mode `0400` at `~/.hindsight/config`. `nix eval` of `apps.update-hindsight` confirms the update script is reachable. `nix fmt` reports every touched file unchanged and `shellcheck` is clean.

I did not run the whole suite. The change adds one package and one template, so the two `package-hindsight` checks plus `home-manager-crs58` are the narrowest selection that would fail if any part of it were wrong; no machine configuration is touched, so no machine check is implicated. The `update.sh` bump path was not executed, since running it would rewrite `package.nix` to a newer release than the one under review.

## Note on placement

`hindsight` reaches the profile through the `# from pkgs/by-name` group in `development-packages.nix`, alongside `golem-binary`, `linear-cli`, `ouroboros` and `uncomment-bin`. That is the fleet-wide `development` aggregate, which four other users also carry. If you would rather this be crs58-only, moving it to that user's `home.packages` is a one-line change.
