### PR TITLE
feat(context): add operating principles, factor task-scoped prose into skills

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "preferences-code-and-collaboration-conventions",
-      "description": "Code and collaboration conventions — style and conventions, documentation, git version control, git history cleanup, change management.",
+      "description": "Code and collaboration conventions — style and conventions, documentation, git version control, git history cleanup, change management, prose clarity, essential complexity.",
       "version": "0.0.0",
       "source": "./modules/home/ai/plugins/preferences-code-and-collaboration-conventions"
     },
@@ -103,7 +103,7 @@
     },
     {
       "name": "nix-build-operations",
-      "description": "Nix build-operations skills — flake PR cycle, broken-package handling, process-compose init, worktree-sparsity eval.",
+      "description": "Nix build-operations skills — flake PR cycle, broken-package handling, process-compose init, worktree-sparsity eval, CI log verification.",
       "version": "0.0.0",
       "source": "./modules/home/ai/plugins/nix-build-operations"
     },

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-agent-teams/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-agent-teams/SKILL.md
@@ -13,21 +13,21 @@ Teammates do not inherit the orchestrator's conversation context, so spawn promp
 Teammates coordinate via shared task list (TaskCreate/TaskUpdate/TaskList) and messaging (SendMessage), not by returning results to the orchestrator.
 The orchestrator remains responsible for teammate lifecycle management.
 
-## Beads-to-task-list mirroring
+## Issue-to-task-list mirroring
 
-Beads-to-task-list mirroring aligns ephemeral team coordination with persistent issue tracking.
-When an agent team works on an epic lineage or cross-cutting collection of beads issues, mirror the relevant issues and their dependencies into the team's shared task list via TaskCreate with appropriate blockedBy/blocks relationships.
-The team's shared task list is the ephemeral coordination substrate; beads issues remain the persistent source of truth.
-Keep both in sync: when a team task completes, update the corresponding bead.
+Issue-to-task-list mirroring aligns ephemeral team coordination with persistent work tracking.
+When an agent team works on a story lineage or cross-cutting collection of Linear stories or OpenSpec changes, mirror the relevant items and their dependencies into the team's shared task list via TaskCreate with appropriate blockedBy/blocks relationships.
+The team's shared task list is the ephemeral coordination substrate; the Linear board and OpenSpec change own the persistent state.
+Keep both in sync: when a team task completes, update the corresponding story or change.
 
 ## Teammate lifecycle: orient, work, checkpoint, shutdown, replace
 
 Teammate lifecycle management integrates with the orient/checkpoint pattern.
 Every new teammate should be instructed to execute `/session-orient` at session start to establish full context on the issue graph and current state.
-For repos without the full workflow (no `session-*` skills installed), fall back to `/issues-beads-orient`.
+For repos without the full workflow (no `session-*` skills installed), instruct the teammate to establish context from the repository's own AGENTS.md and current branch state.
 Teammates should monitor context usage and, when approaching 50% capacity (approximately 100k tokens), execute `/session-checkpoint` to capture learnings, update issue status, and produce a handoff narrative.
-For repos without the full workflow, fall back to `/issues-beads-checkpoint`.
-After checkpoint, the teammate requests shutdown; the orchestrator spawns a replacement oriented with `/session-orient` (or `/issues-beads-orient` in beads-only repos) to continue the work.
+For repos without the full workflow, have the teammate write the checkpoint narrative to a dated file under `docs/notes/` for the successor.
+After checkpoint, the teammate requests shutdown; the orchestrator spawns a replacement oriented with `/session-orient` to continue the work.
 This creates a clean lifecycle: orient, work, checkpoint, shutdown, replace.
 
 ## Subagent identity in team context

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-checkpoint/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-checkpoint/SKILL.md
@@ -178,7 +178,7 @@ Determination of variant: closure if all streams have integrated to main and no 
 
 *Related skills:*
 - `/meta-orchestrator-initiate` — team-level orchestrator initialization; consumes this skill's output
-- `meta-agent-teams` — teammate isolation, beads-to-task-list mirroring, orient/checkpoint lifecycle
+- `meta-agent-teams` — teammate isolation, issue-to-task-list mirroring, orient/checkpoint lifecycle
 - `/session-checkpoint` — session-level checkpoint each AC and WO runs at cycle end; this skill references their outputs
 
 *Theoretical anchors:*

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/SKILL.md
@@ -29,7 +29,7 @@ If the mission scope is single-session-single-repo (no parallel streams, no mult
 This skill orchestrates a higher-level protocol that uses the following as components.
 Do not duplicate their functionality; delegate to them.
 
-- `meta-agent-teams` provides teammate spawn conventions, beads-to-task-list mirroring, and the orient/work/checkpoint/shutdown/replace lifecycle for individual pairs
+- `meta-agent-teams` provides teammate spawn conventions, issue-to-task-list mirroring, and the orient/work/checkpoint/shutdown/replace lifecycle for individual pairs
 - `/session-orient` provides the session-level orientation each AC and WO runs after spawn (with a master-supplied addendum)
 - `/session-checkpoint` provides the session-level checkpoint each AC and WO runs at cycle end
 - `/meta-orchestrator-checkpoint` provides the team-level state capture and handoff that this skill consumes when invoked with a checkpoint payload
@@ -203,7 +203,7 @@ An exemplar session covering user→master entry, N-stream decomposition with ra
 ---
 
 *Related skills:*
-- `meta-agent-teams` — teammate isolation, beads-to-task-list mirroring, orient/checkpoint lifecycle
+- `meta-agent-teams` — teammate isolation, issue-to-task-list mirroring, orient/checkpoint lifecycle
 - `meta-orchestrator-checkpoint` — team-level state capture and handoff
 - `/session-orient` — session-level orientation each AC and WO runs with a master addendum
 - `/session-checkpoint` — session-level checkpoint each AC and WO runs at fill

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-session-resume/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-session-resume/SKILL.md
@@ -4,6 +4,9 @@ description: Generate annotated resume command and add to atuin history for sess
 argument-hint: '[session-uuid] [nohist]'
 disable-model-invocation: false
 ---
+
+# Meta session resume
+
 Generate a resume session command and automatically add it to atuin shell history.
 
 Command format:

--- a/modules/home/ai/plugins/nix-build-operations/.apm/skills/ci-log-verification/SKILL.md
+++ b/modules/home/ai/plugins/nix-build-operations/.apm/skills/ci-log-verification/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: ci-log-verification
+description: Verify CI results by downloading and analyzing complete workflow logs across both CI backends (GitHub Actions and buildbot-nix), rather than piecing together fragments via repeated API calls. Use when validating a branch or PR for merge, when a check fails and log evidence is needed, or when triaging which backend a failing check lives on from gh pr checks output.
+---
+
+# CI log verification
+
+When validating changes for merge, verify CI results by downloading and analyzing complete workflow logs rather than piecing together fragments via repeated API calls.
+
+## Wait and download
+
+Wait for relevant workflows to complete:
+
+```bash
+gh run watch <run_id>
+# or poll with: gh run list --branch <branch> --status completed
+```
+
+Download the complete logs archive:
+
+```bash
+run_id=<run_id>
+mkdir -p logs
+gh api "repos/<owner>/<repo>/actions/runs/${run_id}/logs" > "logs/gha-${run_id}.zip"
+unzip -d "logs/gha-${run_id}" "logs/gha-${run_id}.zip"
+```
+
+Survey available jobs and steps:
+
+```bash
+tree --du -ah "logs/gha-${run_id}"
+```
+
+## Unified PR check log retrieval
+
+Given only a pull request number, the unified entry point for discovering which checks ran and where their logs live is `PAGER=cat gh pr checks <N>`.
+This command emits one row per check with a direct link, spanning both CI backends used by repositories in this workspace.
+GitHub Actions rows link to `https://github.com/<owner>/<repo>/actions/runs/<run_id>/job/<job_id>`.
+Buildbot-nix rows link to `https://buildbot.scientistexperience.net/#/builders/<builder_id>/builds/<build_number>` and correspond to the `buildbot/nix-eval` and `buildbot/nix-build` status checks described in `preferences-nix-ci-cd-integration`.
+
+Use the JSON output to separate the two categories and drive automation:
+
+```bash
+gh pr checks <N> --json name,link \
+  | jq -r '.[] | select(.name | test("^buildbot/")) | .link'
+gh pr checks <N> --json name,link \
+  | jq -r '.[] | select(.link | test("/actions/runs/")) | .link'
+```
+
+Route each link to its backend-specific log-download recipe, writing artifacts under a single `logs/` directory (already gitignored):
+
+```bash
+mkdir -p logs
+
+# GitHub Actions — extract <run_id> from the /runs/<run_id>/job/... URL path
+run_id=<run_id>
+gh api "repos/<owner>/<repo>/actions/runs/${run_id}/logs" > "logs/gha-${run_id}.zip"
+unzip -d "logs/gha-${run_id}" "logs/gha-${run_id}.zip"
+
+# Buildbot-nix — extract <builder_id> and <build_number> from the fragment
+# /#/builders/<builder_id>/builds/<build_number>
+builder_id=<builder_id>
+build_number=<build_number>
+buildbot-logs "${builder_id}" "${build_number}" > "logs/buildbot-${builder_id}-${build_number}.log"
+```
+
+The `buildbot-logs` shell application is defined in the vanixiets repository; see `preferences-nix-ci-cd-integration` for its interface, ssh transport, and authentication model.
+
+## Analyze
+
+After download, survey each artifact before dispatching subagents for targeted analysis:
+
+```bash
+tree --du -ah "logs/gha-${run_id}"
+rg "error:" "logs/buildbot-${builder_id}-${build_number}.log"
+```
+
+Dispatch subagent Tasks to analyze specific log files for the problem at hand rather than manually reading large logs inline.
+This approach provides a complete, well-organized view of CI results and avoids the antipattern of fragmented API-based log retrieval that never yields a clear picture of what happened.

--- a/modules/home/ai/plugins/nix-build-operations/apm.yml
+++ b/modules/home/ai/plugins/nix-build-operations/apm.yml
@@ -1,3 +1,3 @@
 name: nix-build-operations
 version: 0.0.0
-description: Nix build-operations skills — flake PR cycle, broken-package handling, process-compose init, worktree-sparsity eval.
+description: Nix build-operations skills — flake PR cycle, broken-package handling, process-compose init, worktree-sparsity eval, CI log verification.

--- a/modules/home/ai/plugins/nix-build-operations/plugin.json
+++ b/modules/home/ai/plugins/nix-build-operations/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nix-build-operations",
   "version": "0.0.0",
-  "description": "Nix build-operations skills — flake PR cycle, broken-package handling, process-compose init, worktree-sparsity eval."
+  "description": "Nix build-operations skills — flake PR cycle, broken-package handling, process-compose init, worktree-sparsity eval, CI log verification."
 }

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-essential-complexity/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-essential-complexity/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: preferences-essential-complexity
+description: Complexity must pay rent in domain invariants or value delivered to its consumer. Use when designing or reviewing abstractions, type signatures, module boundaries, specifications, or proofs; when deciding what to delete versus keep; when scaling review rigor by refinement-chain position (Lean spec, public API, schema, persisted data, spec-constrained implementation); or when handling sorry, admit, unsafe, or vacuous-proof debt.
+---
+
+# Essential complexity
+
+Shared root: every element of an artifact — a type, an abstraction, a sentence, a qualifier — must pay rent in invariants enforced or value delivered to its consumer.
+Stated confidence must match evidence.
+Uncertainty is information to state precisely, never a substitute for a decision: commit, state the tradeoff taken and what would change your mind.
+Scale care to blast radius: what binds others (specs, APIs, published prose) gets strong care; what a spec already constrains gets fast decisions.
+
+## Complexity must pay rent; domain invariants are the rent
+
+Whatever encodes domain invariants — types, proofs, Decider-style structure — is essential; never strip it.
+Everything else must trace to a spec construct or a present need stated in one sentence, or be deleted.
+No speculative generality: one-instance typeclasses, unused parametricity, forwarding layers, unasked-for configurability all fail the rent test.
+
+## Commit; scale care to position in the refinement chain
+
+The Lean spec layer binds everything downstream — change it only with explicit invariants and a flagged review request.
+Public APIs, schemas, and persisted data get strong care.
+Implementation already constrained by a spec gets fast decisions: decide, note assumptions in the commit, do not stop to ask.
+This governs artifact-level choices within confirmed intent; task-level ambiguity still routes through the session protocol's ask-first rule.
+
+## Rigor must be falsifiable
+
+The spec is the source of truth; divergence is a defect, not a fork.
+Every `sorry`, `admit`, or `unsafe` is flagged debt, never silent.
+Never weaken a statement or strengthen a hypothesis to close a proof — if the honest theorem won't go through, stop and say so.
+Check theorems aren't vacuous; derive tests from spec properties, not from the code.
+A proof of the wrong theorem is worse than none.
+
+## Related skills
+
+For the Lean-to-Rust refinement mechanics this policy governs, see `refinement-driven-development`.
+For severity and evidence-quality criteria, see `preferences-validation-assurance`.
+For the asymptotic architectural ideal this rent rule bounds, see `preferences-theoretical-foundations`: the ideal governs direction of travel; this skill governs what ships today.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/SKILL.md
@@ -5,18 +5,9 @@ description: Git version control conventions including atomic commits, branch wo
 
 # Git version control
 
