### PR TITLE
feat(pkgs/atomic): switch to the npm distribution from-source build

### DIFF
--- a/docs/notes/development/atomic-npm-distribution-compat.md
+++ b/docs/notes/development/atomic-npm-distribution-compat.md
@@ -1,0 +1,43 @@
+# Atomic npm-distribution compatibility findings
+
+Measured on atomic 0.9.13, comparing the npm distribution built by `pkgs/by-name/atomic` against the previous release-archive split-launcher binary.
+Load verdicts come from an RPC-mode driver: synthetic provider, `get_state` and `get_commands` requests, scratch agent directories, offline mode, exit status plus `extension_error` records.
+
+## Why the distribution matters for extension loading
+
+The two distributions select different module maps in `core/extensions/loader-virtual-modules.ts`.
+The split launcher's single-file build selects `virtualModules`, which omits the pi coding-agent specifiers, while the npm distribution selects `_aliases`, which carries `@earendil-works/pi-coding-agent`.
+Every pi-ecosystem extension that value-imports that scope is a fatal load error under the release binary and loads under the npm distribution.
+The legacy `@mariozechner/pi-coding-agent` scope is absent from both maps, so extensions importing it fail under every atomic distribution.
+
+## Load matrix for the fleet's registered set
+
+| extension | npm distribution | release split-launcher |
+|---|---|---|
+| pi-vim 0.14.1 (pristine) | loads | fails: `Cannot find module '@earendil-works/pi-coding-agent'` |
+| @burneikis/pi-vim | fails: `Cannot find module '@mariozechner/pi-coding-agent'` | same failure |
+| rytswd direnv, permission-gate, questionnaire, slow-mode, stash | load; commands registered | load identically |
+| rytswd statusline | loads | loads |
+| edit-write-policy.ts | loads | loads |
+| pi-openai-server-compaction (pristine upstream) | loads without the empty-manifest workaround | fails: same resolution error |
+
+The `@burneikis/pi-vim`, statusline, and edit-write-policy rows are distribution-independent and stay broken or excluded for upstream reasons: the legacy scope absent from both maps, the `setFooter` warn-once stub in isolated interactive mode, and atomic's `edit` tool schema that cannot carry a top-level `path`.
+Interactive custom-editor hosting (`setEditorComponent`) is a stub in every atomic distribution; a vim extension under atomic loads with one warning and a dead editor rather than failing.
+
+## Closure and runtime costs
+
+| | release archive | npm distribution |
+|---|---|---|
+| output size | 302,982,304 B | 754,746,296 B |
+| closure | 433.5 MiB, 5 paths | 2119.4 MiB, 52 paths |
+| `--version` latency, 5-run average | 75 ms | 86 ms |
+
+The closure delta is dominated by nodejs and its slim variants plus the node_modules payload.
+
+## Upstream defects the build surfaced
+
+1. The `prepublishOnly` shrinkwrap generator emits the 9 `@bastani/atomic-natives*` entries with `resolved` URLs but no `integrity`; nix's `prefetch-npm-deps` parser refuses the lockfile outright with `non-git dependencies should have associated integrity`.
+2. The published package.json carries 12 devDependencies the generated shrinkwrap does not cover, so `npm ci` against the published artifact tries to resolve them from the registry and dies `ENOTCACHED` offline; upstream never runs `npm ci` on the tarball, and the two files are mutually inconsistent for that operation.
+3. nixpkgs at rev `9bc02893134c733dd85de46ee4fb2fac696b5529`: `buildNpmPackage` forwards `patches` to its internal `fetchNpmDeps` but strips it from the main derivation, observed as an empty `env.patches` with the config hook's lockfile-consistency check then failing; `postPatch` reaches both consumers and is the working channel.
+
+The repairs for 1 and 2 live in `pkgs/by-name/atomic/npm-dist-repairs.patch`, and `pkgs/by-name/atomic/update.sh` re-derives that patch per bump, verifying the tarball against the registry's published `dist.integrity` before hashing.

--- a/pkgs/by-name/atomic/manifest.json
+++ b/pkgs/by-name/atomic/manifest.json
@@ -1,17 +1,3 @@
 {
-  "version": "0.9.13",
-  "platforms": {
-    "darwin-arm64": {
-      "checksum": "c121ac35ef9db9233f17f4932fc2f399d99dce31f887d202050009f88fc632ec"
-    },
-    "darwin-x64": {
-      "checksum": "522762a5bfc46cce6dcfad5014992992ee142748341355f659af693ca5c9e917"
-    },
-    "linux-arm64": {
-      "checksum": "dd69b47bd2a075482b9849208a114c8f97a4391f959e5137c6f314d3150c6069"
-    },
-    "linux-x64": {
-      "checksum": "f4b33b1d023d071318905f0e9d5108af8692a65035d5fc9c7834d09f25bd4175"
-    }
-  }
+  "version": "0.9.13"
 }