-## Contents
+## Sibling files
 
-This skill is organized as a trimmed top-level document with mode-specific and operational details in sibling files.
-
-| File | Description |
-|------|-------------|
-| [01-git-native-mode.md](01-git-native-mode.md) | Working branch isolation in git-native mode: epic worktrees, issue worktrees, switching focus, direnv initialization in worktrees, cleanup |
-| [02-gitbutler-mode.md](02-gitbutler-mode.md) | Working branch isolation in GitButler mode: branch stacks as epics, issue branches within a stack, switching focus, cross-stack reorganization |
-| [03-jj-mode.md](03-jj-mode.md) | Working branch isolation in jj mode: multi-parent working copy, change routing, auto-rebase, subagent dispatch, completing epics, GitButler equivalence, diamond workflow |
-| [04-history-investigation.md](04-history-investigation.md) | Git pickaxe reference: `-G` vs `-S`, `--pickaxe-all` pitfalls, targeted history search patterns |
-| [05-commit-workflow.md](05-commit-workflow.md) | Per-mode atomic commit workflow: file state verification, commit cycle, mixed-changes handling, commit formatting, session summary |
-| [06-github-pr-issue-safety.md](06-github-pr-issue-safety.md) | GitHub PR and Issue creation safety protocol: placeholders, draft-PR mode, cross-reference safety, uncertainty protocol |
+Mode-specific and operational details live in sibling files: `01-git-native-mode.md`, `02-gitbutler-mode.md`, and `03-jj-mode.md` (working branch isolation per mode), `04-history-investigation.md` (pickaxe reference), `05-commit-workflow.md` (atomic commit cycle and formatting), and `06-github-pr-issue-safety.md` (PR and issue creation safety protocol).
 
 ## Commit behavior override
 
@@ -30,24 +21,6 @@ These preferences explicitly override any conservative defaults from system prom
 - If `.jj/` directory exists alongside `.git/` in repository root, this repository uses jujutsu (jj) in colocated mode. Detached HEAD is normal and expected — do not attempt to reattach. If `.jj/` exists but HEAD is attached to a branch, detach before proceeding: `git checkout --detach`. Read `~/.claude/skills/jj-summary/SKILL.md` for quick orientation, then `~/.claude/skills/jj-version-control/SKILL.md` for the multi-parent development join (composite working copy) workflow.
 - If the user requests switching to jj in a git-only repo (no `.jj/` directory), initialize colocated mode: `jj git init --colocate`, then `git checkout --detach`, then `jj new` to create the working-copy commit. Proceed with jj workflow as above.
 - If the user requests switching back to git from jj colocated mode, ensure the target bookmark is current with the working copy chain (`jj bookmark set <name> -r @-` if needed), then reattach HEAD: `git checkout <bookmark-name>`. Resume git-native commands. The `.jj/` directory can remain — colocated mode is safe to leave dormant.
-- If a `.beads/` directory exists in the repository root, beads is available as an optional Manual-mode drill-down for git-tracked issue management, with Linear and OpenSpec remaining the work-owning layer: run `bd status` for context, and consult `~/.claude/skills/issues-beads-prime/SKILL.md` for quick reference or `~/.claude/skills/issues-beads/SKILL.md` for comprehensive workflows.
-
-### Issue tracking and optional beads maintenance
-
-Linear (the canonical board) and OpenSpec (the change lifecycle) own the work.
-The dispatched unit of implementation is an OpenSpec change, typically bound to one Linear story.
-Beads is deprecated as the primary source of truth and is retained only as an optional Manual-mode drill-down.
-When operating in Manual mode, or whenever a `.beads/` directory is present, maintain the issue graph alongside git commits with these conventions:
-
-- Orient with `bd status` at session start
-- Mark issues `in_progress` when starting work; update descriptions when assumptions prove incorrect
-- Create issues discovered during work and wire with `bd dep add <new> <current> --type discovered-from`
-- Close with implementation context: `bd close <id> --reason "Implemented in $(git rev-parse --short HEAD)"`
-- Check what's unblocked after completion; consider updating newly-ready issues with helpful context
-- After completing a batch of mutations, push to the dolt remote for backup: `bd dolt push`
-
-For beads usage conventions (epic structure, status management, closure policy), see the conventions section of issues-beads-prime.
-Consult `~/.claude/skills/issues-beads-prime/SKILL.md` for command quick reference.
 
 ## VCS terminology glossary
 
@@ -75,18 +48,12 @@ This decoupling ensures skills remain correct across all three modes without con
 The primary ID source is the Linear story or OpenSpec change the work implements.
 When such a story or change is active, branch stacks correspond to the epic-level grouping and branch boundaries correspond to individual stories or changes, using the forms `{epic-ID}-descriptor` for the stack and `{issue-ID}-descriptor` for each boundary.
 
-In Manual mode, when a beads epic is active (`.beads/` exists and an epic is in progress), the beads epic and issue IDs fill those same placeholders:
-
-- Stack name: `{epic-ID}-descriptor` (e.g., `nix-f85-gitbutler-adoption`)
-- Branch name at each boundary: `{issue-ID}-descriptor` (e.g., `nix-f85-1-terminology-glossary`)
-
 When working ad hoc (no tracked story, epic, or change), stacks and boundaries are named descriptively:
 
 - Stack name: descriptive (e.g., `gitbutler-skill`)
 - Branch name at each boundary: descriptive (e.g., `fix-gitbutler-version`)
 
-All modes use identical mechanical operations.
-The difference is purely in naming conventions and whether `bd` lifecycle commands accompany the VCS operations in Manual mode.
+All modes use identical mechanical operations; the difference is purely in naming conventions.
 
 ## Escape hatches
 
@@ -99,20 +66,17 @@ Do not commit if:
 
 File edits on main/master are blocked by the `enforce-branch-before-edit` hook.
 Before attempting to edit any files, create a working branch to which you will commit your changes.
-In Manual mode with a `.beads/` directory present, if you haven't already, invoke `/issues-beads-prime` for beads command reference before proceeding with any editing.
 
 In jj mode, this hook is unnecessary.
 Anonymous chains are first-class and never garbage-collected.
-Create bookmarks when initiating a second chain or when working on a Linear story, OpenSpec change, or (in Manual mode) a beads epic — see the bookmark creation threshold in `~/.claude/skills/jj-version-control/SKILL.md`.
+Create bookmarks when initiating a second chain or when working on a Linear story or OpenSpec change — see the bookmark creation threshold in `~/.claude/skills/jj-version-control/SKILL.md`.
 
-Whenever you are working on a Linear story, OpenSpec change, or (in Manual mode) a beads issue or epic, check the current branch name first.
+Whenever you are working on a Linear story or OpenSpec change, check the current branch name first.
 If it does not correspond to the story, change, or issue you're working on, pause to ask the user whether to create or switch to a matching branch before proceeding.
 
 Branch naming follows the pattern `ID-descriptor` in lowercase kebab-case, where ID references the work item's tracker:
 
 - **Linear / OpenSpec (primary):** Use the Linear story identifier or the OpenSpec change ID the branch implements.
-- **Manual mode with beads** (`.beads/` exists): Use the beads issue ID with dots replaced by dashes.
-  Examples: `nix-pxj-ntfy-server` (epic), `nix-pxj-4-deploy-validate` (task under epic), `nix-i37-fix-flake-lock` (standalone issue).
 - **GitHub-only repos**: Use the issue or PR number.
   Examples: `42-refactor-auth`, `1337-add-feature`.
 
@@ -120,7 +84,7 @@ Never use forward slashes in branch names as they break compatibility with URLs,
 
 Create a new working branch when your next commits won't match the current branch's ID-descriptor:
 
-- Example: current branch is `nix-pxj-4-deploy-validate` but you discover issue `nix-di8` needs fixing first → create `nix-di8-fix-dependency`
+- Example: current branch is `team-1a2b-deploy-validate` but you discover story `team-3c4d` needs fixing first → create `team-3c4d-fix-dependency`
 - When the unit of work is complete and tests pass, offer to integrate to main
 
 To isolate work in a new branch:
@@ -173,18 +137,10 @@ See the integration strategies section in `~/.claude/skills/jj-version-control/S
 
 ### Stack management
 
-Branch stacks mirror the dependency structure of the Linear stories or OpenSpec changes they implement (beads issue dependencies in Manual mode): when work items form a dependency chain (e.g., `nix-pxj.2` blocks `nix-pxj.3`), the corresponding branches should form a stack with matching parent-child relationships.
+Branch stacks mirror the dependency structure of the Linear stories or OpenSpec changes they implement: when work items form a dependency chain, the corresponding branches should form a stack with matching parent-child relationships.
 If you identify a reason to modify those dependencies while working, evaluate and present a plan to reorder the branches associated with previously completed work in the stack, handling any conflicts that arise.
-
-In git-native mode, use the graphite CLI (invoke as `graphite`, not `gt` as shown in official documentation) to manage stacks:
-
-- `graphite log` — view branch stack relationships
-- `graphite track` — register an existing branch with graphite, selecting its parent
-- `graphite create -m "message"` — create a new branch stacked on current, with initial commit
-
-In GitButler mode, native stack operations replace graphite entirely.
-`but branch new -a`, `but branch move`, and `but move` provide all stack management without an external tool.
-See `~/.claude/skills/gitbutler-but-cli/SKILL.md` for the full command reference.
+In git-native mode, manage stacks with the graphite CLI (invoke as `graphite`, not `gt`): `graphite log` views stack relationships, `graphite track` registers an existing branch with its parent, `graphite create -m "message"` creates a stacked branch.
+In GitButler mode, `but branch new -a`, `but branch move`, and `but move` replace graphite entirely; see `~/.claude/skills/gitbutler-but-cli/SKILL.md` for the full command reference.
 
 ## Merge strategy selection
 

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-prose-clarity/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-prose-clarity/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: preferences-prose-clarity
+description: Sentence-level prose discipline grounded in reader-expectations research (Gopen & Swan, Pinker, Williams, Thomas & Turner, McEnerney). Use when writing or editing any prose — documentation, commit messages, working notes, published AGENTS.md or CLAUDE.md files, reports, PR descriptions — when reviewing text for clarity or AI-writing patterns, when calibrating certainty of claims, or when making the smallest safe repair to someone else's text.
+---
+
+# Prose clarity
+
+Every rule below serves one criterion: minimize reader processing cost.
+The grounding is Williams, Gopen & Swan, Pinker, Thomas & Turner, and McEnerney; reason from those frameworks, not Strunk & White folklore.
+
+## The rules
+
+1. Curse of knowledge: before writing, name the intended reader.
+    Define any term that reader would pause on.
+    Give a one-sentence map before a multi-paragraph argument.
+2. Old before new: open sentences with information the reader already has (topic position); land the key new information at the end (stress position).
+    Reorder before you cut.
+3. Characters as subjects, actions as verbs: repair nominalizations ("the failure of X to act" becomes "X failed to act"), except technical terms and nouns serving as the established topic.
+4. Locality: keep subject, verb, and object close; avoid center-embedding; split sentences over ~30 words; vary sentence length and structure.
+5. Cohesion and coherence: within a paragraph, keep a consistent topic thread across sentence subjects, and make exactly one stated point.
+    For multi-paragraph text, fix the point and structure first, sentences second.
+6. Concreteness: prefer specific words over abstractions; replace vague evaluation with a mechanism, action, or measure.
+7. Calibrated claims: match certainty to evidence.
+    Keep hedges that carry information ("suggests", "n=3", "consistent with", confidence intervals); cut hedges that carry none ("it's worth noting", "arguably", throat-clearing openers).
+    Never strip epistemic qualifiers from scientific or technical claims.
+8. Passive voice is correct when the agent is unknown or irrelevant, or when it serves rules 2 or 5; otherwise prefer active.
+9. No slop: no formulaic scaffolding ("In today's …", "Here's the thing", "Let's dive in"); no "it's not X, it's Y" tics; no stock phrases or dead metaphors ("game-changer", "leverage", "delve", "landscape"); no transition chains ("Additionally… Furthermore… Moreover"); no paragraph-closing recaps or moralizing codas; no converting prose to bullets unless the content is a genuine list; one consistent term per concept; never fabricate citations, numbers, or support.
+10. Stance: default to classic style — direct, confident, prose as a transparent window, reader as an intellectual equal.
+    Frame the text inside the reader's problem, not the writer's process.
+11. Editing others' text: make the smallest repair that fixes a confirmed defect; preserve facts, quantities, names, dates, quotes, code, units, scope, attribution, register, voice, and epistemic qualifiers; add no claims; prefer a no-op over an uncertain edit.
+12. Escape hatch: break any rule here sooner than write something awkward or ambiguous.
+    When rules conflict, minimize reader processing cost.
+
+## Highest-blast-radius prose
+
+Published, binding, or long-lived prose — repo-level AGENTS.md and CLAUDE.md files, specs, API-adjacent docs — gets strong care under this skill, not fast decisions.
+For such files, name the cold reader explicitly: an agent or human with no ambient context about the machines, conventions, or history the author takes for granted.
+
+## Related skills
+
+For bulk de-slopping of AI-generated text, use the `unslop` skill's audit and two-pass rewrite flow; this skill supplies the standing criteria it operates under.
+For document structure, frontmatter, and provenance conventions, see `preferences-documentation`.
+For file-level markdown formatting and naming, see `preferences-style-and-conventions`.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
@@ -108,10 +108,12 @@ See `preferences-validation-assurance` for the severity criterion and confidence
 ### CI workflow log verification
 
 When validating changes for merge, retrieve and analyze complete workflow logs across both CI backends (GitHub Actions and buildbot-nix) via the recipes in the `ci-log-verification` skill: wait with `gh run watch`, download full log archives, and use `PAGER=cat gh pr checks <N>` to route each check to its backend before analysis.
+
+### CLI tools and repository lookup
 - Use performant CLI tools matched to task intent:
   - File search (by name/path): use `fd` instead of `find`
   - Content search (within files): use `rg` (ripgrep) instead of `grep`
   - Disk usage (directory sizes): use `diskus` instead of `du -sh`
   - Clipboard (copy to system clipboard): use `cb copy` (`clipboard-jh`) instead of platform-specific `pbcopy` (macOS) or `xclip`/`xsel` (Linux)
   - Notification (push alert to user): use `ntfy-send "<message>"` where `<message>` includes the repo name and summarizes the completed task (default topic is the local hostname; override with `ntfy-send "<message>" <topic>`)
-- When a repository is named, or a substantive technical claim is about to rest on a project's source, options, defaults, API, or upstream documentation, resolve it to a local copy before reasoning about it; see `dependency-source-acquisition` for both lookup categories, the `(see local)` marker directive, and GitHub file, issue, and PR URL handling.
+- When a repository is named, or a substantive technical claim is about to rest on a project's source, options, defaults, API, or upstream documentation, resolve it to a local copy before reasoning about it; see `dependency-source-acquisition` for both lookup kinds, the `(see local)` marker directive, and GitHub file, issue, and PR URL handling.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
@@ -98,7 +98,6 @@ Specify how each commit or collection of changes will be verified as useful prog
 This checkpoint converts abstract plans into auditable intentions, reducing rework from misaligned assumptions.
 For each proposed change, identify the confidence level the verification plan is expected to achieve and whether the verification would be severe — would it fail under plausible incorrect implementations?
 See `preferences-validation-assurance` for the severity criterion and confidence promotion chain.
-When working within a beads issue graph, map each proposed file change to the issue it addresses and confirm the change will satisfy that issue's acceptance criteria.
 
 - Always at least consider testing changes with the relevant framework like bash shell commands where you can validate output, `shellcheck` for shell scripts, `cargo test`, `pytest`, `vitest`, `nix eval` or `nix build`, a task runner like `just test` or `make test`, or `gh workflow run` before considering any work to be complete and correct.
 - Be judicious about test execution. If a test might take a very long time, be resource-intensive, or require elevated security privileges but is important, pause to provide the proposed command and reason why it's an important test.
@@ -108,80 +107,11 @@ When working within a beads issue graph, map each proposed file change to the is
 
 ### CI workflow log verification
 
-When validating changes for merge, verify CI results by downloading and analyzing complete workflow logs rather than piecing together fragments via repeated API calls.
-
-Wait for relevant workflows to complete:
-```bash
-gh run watch <run_id>
-# or poll with: gh run list --branch <branch> --status completed
-```
-
-Download the complete logs archive:
-```bash
-run_id=<run_id>
-mkdir -p logs
-gh api "repos/<owner>/<repo>/actions/runs/${run_id}/logs" > "logs/gha-${run_id}.zip"
-unzip -d "logs/gha-${run_id}" "logs/gha-${run_id}.zip"
-```
-
-Survey available jobs and steps:
-```bash
-tree --du -ah "logs/gha-${run_id}"
-```
-
-#### Unified PR check log retrieval
-
-Given only a pull request number, the unified entry point for discovering which checks ran and where their logs live is `PAGER=cat gh pr checks <N>`.
-This command emits one row per check with a direct link, spanning both CI backends used by repositories in this workspace.
-GitHub Actions rows link to `https://github.com/<owner>/<repo>/actions/runs/<run_id>/job/<job_id>`.
-Buildbot-nix rows link to `https://buildbot.scientistexperience.net/#/builders/<builder_id>/builds/<build_number>` and correspond to the `buildbot/nix-eval` and `buildbot/nix-build` status checks described in `preferences-nix-ci-cd-integration`.
-
-Use the JSON output to separate the two categories and drive automation:
-```bash
-gh pr checks <N> --json name,link \
-  | jq -r '.[] | select(.name | test("^buildbot/")) | .link'
-gh pr checks <N> --json name,link \
-  | jq -r '.[] | select(.link | test("/actions/runs/")) | .link'
-```
-
-Route each link to its backend-specific log-download recipe, writing artifacts under a single `logs/` directory (already gitignored):
-```bash
-mkdir -p logs
-
-# GitHub Actions — extract <run_id> from the /runs/<run_id>/job/... URL path
-run_id=<run_id>
-gh api "repos/<owner>/<repo>/actions/runs/${run_id}/logs" > "logs/gha-${run_id}.zip"
-unzip -d "logs/gha-${run_id}" "logs/gha-${run_id}.zip"
-
-# Buildbot-nix — extract <builder_id> and <build_number> from the fragment
-# /#/builders/<builder_id>/builds/<build_number>
-builder_id=<builder_id>
-build_number=<build_number>
-buildbot-logs "${builder_id}" "${build_number}" > "logs/buildbot-${builder_id}-${build_number}.log"
-```
-
-The `buildbot-logs` shell application is defined in this repository; see `preferences-nix-ci-cd-integration` for its interface, ssh transport, and authentication model.
-After download, survey each artifact before dispatching subagents for targeted analysis:
-```bash
-tree --du -ah "logs/gha-${run_id}"
-rg "error:" "logs/buildbot-${builder_id}-${build_number}.log"
-```
-
-Dispatch subagent Tasks to analyze specific log files for the problem at hand rather than manually reading large logs inline.
-This approach provides a complete, well-organized view of CI results and avoids the antipattern of fragmented API-based log retrieval that never yields a clear picture of what happened.
+When validating changes for merge, retrieve and analyze complete workflow logs across both CI backends (GitHub Actions and buildbot-nix) via the recipes in the `ci-log-verification` skill: wait with `gh run watch`, download full log archives, and use `PAGER=cat gh pr checks <N>` to route each check to its backend before analysis.
 - Use performant CLI tools matched to task intent:
   - File search (by name/path): use `fd` instead of `find`
   - Content search (within files): use `rg` (ripgrep) instead of `grep`
   - Disk usage (directory sizes): use `diskus` instead of `du -sh`
   - Clipboard (copy to system clipboard): use `cb copy` (`clipboard-jh`) instead of platform-specific `pbcopy` (macOS) or `xclip`/`xsel` (Linux)
   - Notification (push alert to user): use `ntfy-send "<message>"` where `<message>` includes the repo name and summarizes the completed task (default topic is the local hostname; override with `ntfy-send "<message>" <topic>`)