--- a/pkgs/by-name/atomic/npm-dist-repairs.patch
+++ b/pkgs/by-name/atomic/npm-dist-repairs.patch
@@ -1,0 +1,98 @@
+--- a/npm-shrinkwrap.json
++++ b/npm-shrinkwrap.json
+@@ -519,6 +519,7 @@
+ 		"node_modules/@bastani/atomic-natives": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives/-/atomic-natives-0.9.13.tgz",
++			"integrity": "sha512-JjbUREWq3DT4jnij0HaSW//2YPdZlj7USKyMTK1rjCt5QZlpPax24Vph2x9lF0qHFaFC0kZpTn1dOpkn00x5gA==",
+ 			"license": "MIT",
+ 			"optionalDependencies": {
+ 				"@bastani/atomic-natives-darwin-arm64": "0.9.13",
+@@ -538,6 +539,7 @@
+ 		"node_modules/@bastani/atomic-natives-darwin-arm64": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-darwin-arm64/-/atomic-natives-darwin-arm64-0.9.13.tgz",
++			"integrity": "sha512-rtkme6mGl6LgzBwHyzWylTuHdPMGG0zcKH2ogD3AA+1jj1nZ3UKedgDTyjqR2kxMEoF786+U4DqkGWtQvioXPQ==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"darwin"
+@@ -550,6 +552,7 @@
+ 		"node_modules/@bastani/atomic-natives-darwin-x64": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-darwin-x64/-/atomic-natives-darwin-x64-0.9.13.tgz",
++			"integrity": "sha512-uNdt6IbguaJWbb2RAdrTCi53e6VXSA1EUrq1YjOBBFk1BNbhsNK+YEt8gNw/Kie9edvGrSCXBkwR+UxiLp7t8g==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"darwin"
+@@ -562,6 +565,7 @@
+ 		"node_modules/@bastani/atomic-natives-linux-arm64-gnu": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-arm64-gnu/-/atomic-natives-linux-arm64-gnu-0.9.13.tgz",
++			"integrity": "sha512-t1KAzxsM6i/zzQwVGjbNRm2FNmUT0l2blgueItReGJXaJHl9AroCM/xySTiRo3Ap27Q2eKX/58nwscqWkwfMXg==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"linux"
+@@ -577,6 +581,7 @@
+ 		"node_modules/@bastani/atomic-natives-linux-arm64-musl": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-arm64-musl/-/atomic-natives-linux-arm64-musl-0.9.13.tgz",
++			"integrity": "sha512-4EBuaPiMKJeAxVgtf+78w0KyGbnAUc8cUnsvmyGNHuDqM8D4RhsV2lmo+5/VGCobnjEtJ2uPBDauCYU9yXHUSg==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"linux"
+@@ -592,6 +597,7 @@
+ 		"node_modules/@bastani/atomic-natives-linux-x64-gnu": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-x64-gnu/-/atomic-natives-linux-x64-gnu-0.9.13.tgz",
++			"integrity": "sha512-ynNsMdfa2ZRlz3PRbF607ETerRRuSZzNR/2mIxjvfgRF31CXzBU04cqyTwq4cxXQ6eMHTemWGepA0/9fYbnU4Q==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"linux"
+@@ -607,6 +613,7 @@
+ 		"node_modules/@bastani/atomic-natives-linux-x64-musl": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-x64-musl/-/atomic-natives-linux-x64-musl-0.9.13.tgz",
++			"integrity": "sha512-p6uHPS26Ekjdt66+c0Xn0luRX7xcH2+ee3aq27JXEg8qXZZvdIRc/johEBtKrhnYa7puy9HlHskGfmKD3MI2iw==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"linux"
+@@ -622,6 +629,7 @@
+ 		"node_modules/@bastani/atomic-natives-win32-arm64-msvc": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-win32-arm64-msvc/-/atomic-natives-win32-arm64-msvc-0.9.13.tgz",
++			"integrity": "sha512-7nrpRT/aU+oqXZcyUZuWWo5VpKf65T5DIde1MOJWoesirpP5/lZ7hb6nENPMhk7bhg17yq1iWefw4jK4Se/l/w==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"win32"
+@@ -634,6 +642,7 @@
+ 		"node_modules/@bastani/atomic-natives-win32-x64-msvc": {
+ 			"version": "0.9.13",
+ 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-win32-x64-msvc/-/atomic-natives-win32-x64-msvc-0.9.13.tgz",
++			"integrity": "sha512-PNusYua6gdsZ7wntHgKpvWl7MOq36ve6XU1kxrRGiuUpTEl1xJo24Gbe2SCGTeJbfe+voqPSby3bq8vHSB48fA==",
+ 			"license": "MIT",
+ 			"os": [
+ 				"win32"
+--- a/package.json
++++ b/package.json
+@@ -129,20 +129,7 @@
+   "optionalDependencies": {
+     "@mariozechner/clipboard": "0.3.9"
+   },
+-  "devDependencies": {
+-    "@types/cross-spawn": "6.0.6",
+-    "@types/diff": "7.0.2",
+-    "@types/hosted-git-info": "3.0.5",
+-    "@types/ms": "2.1.0",
+-    "@types/node": "24.12.4",
+-    "@types/proper-lockfile": "4.1.4",
+-    "@types/semver": "7.7.1",
+-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+-    "ajv": "8.20.0",
+-    "shx": "0.4.0",
+-    "typescript": "7.0.2",
+-    "vitest": "4.1.10"
+-  },
++
+   "keywords": [
+     "coding-agent",
+     "ai",

--- a/pkgs/by-name/atomic/package.nix
+++ b/pkgs/by-name/atomic/package.nix
@@ -1,187 +1,156 @@
-# atomic is Bastani's terminal coding agent, packaged from the upstream
-# prebuilt release tarball. Each archive is produced by `bun build --compile`
-# as a split launcher: a small `atomic` executable that resolves `app.js` and a
-# prebundled node_modules relative to the directory of its own execPath. Bun
-# resolves execPath through symlinks, but the launcher is wrapped rather than
-# symlinked so the runtime tool lookups below can be satisfied. The napi
-# natives ship prebuilt in that bundle, so nothing here needs a Rust toolchain
-# and the release archive is preferred over the published npm package.
+# atomic is Bastani's terminal coding agent, packaged from the published npm
+# distribution. The previous release-archive split launcher (a bun --compile
+# binary) could not resolve @earendil-works/* extension imports: its bundle
+# selects loader-virtual-modules' virtualModules map, which omits the pi
+# coding-agent specifiers, while the npm dist selects the _aliases map, which
+# carries @earendil-works/pi-coding-agent. Every pi-ecosystem extension that
+# value-imports that scope is a fatal load error under the old binary and
+# loads cleanly under this one.
 #
-# Version and per-platform checksums live in manifest.json alongside this file
-# rather than in this expression.
+# The npm tarball ships dist/ prebuilt (upstream's prepublishOnly runs
+# `bun run build` plus a shrinkwrap generator), so nothing is compiled here:
+# the build is `npm ci --ignore-scripts` + `npm rebuild` (which runs the
+# dependencies' install scripts, e.g. @embedded-postgres' pg-symlinks
+# recreation) from the shipped npm-shrinkwrap.json, and the install hook packs
+# the declared `files` and copies node_modules next to them.
 #
+# Pinning: the registry tarball by its sha256 (cross-checkable against the
+# registry's published integrity) and the dependency closure by npmDepsHash
+# over the shipped npm-shrinkwrap.json (lockfileVersion 3, 359 packages).
+#
+# Two upstream-shrinkwrap repairs live in npm-dist-repairs.patch:
+#  - the prepublishOnly generator emits the 9 @bastani/atomic-natives*
+#    entries without `integrity`, which nix's prefetch-npm-deps parser refuses
+#    outright ("non-git dependencies should have associated integrity"); the
+#    patch adds the registry's published sha512 for exactly those 9 tarballs.
+#  - the published package.json retains 12 devDependencies the generated
+#    shrinkwrap does not cover, so `npm ci` tries to resolve them from the
+#    registry and dies ENOTCACHED; dist/ is already built, so they are dead
+#    weight and are removed.
+#
+# The repairs apply in postPatch rather than `patches` because this
+# buildNpmPackage forwards `patches` to its internal fetchNpmDeps but strips it
+# from the main derivation (observed: env.patches empty, the hook's
+# lockfile-consistency check then fails), while postPatch reaches both.
+#
+# Version lives in manifest.json alongside this file; update.sh re-derives the
+# tarball hash, the repairs patch, and npmDepsHash from the registry per bump.
 # update: nix run .#update-atomic
 # source: https://github.com/bastani-inc/atomic
 {
   lib,
-  stdenv,
+  buildNpmPackage,
+  nodejs_22,
   fetchurl,
-  autoPatchelfHook,
   makeBinaryWrapper,
-  versionCheckHook,
-  writableTmpDirAsHomeHook,
-  runCommand,
-  jq,
   fd,
   ripgrep,
+  runCommand,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 let
   manifest = lib.importJSON ./manifest.json;
-  platforms = {
-    x86_64-linux = "linux-x64";
-    aarch64-linux = "linux-arm64";
-    aarch64-darwin = "darwin-arm64";
-  };
-  platform = platforms.${stdenv.hostPlatform.system} or null;
 in
-# The flake forces `checks.<system>` for every system it evaluates, so a system
-# outside the map has to make this attribute absent rather than throw when the
-# derivation is forced.
-if platform == null then
-  null
-else
-  stdenv.mkDerivation (finalAttrs: {
-    pname = "atomic";
-    inherit (manifest) version;
+buildNpmPackage (finalAttrs: {
+  pname = "atomic";
+  inherit (manifest) version;
 
-    src = fetchurl {
-      url = "https://github.com/bastani-inc/atomic/releases/download/${finalAttrs.version}/atomic-${platform}.tar.gz";
-      sha256 = manifest.platforms.${platform}.checksum;
-    };
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@bastani/atomic/-/atomic-${finalAttrs.version}.tgz";
+    hash = "sha256-Q/JiNxkoMaCN59R+EkIgzIyOfrClUFc8BKMqlOmLPFc=";
+  };
+  sourceRoot = "package";
 
-    sourceRoot = "atomic";
+  nodejs = nodejs_22;
+  npmDepsHash = "sha256-DQr7M0nSI/ojZOocCYq3R/sSQSZnI60RVTE34tuj+3g=";
 
-    dontConfigure = true;
-    dontBuild = true;
+  postPatch = ''
+    patch -p1 < ${./npm-dist-repairs.patch}
+  '';
 
-    # the launcher carries its bytecode payload past the end of the executable
-    # image, which stripping discards
-    dontStrip = true;
+  # dist/ is prebuilt in the tarball; there is nothing to npm-run.
+  dontNpmBuild = true;
 
-    nativeBuildInputs = [
-      makeBinaryWrapper
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isElf [
-      autoPatchelfHook
-      jq
-    ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
-    buildInputs = lib.optionals stdenv.hostPlatform.isElf [
-      stdenv.cc.cc.lib
-    ];
+  # atomic resolves fd and rg from PATH and otherwise downloads a release
+  # binary from GitHub at first use. PATH is suffixed so the caller's own
+  # tools still win.
+  postFixup = ''
+    wrapProgram "$out/bin/atomic" \
+      --set ATOMIC_SKIP_VERSION_CHECK 1 \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          fd
+          ripgrep
+        ]
+      }
+  '';
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  doInstallCheck = true;
+  # --version (versionCheckHook) proves dist/cli.js and its node_modules
+  # closure load; --help additionally proves the CLI surface imports.
+  postInstallCheck = ''
+    "$out/bin/atomic" --help | grep -q "AI coding assistant"
+  '';
 
-    installPhase = ''
-      runHook preInstall
+  strictDeps = true;
 
-      mkdir -p "$out/lib"
-      cp -R . "$out/lib/atomic"
+  passthru = {
+    updateScript = ./update.sh;
 
-      # atomic resolves fd and rg from PATH and otherwise downloads a release
-      # binary from GitHub at first use, which cannot run against this libc.
-      # PATH is suffixed so the caller's own tools still win.
-      makeWrapper "$out/lib/atomic/atomic" "$out/bin/atomic" \
-        --set ATOMIC_SKIP_VERSION_CHECK 1 \
-        --suffix PATH : ${
-          lib.makeBinPath [
-            fd
-            ripgrep
-          ]
+    # doInstallCheck runs against $out while it is still being built and still
+    # writable. This runs the same CLI against the finished, read-only store
+    # path.
+    tests.help =
+      runCommand "atomic-test-help"
+        {
+          meta.timeout = 60;
         }
+        ''
+          export HOME="$PWD/home"
+          mkdir -p "$HOME"
 
-      runHook postInstall
-    '';
+          ${lib.getExe finalAttrs.finalPackage} --help > help.txt
 
-    # @embedded-postgres carries its shared libraries as versioned files with
-    # the SONAME links recorded in native/pg-symlinks.json, which upstream's
-    # npm postinstall recreates; a release tarball never runs that script, so
-    # the links are absent. The postgres binaries resolve their libraries
-    # through an $ORIGIN-relative rpath, so without the links autoPatchelf
-    # cannot satisfy libicuuc.so.60 and the durable-workflow database has no
-    # runtime. Upstream ships this payload in the linux-x64 archive only.
-    postInstall = lib.optionalString stdenv.hostPlatform.isElf ''
-      for pkgdir in "$out"/lib/atomic/node_modules/@embedded-postgres/*/; do
-        [ -f "$pkgdir/native/pg-symlinks.json" ] || continue
-        jq -r '.[] | [.source, .target] | @tsv' "$pkgdir/native/pg-symlinks.json" \
-          | while IFS=$'\t' read -r source target; do
-            # upstream's own script swallows an existing target, so a release
-            # that starts shipping these links stays a no-op here rather than
-            # failing the build
-            [ -e "$pkgdir$target" ] || [ -L "$pkgdir$target" ] \
-              || ln -s "$(basename "$source")" "$pkgdir$target"
-          done
-      done
-    '';
+          grep -q "AI coding assistant" help.txt
+          grep -q "atomic \[options\] \[@files\.\.\.\] \[messages\.\.\.\]" help.txt
+          grep -q "Install extension source and add to settings" help.txt
 
-    # postgres's procedural-language handlers link against the interpreters of
-    # the distribution that built them. atomic loads no PL handler, and nixpkgs
-    # carries none of these interpreter versions.
-    autoPatchelfIgnoreMissingDeps = [
-      "libperl.so.5.26"
-      "libpython3.6m.so.1.0"
-      "libtcl8.6.so"
-    ];
+          touch "$out"
+        '';
+  };
 
-    nativeInstallCheckInputs = [
-      versionCheckHook
-      writableTmpDirAsHomeHook
-    ];
-    versionCheckKeepEnvironment = [ "HOME" ];
-    doInstallCheck = true;
-
-    # the launcher answers --version itself, before importing the sidecar
-    # bundle, so only --help proves the payload resolved
-    postInstallCheck = ''
-      "$out/bin/atomic" --help | grep -q "AI coding assistant"
-    '';
-
-    strictDeps = true;
-
-    passthru = {
-      updateScript = ./update.sh;
-
-      # doInstallCheck runs against $out while it is still being built and
-      # still writable. This runs the same launcher against the finished,
-      # read-only store path, which is the condition the split launcher and
-      # its sidecar payload actually have to survive.
-      tests.help =
-        runCommand "atomic-test-help"
-          {
-            meta.timeout = 60;
-          }
-          ''
-            export HOME="$PWD/home"
-            mkdir -p "$HOME"
-
-            ${lib.getExe finalAttrs.finalPackage} --help > help.txt
-
-            grep -q "AI coding assistant" help.txt
-            grep -q "atomic \[options\] \[@files\.\.\.\] \[messages\.\.\.\]" help.txt
-            grep -q "Install extension source and add to settings" help.txt
-
-            touch "$out"
-          '';
+  meta = {
+    description = "Coding agent CLI with read, bash, edit, write tools and session management";
+    homepage = "https://github.com/bastani-inc/atomic";
+    changelog = "https://github.com/bastani-inc/atomic/releases/tag/${finalAttrs.version}";
+    # LICENSE is the MIT text plus a clause requiring a product above 100
+    # million monthly active users or $20 million monthly revenue to display
+    # 'Atomic' in its interface. That condition is not part of MIT and has no
+    # SPDX identifier, so lib.licenses.mit would misstate the terms; the
+    # repository's package.json nonetheless declares MIT and GitHub reports
+    # the license as NOASSERTION.
+    license = {
+      shortName = "MIT-with-atomic-attribution";
+      fullName = "MIT License with Atomic attribution requirement";
+      url = "https://github.com/bastani-inc/atomic/blob/main/LICENSE";
+      free = true;
+      redistributable = true;
     };
-
-    meta = {
-      description = "Coding agent CLI with read, bash, edit, and write tools and session management";
-      homepage = "https://github.com/bastani-inc/atomic";
-      changelog = "https://github.com/bastani-inc/atomic/releases/tag/${finalAttrs.version}";
-      # LICENSE is the MIT text plus a clause requiring a product above 100
-      # million monthly active users or $20 million monthly revenue to display
-      # 'Atomic' in its interface. That condition is not part of MIT and has no
-      # SPDX identifier, so lib.licenses.mit would misstate the terms; the
-      # repository's package.json nonetheless declares MIT and GitHub reports
-      # the license as NOASSERTION.
-      license = {
-        shortName = "MIT-with-atomic-attribution";
-        fullName = "MIT License with Atomic attribution requirement";
-        url = "https://github.com/bastani-inc/atomic/blob/main/LICENSE";
-        free = true;
-        redistributable = true;
-      };
-      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-      mainProgram = "atomic";
-      platforms = lib.attrNames platforms;
-      maintainers = with lib.maintainers; [ cameronraysmith ];
-    };
-  })
+    # dist/ is prebuilt upstream and the napi natives ship prebuilt binaries
+    # through the platform optionalDependencies.
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "atomic";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    maintainers = [ ];
+  };
+})

--- a/pkgs/by-name/atomic/update.sh
+++ b/pkgs/by-name/atomic/update.sh
@@ -1,45 +1,141 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p curl jq cacert git
+#!nix-shell --pure -i bash -p curl jq cacert git python3 nodejs nix
 # shellcheck shell=bash
+
+# Update pkgs/by-name/atomic to the latest npm release of @bastani/atomic:
+#   1. resolve the version from the registry's latest dist-tag,
+#   2. verify the tarball against the registry's published sha512 integrity,
+#   3. re-derive npm-dist-repairs.patch for that tarball (the integrity
+#      backfill for @bastani/atomic-natives* entries and the devDependencies
+#      removal - see package.nix for why both are needed),
+#   4. write manifest.json and the src hash into package.nix,
+#   5. run one build cycle to learn the new npmDepsHash from the mismatch
+#      (a no-op when the dependency closure is unchanged), then a verifying
+#      build.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-MANIFEST="${REPO_ROOT}/pkgs/by-name/atomic/manifest.json"
+PKG_DIR="${REPO_ROOT}/pkgs/by-name/atomic"
+ENC_PACKAGE="%40bastani%2Fatomic"
 
-REPO="bastani-inc/atomic"
-RELEASES_API="https://api.github.com/repos/${REPO}/releases"
-DOWNLOADS="https://github.com/${REPO}/releases/download"
+version="$(curl -fsSL "https://registry.npmjs.org/${ENC_PACKAGE}" | jq -r '.["dist-tags"].latest')"
+[ -n "$version" ] || { echo "error: empty latest version" >&2; exit 1; }
+tarball="https://registry.npmjs.org/@bastani/atomic/-/atomic-${version}.tgz"
+echo "updating @bastani/atomic to ${version}"
 
-# /releases/latest is the newest non-prerelease; atomic publishes -alpha.N tags
-# continuously between stable releases, so listing tags would track those too.
-version="$(curl -fsSL "${RELEASES_API}/latest" | jq -r '.tag_name')"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+curl -fsSL "$tarball" -o "$work/atomic.tgz"
+mkdir -p "$work/package"
+tar -xzf "$work/atomic.tgz" -C "$work/package" --strip-components=1
 
-# Upstream publishes a SHA256SUMS asset covering every archive in the release,
-# so the checksums are read rather than recomputed by fetching each tarball.
-manifest="$(
-  curl -fsSL "${DOWNLOADS}/${version}/SHA256SUMS" \
-    | jq -Rn --arg version "$version" '
-      {
-        $version,
-        platforms: [
-          inputs
-          | split(" ")
-          | map(select(length > 0))
-          | select(length == 2)
-          | select(.[1] | test("^atomic-(darwin|linux)-(x64|arm64)\\.tar\\.gz$"))
-          | {
-            key: (.[1] | ltrimstr("atomic-") | rtrimstr(".tar.gz")),
-            value: { checksum: .[0] }
-          }
-        ] | from_entries
-      }'
-)"
+python3 - "$work" "$PKG_DIR/npm-dist-repairs.patch" "$version" <<'PY'
+import base64, difflib, hashlib, json, re, sys, urllib.parse, urllib.request
 
-if [[ "$(jq '.platforms | length' <<<"$manifest")" -eq 0 ]]; then
-  echo "error: no matching archives in SHA256SUMS for ${version}" >&2
-  exit 1
+work, patch_path, version = sys.argv[1], sys.argv[2], sys.argv[3]
+pkg_dir = f"{work}/package"
+
+def registry(path):
+    with urllib.request.urlopen(f"https://registry.npmjs.org/{path}") as r:
+        return json.load(r)
+
+# The bytes the nix hash is derived from must match the registry's published
+# integrity for the same version.
+meta = registry(urllib.parse.quote("@bastani/atomic", safe="") + "/" + version)
+digest = "sha512-" + base64.b64encode(
+    hashlib.sha512(open(f"{work}/atomic.tgz", "rb").read()).digest()
+).decode()
+assert digest == meta["dist"]["integrity"], "tarball does not match registry integrity"
+
+# Repair 1: backfill integrity for entries the shrinkwrap generator left
+# without one (all of them are @bastani/atomic-natives*).
+shrink_src = open(f"{pkg_dir}/npm-shrinkwrap.json").read()
+shrink = json.loads(shrink_src)
+integ = {}
+for key, entry in shrink["packages"].items():
+    if key == "" or "integrity" in entry:
+        continue
+    resolved = entry.get("resolved", "")
+    m = re.match(r"https://registry\.npmjs\.org/(.+)/-/.+\.tgz$", resolved)
+    if not m:
+        sys.exit(f"error: non-registry entry without integrity: {key}")
+    dist = registry(f"{urllib.parse.quote(m.group(1), safe='')}/{entry['version']}")["dist"]
+    if dist["tarball"] != resolved:
+        sys.exit(f"error: registry tarball moved for {key}")
+    integ[m.group(1)] = dist["integrity"]
+
+out = []
+for line in shrink_src.split("\n"):
+    out.append(line)
+    m = re.match(r'^(\t+)"resolved": "(https://registry\.npmjs\.org/(.+)/-/.+\.tgz)",$', line)
+    if m and m.group(3) in integ:
+        out.append(f'{m.group(1)}"integrity": "{integ[m.group(3)]}",')
+shrink_new = "\n".join(out)
+json.loads(shrink_new)  # validate
+
+# Repair 2: delete the devDependencies object, which the generated shrinkwrap
+# does not cover and `npm ci` would try to resolve from the network.
+pkg_src = open(f"{pkg_dir}/package.json").read()
+m = re.search(r'^(\s*)"devDependencies": \{\s*$', pkg_src, re.M)
+if m:
+    i = pkg_src.index("{", m.start())
+    depth = 0
+    for j in range(i, len(pkg_src)):
+        if pkg_src[j] == "{":
+            depth += 1
+        elif pkg_src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                end = j + 1
+                if pkg_src[end : end + 1] == ",":
+                    end += 1
+                break
+    pkg_new = re.sub(r"\n{3,}", "\n\n", pkg_src[: m.start()] + pkg_src[end:])
+    json.loads(pkg_new)  # validate
+else:
+    pkg_new = pkg_src
+
+def unified(a, b, name):
+    lines = list(difflib.unified_diff(a.split("\n"), b.split("\n"), n=3, lineterm=""))
+    return f"--- a/{name}\n+++ b/{name}\n" + "\n".join(lines[2:]) + "\n"
+
+open(patch_path, "w").write(
+    unified(shrink_src, shrink_new, "npm-shrinkwrap.json")
+    + unified(pkg_src, pkg_new, "package.json")
+)
+print(f"regenerated npm-dist-repairs.patch ({len(integ)} integrity backfills)")
+PY
+
+jq -n --arg version "$version" '{version: $version}' > "$PKG_DIR/manifest.json"
+
+src_hash="$(nix store prefetch-file --json "$tarball" | jq -r .hash)"
+python3 - "$PKG_DIR/package.nix" "$src_hash" <<'PY'
+import re, sys
+path, src_hash = sys.argv[1], sys.argv[2]
+s = open(path).read()
+s, n = re.subn(r'(hash = )"?sha256-[A-Za-z0-9+/=]+"?;', rf'\g<1>"{src_hash}";', s, count=1)
+assert n == 1, "src hash line not found"
+open(path, "w").write(s)
+print(f"wrote src hash {src_hash}")
+PY
+
+# npmDepsHash: a bumped closure makes the committed hash mismatch; the error
+# carries the correct value. An unchanged closure builds clean and skips this.
+got="$(nix build --no-link "$REPO_ROOT#atomic" 2>&1 || true)"
+got="$(printf '%s' "$got" | grep -oE 'got: +sha256-[A-Za-z0-9+/=]+' | head -1 | tr -d ' ' | sed 's/^got://' || true)"
+if [ -n "$got" ]; then
+  python3 - "$PKG_DIR/package.nix" "$got" <<'PY'
+import re, sys
+path, got = sys.argv[1], sys.argv[2]
+s = open(path).read()
+s, n = re.subn(r'(npmDepsHash = )"sha256-[A-Za-z0-9+/=]+";', rf'\g<1>"{got}";', s, count=1)
+assert n == 1, "npmDepsHash line not found"
+open(path, "w").write(s)
+print(f"wrote npmDepsHash {got}")
+PY
 fi
 
-echo "$manifest" > "$MANIFEST"
-echo "atomic manifest updated to ${version}"
+echo "verifying build"
+nix build -L --no-link "$REPO_ROOT#atomic"
+echo "atomic updated to ${version}; run the checks before pushing"


### PR DESCRIPTION
## What

Replaces `pkgs/by-name/atomic`'s release-archive packaging with a `buildNpmPackage` build of the published npm distribution (`@bastani/atomic@0.9.13`), and moves `update.sh` from the GitHub SHA256SUMS manifest to the npm registry. The previous artifact is a split launcher: a bun `--compile` executable that ships beside a prebundled `app.js`. Decision evidence: `docs/notes/development/atomic-npm-distribution-compat.md`.

## Why the switch

The two distributions select different module maps in `core/extensions/loader-virtual-modules.ts`. The split launcher selects `virtualModules`, which omits the pi coding-agent specifiers; the npm distribution selects `_aliases`, which carries `@earendil-works/pi-coding-agent`. A pi-ecosystem extension that value-imports that scope fails to load under the split launcher, taking the extension host down with it, and loads cleanly under the npm distribution. Measured on the fleet's whole registered set under the built npm-distribution binary: everything loads, including pristine `pi-vim` v0.14.1 and the compaction extension without its empty-atomic-manifest workaround — under the split launcher both of those exit 1 with `Cannot find module '@earendil-works/pi-coding-agent'` (RPC smoke driver, rc 0 vs rc 1). The accepted cost: closure 434 MiB/5 paths → 2119 MiB/52 paths (~4.9x), output ~290 → ~720 MiB.

## Comparison: which shape won

The winner is the nixpkgs house convention — `buildNpmPackage` + `npmDepsHash` + `dontNpmBuild` + `postPatch` repairs — refined with the install-check hook pattern shared by llm-agents and this repo's previous packaging.

- vs **numtide/llm-agents.nix `packages/pi/package.nix`**: their shape swaps the broken upstream shrinkwrap for a regenerated, vendored `package-lock.json`; a `srcWithLock` runCommand deletes `npm-shrinkwrap.json` and copies their lock in. Their updater (`scripts/updater/npm.py`) regenerates the lock from the registry, which resolves transitive ranges fresh and abandons upstream's published closure. That trade contradicts this flake's pinned-hash discipline, so the repairs patch was kept instead: it backfills exactly 9 integrities and deletes 12 devDependencies while preserving the upstream-published dependency set byte-for-byte. Adopted from llm-agents: the `versionCheckHook` + HOME-hook install-check family (their pi packaging, `packages/pi/package.nix:141-155`) rather than hand-rolled `postInstallCheck` environment exports. Three of their techniques did not fit here: the `mkUpdater` bot (a repo-wide update service; this flake uses per-package update apps in `modules/apps/updates.nix`), `npmDepsFetcherVersion = 2` + `makeCacheWritable` (v1 worked, and rev sensitivity is managed by the single flake-pinned nixpkgs), and the bun `--compile` standalone path (the bun single-file build is exactly what breaks `_aliases`).
- vs **nixpkgs corpus**: the resulting expression matches the canonical prebuilt-dist npm packages — `pkgs/by-name/pl/playwright-mcp` (`dontNpmBuild = true` + `npmDepsHash` + wrapper) is the closest sibling. `firebase-tools`' `postPatch = 'cp ./npm-shrinkwrap.json ./package-lock.json'` documents the shrinkwrap-priority rule our repairs operate under.

## Upstream defects the build surfaced (repairs live in `npm-dist-repairs.patch`)

1. The prepublishOnly shrinkwrap generator emits the 9 `@bastani/atomic-natives*` entries without `integrity`; nix's `prefetch-npm-deps` refuses ("non-git dependencies should have associated integrity").
2. The published package.json carries devDependencies the shrinkwrap does not cover; `npm ci` dies ENOTCACHED offline.
3. nixpkgs at rev `9bc02893134c733dd85de46ee4fb2fac696b5529`: `buildNpmPackage` forwards `patches` to its internal `fetchNpmDeps` but strips it from the main derivation — `env.patches` arrives empty and the config hook's lockfile-consistency check then fails — so the repairs apply through `postPatch`, which reaches both consumers.

`update.sh` re-derives the patch from the registry on every bump; regenerating it for 0.9.13 reproduced the committed patch byte-identical. It verifies the tarball against the registry's published `dist.integrity` (sha512/SRI) before hashing.

## Deliberately unchanged

- `statusline` and `edit-write-policy` atomic exclusions: their reasons (`setFooter` stub in isolated interactive mode; `edit` tool schema divergence) are upstream and distribution-independent.
- `pi-openai-server-compaction`'s empty-manifest workaround derivation: it now loads pristine under the new binary, but removing the workaround is a separate cleanup with its own spec surface.
- No atomic smoke check was added (known gap); the manual RPC load evidence below covers what a smoke check would assert.

## Checks run (selection rationale)

- `nix build -L .#atomic` — the derivation itself; `installCheckPhase` now runs `versionCheckHook` (`--version` found 0.9.13 against the built output) plus a `--help` grep.
- `nix build -L .#atomic.tests.help` — CLI against the finished read-only store path.
- `nix build -L .#checks.aarch64-darwin.atomic-agent-environment-structural` — the atomic environment regulator against the new package.
- `nix build -L .#checks.aarch64-darwin.pi-agent-environment-smoke` — neighbor guard: the shared extension set still loads under pi, ruling out cross-damage from this change.
- `./pkgs/by-name/atomic/update.sh` — full idempotency run on 0.9.13: resolves the version, verifies SRI integrity, regenerates the repairs patch byte-identical, rewrites identical hashes, and finishes with a green verifying build.
- Load evidence (RPC driver, scratch agent dirs; method recorded in `docs/notes/development/atomic-npm-distribution-compat.md`): pristine pi-vim under the final artifact rc 0 / no `extension_error`; the split-launcher control rc 1 with the resolution error.

Not run: a full `nix flake check`, because its blast radius reaches far beyond a single-package swap, and interactive pty sessions, because editor hosting under isolation is an upstream limitation independent of this change (see the findings note).