-- When the user mentions a git repository by name (from GitHub or any other forge), or you are about to state a substantive technical claim grounded in a software project's source, options, defaults, API, or upstream documentation — first check for a local copy before reaching for web tools or asking the user for context. Treat the lookup as default for such claims; bypass it only with explicit justification. Settle the identity before routing, because the authorship test cannot be evaluated without knowing the org: a fully-qualified `org/repo` or a forge URL settles it outright, while a bare name that may match many repositories calls for `gh search repos <name>`, and when more than one plausible match survives, ask the user which they meant rather than guessing. Then route by authorship. *Category 1* is a repository we develop or maintain — we cut releases or land commits upstream — and lives under `~/projects/<topic>-workspace/<repo>/`. *Category 2* is a third-party dependency or research-reference repository we consult but do not maintain, and lives under `~/ghq/<host>/<org>/<repo>`.
-- Category 2 lookup, under `~/ghq/`: `ghq list -p <name>` is authoritative because it walks the filesystem directly rather than consulting an index, while `zoxide query -l <name>` is a fast-path cache only, so validate any hit against `ghq list -p` before relying on it. On hit: treat the local path as the source of truth and use `~/ghq/...` paths in subsequent prompts and writeups. On miss: acquire the repo with `ghq-sync <url>`, which clones shallow and blobless and registers the path with zoxide, where a raw `ghq get` clones without registering. Prefer the canonical upstream; acquire a personal fork only when contribution back to upstream is anticipated. Never ask the user to clone a Category-2 repository into `~/projects/`. See the `dependency-source-acquisition` skill for the full flow.
-- Category 1 lookup, under `~/projects/`. The steps:
-  1. Search the full tree: `fd -t d -d 4 '^<repo>$' ~/projects` (the canonical layout is `~/projects/<topic>-workspace/<repo>/`, but copies may live elsewhere; repo names can have variants such as `<repo>.jl` or `<repo>-rs`).
-  2. Verify the match: `cd candidate-dir && git remote -v` to confirm the origin matches the expected forge URL. Name collisions are common with single-token repo names, so this step is required, not optional, before treating a candidate as authoritative.
-  3. On hit: treat the local path as the source of truth. Dispatch subagent Tasks to that path for research, reference, or comparison, and use `~/projects/...` paths in subsequent prompts and writeups.
-  4. On miss: surface the failure to the user and ask them to clone or fork the repo to `~/projects/<topic>-workspace/<repo>/` (or to provide the path if it lives elsewhere) before proceeding. Do not silently fall back to `WebFetch`/`WebSearch` for substantive research when a local copy would be more authoritative; web tools remain appropriate only for genuinely web-native content (release notes pages, issue discussions, blog posts). When surfacing the miss, propose the exact command: `git clone <url> ~/projects/<topic>-workspace/<repo>/` for reference-only work, or `gh repo fork <org>/<repo> --clone --remote -- ~/projects/<topic>-workspace/<repo>/` when contribution back to upstream is anticipated. Pause the work thread until the clone is in place or the user provides an alternative path.
-- When given a GitHub file URL (e.g., `https://github.com/org/repo/blob/ref/path/to/file.ext#L119-L131`), apply the lookup above for `repo`, then Read the file with the line range. Use `WebFetch` only if no local copy exists and the user has declined to clone.
-- When given a GitHub issue/PR URL (e.g., `https://github.com/org/repo/issues/2491`), use `gh issue view 2491 -R org/repo` or `gh pr view 2491 -R org/repo` to access discussion content and metadata.
-- When the user appends `(see local)` — or a close variant such as `(see local clone)` or `(local)` — to a name, treat it as a mandatory directive to apply the lookup above for that name *before* responding. The marker removes the "could plausibly identify a git repository" judgment from the trigger bullet above: with the marker present, the lookup is unconditional. Do not answer from general knowledge, do not reach for `WebFetch`/`WebSearch`, and do not ask whether a clone exists. If the lookup returns no hit, fall through to that category's on-miss handling: the Category-1 clone request, or `ghq-sync <url>` for Category 2.
+- When a repository is named, or a substantive technical claim is about to rest on a project's source, options, defaults, API, or upstream documentation, resolve it to a local copy before reasoning about it; see `dependency-source-acquisition` for both lookup categories, the `(see local)` marker directive, and GitHub file, issue, and PR URL handling.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/apm.yml
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/apm.yml
@@ -1,6 +1,6 @@
 name: preferences-code-and-collaboration-conventions
 version: 0.0.0
-description: Code and collaboration conventions — style and conventions, documentation, git version control, git history cleanup, change management.
+description: Code and collaboration conventions — style and conventions, documentation, git version control, git history cleanup, change management, prose clarity, essential complexity.
 dependencies:
   apm:
     # unslop as a walked remote dep pinned to the full 40-char SHA. The repo root is

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/plugin.json
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "preferences-code-and-collaboration-conventions",
   "version": "0.0.0",
-  "description": "Code and collaboration conventions — style and conventions, documentation, git version control, git history cleanup, change management."
+  "description": "Code and collaboration conventions — style and conventions, documentation, git version control, git history cleanup, change management, prose clarity, essential complexity."
 }

--- a/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-ci-cd-integration/SKILL.md
+++ b/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-ci-cd-integration/SKILL.md
@@ -143,7 +143,7 @@ buildbot-logs <builder_id> <build_number> > "logs/buildbot-<builder_id>-<build_n
 ```
 Set `BUILDBOT_INCLUDE_HIDDEN=1` to include steps marked hidden.
 Authentication uses the buildbot http basic auth password read from sops-decrypted secrets on the master, so the invoking user must have ssh access to the buildbot host and non-interactive sudo privileges to read that secret.
-See the "Unified PR check log retrieval" subsection in `preferences-style-and-conventions` for the cross-backend entry point (`gh pr checks <N>`) that produces the builder/build inputs alongside GitHub Actions run ids.
+See the "Unified PR check log retrieval" section in the `ci-log-verification` skill for the cross-backend entry point (`gh pr checks <N>`) that produces the builder/build inputs alongside GitHub Actions run ids.
 
 Cross-reference `references/buildbot-nix-configuration.md` for the full `buildbot-nix.toml` schema, GitHub App permissions, worker configuration, and effect pipeline details.
 

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/dependency-source-acquisition/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/dependency-source-acquisition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-source-acquisition
-description: Resolve a named repository to a local copy before reasoning about it, and acquire one when missing. Covers both lookup categories: Category 1 (repositories we maintain, under ~/projects/<repo>) and Category 2 (third-party and reference repositories, under ~/ghq via ghq). Use whenever a repository is named in a task, when about to state a substantive technical claim grounded in a project's source, options, defaults, API, or upstream documentation, when resolving a package's source-repository URL from cargo/uv/bun/nix metadata, when a "(see local)" marker is appended to a name, or when given a GitHub file, issue, or PR URL.
+description: Resolve a named repository to a local copy before reasoning about it, and acquire one when missing. Covers both lookup kinds: maintained repositories under ~/projects/<repo> and reference repositories under ~/ghq via ghq. Use whenever a repository is named in a task, when about to state a substantive technical claim grounded in a project's source, options, defaults, API, or upstream documentation, when resolving a package's source-repository URL from cargo/uv/bun/nix metadata, when a "(see local)" marker is appended to a name, or when given a GitHub file, issue, or PR URL.
 ---
 
 # Dependency source acquisition
@@ -14,12 +14,11 @@ Resolve the org first: a bare name is often ambiguous — `gh search repos <name
 A fully-qualified `org/repo` or a forge URL settles identity outright; when more than one plausible match survives a search, ask which one was meant rather than guessing.
 
 Then branch on authorship.
-The distinguishing question: if we cut releases or land commits upstream it is Category 1; if we only read it, it is Category 2.
+The distinguishing question: if we cut releases or land commits upstream it is a maintained repo; if we only read it, it is a reference repo.
 
-## Category 1 lookup — repositories we maintain
+## Maintained-repo lookup
 
-Category 1 lives under `~/projects/<repo>/` (copies may sit deeper; repo names can have variants such as `<repo>.jl` or `<repo>-rs`).
-The firstmate home at `~/firstmate` is itself a maintained repository.
+Maintained repositories live under `~/projects/<repo>/` (copies may sit deeper; repo names can have variants such as `<repo>.jl` or `<repo>-rs`).
 
 1. Search the tree: `fd -t d -d 4 '^<repo>$' ~/projects`
 2. Verify the match: `cd <candidate> && git remote -v` to confirm the origin matches the expected forge URL.
@@ -27,13 +26,23 @@ The firstmate home at `~/firstmate` is itself a maintained repository.
 3. On hit: treat the local path as the source of truth, dispatch research subagents to it, and use that path in prompts and writeups.
 4. On miss: surface the failure to the user and ask them to clone it to `~/projects/<repo>/` (or provide the path if it lives elsewhere) before proceeding; propose the exact command — `git clone <url> ~/projects/<repo>/` for reference-only work, or `gh repo fork <org>/<repo> --clone --remote -- ~/projects/<repo>/` when contribution back upstream is anticipated.
    Do not silently fall back to web tools for substantive research when a local copy would be more authoritative; web tools remain appropriate only for genuinely web-native content (release notes, issue discussions, blog posts).
+   Pause the work thread until the clone is in place or the user provides an alternative path.
 
-Never ask the user to clone a Category-2 repository into `~/projects/`.
+Never ask the user to clone a reference repo into `~/projects/`.
+
+## Reference-repo lookup
+
+The gate is `ghq list -p <name>` (under "Engine: ghq" below): authoritative because it walks the filesystem directly rather than consulting an index.
+`zoxide query -l <name>` is a fast-path cache only — validate any hit against `ghq list -p` before relying on it.
+On a miss, acquire the repository with `ghq-sync <url>`, which clones shallow and blobless and registers the path with zoxide; a raw `ghq get` clone does not register.
+Prefer the canonical upstream; acquire a personal fork only when contribution back to upstream is anticipated.
+A shallow clone sits at HEAD, which is usually not the revision we pin — read at the pinned revision or every line anchor you cite will be wrong.
+This fleet configures `ghq root` to `~/ghq`, so `$(ghq root)/<host>/<org>/<repo>` and `~/ghq/<host>/<org>/<repo>` coincide.
 
 ## The `(see local)` marker
 
 When the user appends `(see local)` — or a close variant such as `(see local clone)` or `(local)` — to a name, the lookup above is unconditional: do not answer from general knowledge, do not reach for web tools, and do not ask whether a clone exists.
-If the lookup returns no hit, fall through to that category's on-miss handling above.
+If the lookup returns no hit, fall through to that category's on-miss handling: the maintained-repo clone request above, or the `ghq-sync` acquisition under "Reference-repo lookup" above.
 
 ## GitHub URL handling
 
@@ -56,14 +65,13 @@ ghq list             # prints host/owner/repo (relative paths) for everything al
 
 A hit means the source is already local — review it in place, do not re-clone.
 
-On a miss, fetch lazily — shallow, blobless, no submodules — which is enough to review the current tree:
+On a miss, fetch with `ghq-sync <url>`, which performs the lazy clone — shallow, blobless, no submodules, enough to review the current tree — and registers the path with zoxide:
 
 ```bash
-ghq get --shallow --partial blobless --no-recursive <host>/<owner>/<repo>
-# also accepts a full https URL
+ghq-sync <url>   # shallow + blobless clone into $(ghq root)/<host>/<org>/<repo>, registered with zoxide
 ```
 
-`--shallow` is depth-1, `--partial blobless` is a blobless partial clone, and `--no-recursive` skips submodules.
+The lower-level `ghq get --shallow --partial blobless --no-recursive <host>/<owner>/<repo>` performs the same clone without registering the path with zoxide; use it only when registration is unwanted, and complete registration manually otherwise.
 
 When the review needs full history, blame, or submodule contents, promote the lazy clone to a full one.
 `ghq get -u` only updates the existing clone in place — it runs a fast-forward pull or fetch and leaves the clone grafted (shallow) and blobless — so it does not promote a lazy clone to full.

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/dependency-source-acquisition/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/dependency-source-acquisition/SKILL.md
@@ -1,19 +1,44 @@
 ---
 name: dependency-source-acquisition
-description: Acquire a correct local copy of a dependency's or research-reference repo's upstream source and review it whole, instead of reading it one file at a time through the GitHub API or web UI. Use when acquiring or reviewing the source of a Category-2 dependency or reference repo, downloading upstream source to study locally, resolving a package's source-repository URL from cargo/uv/bun/nix metadata, or working with ghq to clone and catalog upstream sources.
+description: Resolve a named repository to a local copy before reasoning about it, and acquire one when missing. Covers both lookup categories: Category 1 (repositories we maintain, under ~/projects/<repo>) and Category 2 (third-party and reference repositories, under ~/ghq via ghq). Use whenever a repository is named in a task, when about to state a substantive technical claim grounded in a project's source, options, defaults, API, or upstream documentation, when resolving a package's source-repository URL from cargo/uv/bun/nix metadata, when a "(see local)" marker is appended to a name, or when given a GitHub file, issue, or PR URL.
 ---
 
 # Dependency source acquisition
 
 ## When to fire
 
-When working in — or researching for potential inclusion — a dependency or reference repository we do not primarily maintain, acquire a correct local copy of its upstream source and review it as a whole, rather than fetching one file at a time through the GitHub API or web UI.
+When a repository is named — or a substantive technical claim is about to rest on a project's source, options, defaults, API, or upstream documentation — check for a local copy first; treat the lookup as the default and bypass it only with explicit justification.
 Whole-tree review with `rg`, `fd`, and direct file reads surfaces cross-file structure, call sites, and conventions that piecemeal API fetches miss, and it costs one clone instead of many round trips.
 
-This skill governs Category 2 only.
-Category 1 — repositories we develop or maintain — stays under `~/projects/<topic>-workspace/<repo>/` per the `~/projects/` lookup convention in preferences-style-and-conventions.
-Category 2 — third-party dependencies and research-reference repositories we consult but do not maintain — is acquired and cataloged through ghq, described below.
-The distinguishing question is authorship: if we cut releases or land commits upstream it is Category 1; if we only read it, it is Category 2.
+Resolve the org first: a bare name is often ambiguous — `gh search repos <name>` returns dozens of matches for a common word — and the org determines everything downstream.
+A fully-qualified `org/repo` or a forge URL settles identity outright; when more than one plausible match survives a search, ask which one was meant rather than guessing.
+
+Then branch on authorship.
+The distinguishing question: if we cut releases or land commits upstream it is Category 1; if we only read it, it is Category 2.
+
+## Category 1 lookup — repositories we maintain
+
+Category 1 lives under `~/projects/<repo>/` (copies may sit deeper; repo names can have variants such as `<repo>.jl` or `<repo>-rs`).
+The firstmate home at `~/firstmate` is itself a maintained repository.
+
+1. Search the tree: `fd -t d -d 4 '^<repo>$' ~/projects`
+2. Verify the match: `cd <candidate> && git remote -v` to confirm the origin matches the expected forge URL.
+   Name collisions are common with single-token repo names, so this step is required, not optional, before treating a candidate as authoritative.
+3. On hit: treat the local path as the source of truth, dispatch research subagents to it, and use that path in prompts and writeups.
+4. On miss: surface the failure to the user and ask them to clone it to `~/projects/<repo>/` (or provide the path if it lives elsewhere) before proceeding; propose the exact command — `git clone <url> ~/projects/<repo>/` for reference-only work, or `gh repo fork <org>/<repo> --clone --remote -- ~/projects/<repo>/` when contribution back upstream is anticipated.
+   Do not silently fall back to web tools for substantive research when a local copy would be more authoritative; web tools remain appropriate only for genuinely web-native content (release notes, issue discussions, blog posts).
+
+Never ask the user to clone a Category-2 repository into `~/projects/`.
+
+## The `(see local)` marker
+
+When the user appends `(see local)` — or a close variant such as `(see local clone)` or `(local)` — to a name, the lookup above is unconditional: do not answer from general knowledge, do not reach for web tools, and do not ask whether a clone exists.
+If the lookup returns no hit, fall through to that category's on-miss handling above.
+
+## GitHub URL handling
+
+Given a GitHub file URL (e.g. `https://github.com/org/repo/blob/ref/path#L119-L131`), apply the lookup for `repo`, then read the file with the line range.
+Given an issue or PR URL (e.g. `https://github.com/org/repo/issues/2491`), use `gh issue view 2491 -R org/repo` or `gh pr view 2491 -R org/repo`.
 
 ## Engine: ghq
 
@@ -132,4 +157,4 @@ On a gap, fall back to `https://pypi.org/pypi/<pkg>/json` `.info.project_urls` (
 Once the source is local, review the whole tree with `rg`, `fd`, and file reads rather than fetching individual files through the GitHub API.
 Record nothing extra: `ghq list` is the catalog, so there is no manifest to maintain.
 
-The `~/projects/` Category-1 lookup convention in preferences-style-and-conventions is the policy anchor for this skill; this skill is its Category-2 arm.
+This skill is the canonical home for both lookup categories; the global context file's session protocol and the style skill both defer to it.

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/SKILL.md
@@ -75,8 +75,7 @@ The combined signal means the agent should adopt the jj workflow described in th
 
 For quick command orientation, see `~/.claude/skills/jj-summary/SKILL.md`.
 For comprehensive command reference, see `~/.claude/skills/jj-workflow/SKILL.md`.
-For git-mode equivalents and beads integration, see `~/.claude/skills/preferences-git-version-control/SKILL.md`.
-For beads command quick reference, see `~/.claude/skills/issues-beads-prime/SKILL.md`.
+For git-mode equivalents, see `~/.claude/skills/preferences-git-version-control/SKILL.md`.
 
 ## Bookmark workflow
 
@@ -117,7 +116,7 @@ Three tiers govern when bookmarks become necessary:
 2. *Second chain initiated*: bookmarks become required for both chains.
    Bookmark the existing chain tip, create a new chain from main, bookmark its tip, then create a multi-parent `@` over both.
 
-3. *Beads epic session*: create bookmarks at session start following the `{epic-ID}-descriptor` naming convention.
+3. *Tracked work-item session*: when working a Linear story or OpenSpec change, create bookmarks at session start following the `{issue-ID}-descriptor` naming convention.
 
 The discipline is "create bookmarks at the moment you need to distinguish chains" — not "always create a bookmark before working."
 
@@ -138,6 +137,11 @@ Recovery patterns:
 - Concurrent operations created divergence: inspect with `jj log` and resolve with `jj bookmark set`
 
 The operation log is your safety net - use it fearlessly.
+
+## Working-copy hazards
+
+Three headlines govern every hazard: never relocate `@` off the wip join; path-scope every squash and check for `(divergent)` and `wip??` before squashing; treat surprising reads of shared state as transients until `jj op log` says otherwise.
+The full catalog — splice impossibility, the clan-install second child, the `wip` bookmark slide, snapshot size gating, foreign modifications from concurrent sessions, auto-rebase id stability, and worktree interop with external frameworks — lives in [hazards.md](hazards.md).
 
 ## Conflict management
 

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/hazards.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/hazards.md
@@ -54,17 +54,5 @@ Recovery for the second is `jj undo`; the first needs nothing.
 
 ## Worktree interop
 
-The worktree-creating surfaces are ask-gated rather than denied.
-Answer affirmatively only when a separate filesystem tree is itself the point, and otherwise stay on the development join.
-In a flake repository that tree must be a git worktree rather than `jj workspace add`.
-
-The discipline is exclusive branch ownership and return-by-ref.
-A branch belongs to the jj primary or to one worktree, never both, so never point a worktree at a bookmark on or under the primary's `@` or at one a live development join includes.
-Work returns by ref: commit in the worktree, let the primary import it, then integrate with `jj new <branch>` or `jj bookmark set <target> -r <branch>`.
-
-The primary's HEAD stays detached throughout; that is healthy and never drift to repair.
-Never run `git checkout` or `git switch` to reattach, `git checkout -f`, `git branch -D`, or `git fetch --prune`, and never use `git stash` in a jj working copy.
-If jj moves a bookmark a worktree holds, that worktree's HEAD detaches at the old commit with files intact; recover with `git symbolic-ref HEAD refs/heads/<branch>`.
-Ref deletion is the destructive class here, and its recovery is the same top-level `jj undo`.
-
-An external agent framework such as firstmate gets its own clone rather than a symlink to a working copy we also use, because its fleet-sync runs exactly the operations forbidden above.
+`jj-version-control/SKILL.md` §"Worktree interop" is the authority for worktree mechanics — it carries the jj-version provenance and upstream citations this file does not, and the worktree-surface hook messages point there.
+The summary: worktree-creating surfaces are ask-gated; a flake repository's separate tree must be a git worktree rather than `jj workspace add`; the discipline is exclusive branch ownership and return-by-ref; and an external agent framework such as firstmate gets its own clone rather than a symlink to a working copy we also use.

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/hazards.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/hazards.md
@@ -1,0 +1,70 @@
+# jj working-copy hazards
+
+Full catalog of working-copy hazards for jj development joins, folded from the global context file.
+The global context keeps the headline rules; this file holds the detail and recovery procedures.
+See `SKILL.md` for the development-join invariant this catalog protects.
+
+## Splice impossibility below the join
+
+Splicing chain-bound content is often structurally impossible.
+An edit whose anchor was created by a chain commit has no anchor below the join, so a splice-below-join instruction cannot be satisfied and fails in a way that looks like a jj bug.
+Refuse such an instruction and ask.
+
+## `clan machines install` mints a second child
+
+`clan machines install` makes its own git commit mid-run (message form `inventory.json: update install time of <machine>`).
+jj imports the HEAD move and mints a working-copy commit on top, so the join gains a second child and the change exists twice, in jj's wip snapshot and in clan's commit.
+Verify `jj diff --from <clan-commit> --to <wip>` is empty before folding.
+
+## `wip` bookmark slide on exhausted `@`
+
+A `--from @` squash that empties `@` slides the pushed `wip` bookmark down onto the join.
+Machines rebuild from that bookmark, so restore it with `jj bookmark set wip -r @`.
+
+## Snapshot size gating is new-files-only
+
+`snapshot.max-new-file-size` gates new files only.
+Once jj tracks a file, every later snapshot ingests it whole at any size, and only a gitignore entry prevents that.
+Never download into a working copy.
+
+## Foreign modifications are concurrent sessions
+
+A concurrent session's uncommitted work appears in your `jj status` as a foreign modification, then vanishes when that session commits it, which reads as a file mutating itself.
+Do not chase it or revert it.
+
+## One file per agent is not isolation
+
+jj snapshots the entire working copy rather than the file an agent touched, so concurrent editors can still produce divergent commits and a conflicted `wip??` bookmark.
+A wholesale `--from @` squash sweeps a concurrent session's work into your chain, so path-scope every squash; the scoping protects only the routing.
+Check for `(divergent)` and `wip??` before squashing.
+A subagent is the sole editor of one chain, never of the working copy.
+
+## Auto-rebase changes commit ids, not content
+
+Auto-rebase moves the commit ids on your own chain when a neighbour splices below it.
+Change ids and content are both untouched, so compare a diff digest rather than commit ids to prove nothing changed.
+
+## Surprising reads are transients until `jj op log` says otherwise
+
+`--ignore-working-copy` stops you perturbing the working copy and gives no consistent view across a concurrent rewrite, so `jj diff --stat` reports zero files for a commit that holds content while another session rebases.
+A changed `@` change id is the signature of a destroyed working-copy commit and a promoted one alike.
+Promotion leaves the old change in place with describe, bookmark and rebase entries.
+Destruction shows a squash that omitted `--keep-emptied`, with the old change abandoned.
+Recovery for the second is `jj undo`; the first needs nothing.
+
+## Worktree interop
+
+The worktree-creating surfaces are ask-gated rather than denied.
+Answer affirmatively only when a separate filesystem tree is itself the point, and otherwise stay on the development join.
+In a flake repository that tree must be a git worktree rather than `jj workspace add`.
+
+The discipline is exclusive branch ownership and return-by-ref.
+A branch belongs to the jj primary or to one worktree, never both, so never point a worktree at a bookmark on or under the primary's `@` or at one a live development join includes.
+Work returns by ref: commit in the worktree, let the primary import it, then integrate with `jj new <branch>` or `jj bookmark set <target> -r <branch>`.
+
+The primary's HEAD stays detached throughout; that is healthy and never drift to repair.
+Never run `git checkout` or `git switch` to reattach, `git checkout -f`, `git branch -D`, or `git fetch --prune`, and never use `git stash` in a jj working copy.
+If jj moves a bookmark a worktree holds, that worktree's HEAD detaches at the old commit with files intact; recover with `git symbolic-ref HEAD refs/heads/<branch>`.
+Ref deletion is the destructive class here, and its recovery is the same top-level `jj undo`.
+
+An external agent framework such as firstmate gets its own clone rather than a symlink to a working copy we also use, because its fleet-sync runs exactly the operations forbidden above.

--- a/modules/home/tools/agents-md.nix
+++ b/modules/home/tools/agents-md.nix
@@ -1,5 +1,7 @@
 # AI agent documentation generation
-# Generates unified CLAUDE.md, AGENTS.md, GEMINI.md, CRUSH.md, OPENCODE.md
+# Generates ~/.claude/CLAUDE.md, ~/.codex/AGENTS.md, ~/.factory/AGENTS.md,
+# ~/.gemini/GEMINI.md, ~/.hermes/SOUL.md, ~/.config/crush/CRUSH.md, and
+# ~/.config/opencode/AGENTS.md (plus pi via programs.pi-coding-agent.context)
 # from shared configuration with references to preference documents
 { ... }:
 {
@@ -27,22 +29,12 @@
           2. Are there ambiguities requiring clarification before I proceed?
           3. Would local access to external source code or documentation improve
           this work? Whenever a repository is named, resolve it to a local path
-          before reasoning about it. Resolve the org first: a bare name is often
-          ambiguous — `gh search repos <name>` returns dozens of matches for a
-          common word — and the org determines everything downstream, so when
-          more than one plausible match exists, ask which one rather than
-          guessing. A fully-qualified `org/repo` or a forge URL settles it. Then
-          branch on authorship. A repository we maintain, meaning we cut
-          releases or land commits upstream, lives at
-          `~/projects/<topic>-workspace/<repo>/`; find it with `fd -t d -d 4
-          '^<repo>$' ~/projects`, confirm with `git remote -v`, and on a miss
-          ask the user to clone it there. A repository we only read lives at
-          `~/ghq/<host>/<org>/<repo>`; `ghq list -p <name>` is authoritative
-          because it walks the filesystem, `zoxide query -l <name>` is a cache
-          whose hits must be validated against it, and on a miss `ghq-sync
-          <url>` clones shallow and blobless and registers the path. A shallow
-          clone sits at HEAD, which is usually not the revision we pin, so read
-          at the pinned rev or every line anchor you cite will be wrong.
+          before reasoning about it: resolve the org first, then route by
+          authorship — repositories we maintain live under `~/projects/<repo>/`,
+          repositories we only read live under `~/ghq/<host>/<org>/<repo>/`. The
+          full lookup procedure, on-miss acquisition, and the `(see local)`
+          marker directive live in
+          ${skillsPath}/dependency-source-acquisition/SKILL.md.
           4. Should I present my task decomposition for approval before
           dispatching?
 
@@ -64,6 +56,8 @@
 
           - style and conventions: @${skillsPath}/preferences-style-and-conventions/SKILL.md
           - git version control: @${skillsPath}/preferences-git-version-control/SKILL.md
+          - prose clarity (sentence-level writing discipline, reader processing cost, calibrated claims, editing others' text): ${skillsPath}/preferences-prose-clarity/SKILL.md
+          - essential complexity (complexity pays rent in domain invariants; refinement-chain care scaling; falsifiable rigor, sorry-debt): ${skillsPath}/preferences-essential-complexity/SKILL.md
           - git history cleanup: ${skillsPath}/preferences-git-history-cleanup/SKILL.md
           - comment cleanup (uncomment-driven noise-comment removal, load-bearing marker preservation; operational arm of the code-comments policy): ${skillsPath}/preferences-comment-cleanup/SKILL.md
           - jj version control: ${skillsPath}/jj-summary/SKILL.md
@@ -123,6 +117,7 @@
           - nix flake checks architecture (check taxonomy, derivation patterns, VM tests): ${skillsPath}/preferences-nix-checks-architecture/SKILL.md
           - nix CI/CD integration (nix-fast-build, buildbot-nix, effects, migration): ${skillsPath}/preferences-nix-ci-cd-integration/SKILL.md
           - nix flake PR cycle (enumerate checks, probe via nix eval/build, just check-fast, draft PR, buildbot monitor, ready, Mergify): ${skillsPath}/nix-flake-pr-cycle/SKILL.md
+          - CI workflow log verification (GHA + buildbot unified retrieval, full log archives, buildbot-logs): ${skillsPath}/ci-log-verification/SKILL.md
           - python development: ${skillsPath}/preferences-python-development/SKILL.md
           - rust development: ${skillsPath}/preferences-rust-development/SKILL.md
           - haskell development: ${skillsPath}/preferences-haskell-development/SKILL.md
@@ -137,24 +132,35 @@
           # Temporal provenance awareness
 
           When reading information from multiple files during any task, be alert
-          to potential contradictions between sources. When conflicting or
-          potentially outdated information is detected:
+          to contradictions between sources, and weigh recency of the specific
+          conflicting content over document type: a recently edited working note
+          can supersede an older formal spec, and vice versa.
+          Assess recency through git history, never filesystem mtime — `git log
+          --follow -1 --format='%ai' -- <file>` for file-level provenance, `git
+          blame -L <start>,<end> <file>` for line-level. Flag detected
+          contradictions to the user with provenance evidence — file paths,
+          dates, relevant line ranges — rather than silently choosing one
+          interpretation. The full procedure and its application scope live in
+          ${skillsPath}/preferences-documentation/SKILL.md under "Temporal
+          provenance".
 
-          1. Compare file provenance using git history (not filesystem mtime,
-          which is unreliable after checkout or rebase):
-             - Last commit touching the file:
-             `git log --follow -1 --format='%ai' -- <file>`
-             - Last edit to specific lines: `git blame -L <start>,<end> <file>`
-          2. Assume more recently edited content is more likely to be current.
-          There is no rigid document type hierarchy — a recently edited working
-          note can supersede an older formal spec, and vice versa.
-          3. Flag detected contradictions to the user with provenance evidence
-          (file paths, dates, relevant line ranges) rather than silently
-          choosing one interpretation.
+          # Operating principles
 
-          This applies to all document types: skills, AGENTS.md (or CLAUDE.md)
-          sections, docs/development/ specs, docs/notes/ working notes, and
-          inline code comments.
+          Every element of an artifact — a type, an abstraction, a sentence, a
+          qualifier — must pay rent in invariants enforced or value delivered to
+          its consumer. Stated confidence must match evidence. Uncertainty is
+          information to state precisely, never a substitute for a decision:
+          commit, state the tradeoff taken and what would change your mind.
+          Scale care to blast radius: what binds others (specs, APIs, published
+          prose) gets strong care; what a spec already constrains gets fast
+          decisions. These principles govern artifact-level choices within
+          confirmed intent; the session protocol above governs task-level
+          ambiguity — ask there, commit here. When sections or skills conflict,
+          the more specific scope wins; when in doubt, minimize consumer
+          processing cost — reader or maintainer.
+          Applied per medium:
+          - prose, any writing or editing: ${skillsPath}/preferences-prose-clarity/SKILL.md
+          - code, specs, and proofs: ${skillsPath}/preferences-essential-complexity/SKILL.md
 
           # Engineering standards
 
@@ -180,6 +186,9 @@
           a type-checkable Lean specification beside the implementation and
           closing the spec-to-code gap through refinement and translation
           validation.
+          That ideal governs direction of travel; the operating principles above
+          govern what ships today — nothing lands that does not pay rent in
+          enforced invariants or delivered value.
 
           ## Code comments
 
@@ -261,23 +270,15 @@
 
           When the work involves parallel independent work streams, adversarial
           review, multi-perspective analysis, or long-running collaborative
-          phases, consider using agent teams as a second orchestration mode.
-          Agent teams spawn persistent teammates that coordinate via shared task
-          list and messaging rather than returning results.
-
-          Orchestration mode selection criteria:
-          - DAG dispatch (subagent Tasks): sequential dependencies, focused
-          research, tight orchestrator control, one-shot work items that return
-          a result
-          - Agent teams: parallel independent work streams, adversarial review
-          (e.g. dispatching code-reviewer as a teammate), multi-perspective
-          analysis, long-running collaborative phases
-          - Hybrid: DAG dispatch for initial research, then spawn a team for
-          implementation and review
-
-          For detailed agent team conventions including teammate isolation,
-          Linear/OpenSpec-to-task-list mirroring, and the orient/checkpoint
-          lifecycle, see ${skillsPath}/meta-agent-teams/SKILL.md
+          phases, agent teams are the second orchestration mode: persistent
+          teammates coordinating via shared task list and messaging rather than
+          one-shot results. Selection: DAG dispatch (subagent Tasks) for
+          sequential dependencies, focused research, and tight orchestrator
+          control; agent teams for parallel independent streams and adversarial
+          review; hybrid — DAG research first, then a team for implementation
+          and review. For teammate isolation, Linear/OpenSpec-to-task-list
+          mirroring, and the orient/checkpoint lifecycle, see
+          ${skillsPath}/meta-agent-teams/SKILL.md
 
           # Version control and work dispatch
 
@@ -340,74 +341,31 @@
 
           ## Working-copy hazards
 
-          - Splicing chain-bound content is often structurally impossible. An
-          edit whose anchor was created by a chain commit has no anchor below
-          the join, so a splice-below-join instruction cannot be satisfied and
-          fails in a way that looks like a jj bug. Refuse such an instruction
-          and ask.
-          - `clan machines install` makes its own git commit mid-run (message
-          form `inventory.json: update install time of <machine>`). jj imports
-          the HEAD move and mints a working-copy commit on top, so the join
-          gains a second child and the change exists twice, in jj's wip snapshot
-          and in clan's commit. Verify `jj diff --from <clan-commit> --to <wip>`
-          is empty before folding.
-          - A `--from @` squash that empties `@` slides the pushed `wip`
-          bookmark down onto the join. Machines rebuild from that bookmark, so
-          restore it with `jj bookmark set wip -r @`.
-          - `snapshot.max-new-file-size` gates new files only. Once jj tracks a
-          file, every later snapshot ingests it whole at any size, and only a
-          gitignore entry prevents that. Never download into a working copy.
-          - A concurrent session's uncommitted work appears in your `jj status`
-          as a foreign modification, then vanishes when that session commits it,
-          which reads as a file mutating itself. Do not chase it or revert it.
-          - One file per agent is not isolation. jj snapshots the entire working
-          copy rather than the file an agent touched, so concurrent editors can
-          still produce divergent commits and a conflicted `wip??` bookmark. A
-          wholesale `--from @` squash sweeps a concurrent session's work into
-          your chain, so path-scope every squash; the scoping protects only the
-          routing. Check for `(divergent)` and `wip??` before squashing. A
-          subagent is the sole editor of one chain, never of the working copy.
-          - Auto-rebase moves the commit ids on your own chain when a neighbour
-          splices below it. Change ids and content are both untouched, so
-          compare a diff digest rather than commit ids to prove nothing changed.
-          - A surprising read of shared state is a transient until `jj op log`
-          says otherwise. `--ignore-working-copy` stops you perturbing the
-          working copy and gives no consistent view across a concurrent
-          rewrite, so `jj diff --stat` reports zero files for a commit that
-          holds content while another session rebases. A changed `@` change id
-          is the signature of a destroyed working-copy commit and a promoted
-          one alike. Promotion leaves the old change in place with describe,
-          bookmark and rebase entries. Destruction shows a squash that omitted
-          `--keep-emptied`, with the old change abandoned. Recovery for the
-          second is `jj undo`; the first needs nothing.
+          Three headlines: never relocate `@` off the wip join; path-scope every
+          squash and check for `(divergent)` and `wip??` before squashing; treat
+          surprising reads of shared state as transients until `jj op log` says
+          otherwise. Recovery for the destructive class is top-level `jj undo`;
+          there is no `jj op undo`. The full catalog — splice impossibility
+          below the join, the clan-install second child, the `wip` bookmark
+          slide, snapshot size gating, concurrent-session foreign modifications,
+          auto-rebase commit-id churn — lives in
+          ${skillsPath}/jj-version-control/hazards.md.
 
           ## Worktree interop and external frameworks
 
-          The worktree-creating surfaces are ask-gated rather than denied.
-          Answer affirmatively only when a separate filesystem tree is itself
-          the point, and otherwise stay on the development join. In a flake
-          repository that tree must be a git worktree rather than `jj workspace
-          add`.
-
-          The discipline is exclusive branch ownership and return-by-ref. A
-          branch belongs to the jj primary or to one worktree, never both, so
-          never point a worktree at a bookmark on or under the primary's `@` or
-          at one a live development join includes. Work returns by ref: commit
-          in the worktree, let the primary import it, then integrate with `jj
-          new <branch>` or `jj bookmark set <target> -r <branch>`. The primary's
-          HEAD stays detached throughout; that is healthy and never drift to
-          repair. Never run `git checkout` or `git switch` to reattach, `git
-          checkout -f`, `git branch -D`, or `git fetch --prune`, and never use
-          `git stash` in a jj working copy. If jj moves a bookmark a worktree
-          holds, that worktree's HEAD detaches at the old commit with files
-          intact; recover with `git symbolic-ref HEAD refs/heads/<branch>`. Ref
-          deletion is the destructive class here, and its recovery is the same
-          top-level `jj undo`.
-
-          An external agent framework such as firstmate gets its own clone
-          rather than a symlink to a working copy we also use, because its
-          fleet-sync runs exactly the operations forbidden above. See
-          ${skillsPath}/jj-version-control/SKILL.md for the mechanics.
+          Worktree creation is ask-gated: answer affirmatively only when a
+          separate filesystem tree is itself the point; otherwise stay on the
+          development join. In a flake repository that tree must be a git
+          worktree rather than `jj workspace add`. The discipline is exclusive
+          branch ownership — a branch belongs to the jj primary or to one
+          worktree, never both — and return-by-ref: commit in the worktree,
+          integrate by ref in the primary. The primary's HEAD stays detached
+          throughout; never reattach it, force-checkout, delete branches, `git
+          fetch --prune`, or `git stash` in a jj working copy. An external agent
+          framework such as firstmate gets its own clone rather than a symlink
+          to a working copy we also use, because its fleet-sync runs exactly the
+          operations forbidden above. Full mechanics and recovery:
+          ${skillsPath}/jj-version-control/hazards.md
         '';
       };
     };

--- a/modules/home/tools/agents-md.nix
+++ b/modules/home/tools/agents-md.nix
@@ -66,7 +66,7 @@
           - documentation: ${skillsPath}/preferences-documentation/SKILL.md
           - change management: ${skillsPath}/preferences-change-management/SKILL.md
           - agentic planning and development (state-machine router across the Linear-canonical board Backlog -> Todo -> In Progress -> In Review -> Done; AFK/HIL/Manual execution-mode fork; four file-anchored OpenSpec-artifact forward gates): ${skillsPath}/agentic-planning-development-workflow/SKILL.md
-          - project management (Linear Method ontology, workspace safety gate, ownership-by-layer: Linear + OpenSpec own the work, beads an optional Manual-mode drill-down): ${skillsPath}/project-management/SKILL.md
+          - project management (Linear Method ontology, workspace safety gate, ownership-by-layer: Linear + OpenSpec own the work): ${skillsPath}/project-management/SKILL.md
           - superpowers discipline gate (invoke the relevant skill before any response or action, including clarifying questions; process-skills-first): ${skillsPath}/using-superpowers/SKILL.md
           - session resumption (resume command, atuin history, session continuation): ${skillsPath}/meta-session-resume/SKILL.md
           - session search (session transcript discovery, keyword intersection): ${skillsPath}/meta-search-sessions/SKILL.md
@@ -287,11 +287,11 @@
           When dispatching a Task for implementation work, the dispatched unit
           is an OpenSpec change — typically bound to one Linear story via
           openspec-linear-sync and driven through the
-          agentic-planning-development-workflow router's HIL mode — not a beads
-          issue. The dispatch protocol depends on the active VCS mode. Detect
-          mode at dispatch time: `.jj/` directory present in the repository root
-          indicates jj mode (the default for this workspace); otherwise almost
-          surely git-native mode.
+          agentic-planning-development-workflow router's HIL mode. The dispatch
+          protocol depends on the active VCS mode. Detect mode at dispatch
+          time: `.jj/` directory present in the repository root indicates jj
+          mode (the default for this workspace); otherwise almost surely
+          git-native mode.
 
           See ${skillsPath}/preferences-git-version-control/SKILL.md for
           working-branch isolation conventions and subagent dispatch in each
@@ -365,7 +365,7 @@
           framework such as firstmate gets its own clone rather than a symlink
           to a working copy we also use, because its fleet-sync runs exactly the
           operations forbidden above. Full mechanics and recovery:
-          ${skillsPath}/jj-version-control/hazards.md
+          ${skillsPath}/jj-version-control/SKILL.md under "Worktree interop"
         '';
       };
     };


### PR DESCRIPTION
The agent context this repo generates is standing text paid for eight times over: one body ships to eight sinks, and two skills are `@`-loaded into every session.
This PR applies that cost test to the context file itself — a compact operating-principles section stays in the body, and task-scoped procedures move to indexed skill homes.

## Where the agent context content actually lives

The global context file is generated: `modules/home/tools/agents-md.nix` writes one shared body to eight sinks — `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.factory/AGENTS.md`, `~/.gemini/GEMINI.md`, `~/.hermes/SOUL.md`, the XDG `crush/CRUSH.md` and `opencode/AGENTS.md`, and pi via `programs.pi-coding-agent.context`. Two skills are `@`-loaded into every Claude Code session (`preferences-style-and-conventions`, `preferences-git-version-control`), so prose in those files is paid for twice: once per sink and once per session.

## What changed

- **`feat(skills)`** adds three skills and one reference doc:
  `preferences-prose-clarity` (twelve sentence-level rules grounded in Gopen & Swan, Pinker, Williams, Thomas & Turner, and McEnerney, plus the editing-others protocol and escape hatch), `preferences-essential-complexity` (complexity-pays-rent economics, refinement-chain care scaling, falsifiable rigor; `refinement-driven-development` keeps the Lean-Rust mechanics, this skill the policy), `ci-log-verification` (the GHA + buildbot log-retrieval recipes lifted verbatim from the style skill), and `jj-version-control/hazards.md`, the full working-copy-hazard catalog folded out of the global body.
- **`feat(context)`** rewrites the agents-md body: a new Operating-principles section (rent economics, calibrated confidence, blast-radius care scaling, and the explicit scope split against the session protocol — artifact-level choices commit, task-level ambiguity asks); CI-log and repo-lookup sections replaced by index pointers; temporal-provenance, agent-teams, and worktree sections compressed; jj hazards replaced by three headlines plus a pointer; the stale five-file header comment corrected to the real eight sinks (seven generated files plus pi); maintained-repo lookup path updated to `~/projects/<repo>/`. File: 414 → 372 lines on text replicated eight times.
- **`refactor(skills)`** makes `dependency-source-acquisition` the canonical home for both lookup kinds (maintained repos under `~/projects/<repo>/` with fd search, remote verification, and on-miss handling; org-first identity resolution; the `(see local)` marker; GitHub URL handling), removing the duplication where the lookup procedure was stated in full twice. The two `@`-loaded skills are trimmed — style 187 → 117 lines, git-vc 219 → 175 — by moving CI recipes, lookup bullets, the Contents table, the beads sections, and stack-management detail to indexed homes. `meta-session-resume` gains its missing H1.
- **`fix(context)`** retires the two residual beads references in the body (the project-management index entry and the dispatch-unit sentence); restores the reference-repo lookup policy in `dependency-source-acquisition` (zoxide-cache caveat, `ghq-sync` on-miss with the registration note, upstream-over-fork preference, pinned-revision warning, `ghq root` reconciliation) and the maintained-repo pause directive; points `hazards.md`'s worktree section at the `jj-version-control` authority section instead of restating it; revoices `meta-agent-teams` mirroring to Linear/OpenSpec ownership; and updates the touched packages' descriptions across all three manifest sites (`marketplace.json`, `apm.yml`, `plugin.json`).

## Deliberately left in place

| Item | Why |
| --- | --- |
| Deeper `bd` references: `jj-version-control` under "Beads integration" and "Diamond workflow: beads epic to jj chain topology", and `bd` mentions in the git-vc sibling files `01-git-native-mode.md` and `03-jj-mode.md` | The always-loaded surfaces are beads-free; these on-demand sections are read-only and retire with their own change |
| `unslop` and `preferences-documentation` overlap with the new prose skill | Complementary layers, cross-referenced rather than merged |
| `programs.agents-md` destination map | Unchanged; `eval-agents-md` still pins the seven-file contract |

## Obligations checked

- **Skills census**: this branch delivers 131 first-party skills, up from 128 on main; the three new skills land in two existing packages, so no new `marketplace.json` entry was needed — the two touched packages' descriptions were updated at all three sites.
- **Index integrity**: all 74 Development-guidelines index entries and every other skill-path reference in the body (85 occurrences, 79 distinct targets, trailing punctuation normalized) resolve. The five that are not first-party (`code-review`, `systematic-debugging`, `test-driven-development`, `using-superpowers`, `verification-before-completion`) are remote apm dependencies delivered by the compose — not orphans.
- **Untracked-file trap**: Nix flake source filtering silently drops untracked files; the four new files are staged (`git add`) so the compose sees them. CI checks out committed trees and is unaffected.
- **Inbound pointers**: `preferences-nix-ci-cd-integration`'s reference to the relocated "Unified PR check log retrieval" section is repointed at `ci-log-verification`; the three cross-references to the renamed mirroring section in `meta-agent-teams` follow the new name.

## Blast radius

Every harness session on every machine: the body ships to all eight sinks and both `@`-loaded skills changed. No nix module interface changed — `programs.agents-md` and `aiSkills` options are untouched. Buildbot re-runs the closure operator authoritatively at PR time.

## Verification

Run against built derivations, not sources:

- `nix build .#apm-skills-compose` — passes; the composed tree contains `preferences-prose-clarity`, `preferences-essential-complexity`, `ci-log-verification`, `jj-version-control/hazards.md`, and the trimmed git-vc.
- `nix build .#checks.aarch64-darwin.eval-agents-md` — passes.
- `nix eval .#checks.aarch64-darwin.home-manager-crs58.drvPath` — evaluates.

Not done, deliberately: home-manager activation per machine (`just activate`) and the cognee corpus refresh are delivery-day actions, not merge prerequisites.
