### PR TITLE
fix(hooks): don't gate kill word inside quoted search patterns

### DIFF
--- a/modules/checks/hooks.nix
+++ b/modules/checks/hooks.nix
@@ -45,6 +45,14 @@
             # A safe-looking segment must not launder a later unsafe one.
             "ask kill 1308; kill $OTHER"
             "ask ps aux | xargs kill"
+            # A `kill` inside a quoted search pattern is data, not a command:
+            # the `|` alternations of an rg pattern are not shell operators.
+            # Observed 2026-08-12: the gate pattern-matched the quoted word and
+            # stalled a crewmate on two read-only ripgrep searches.
+            "allow rg -n \"process group|kill -.*-\\$|setsid|pgid|kill_tree|_drain\" bin/*.sh | head -40"
+            "allow rg -n 'watchdog|kill -9' modules/ | head -20"
+            # A genuine process termination next to a quoted pattern still gates.
+            "ask rg -n \"kill\" bin/*.sh | head -5; kill $WATCHER_PID"
 
             # nix run/shell is ungated in every form. An "ask" is a hard stall for
             # an agent worker launched with permissions bypassed, and nix run is

--- a/modules/home/tools/hooks/gate-dangerous-commands.sh
+++ b/modules/home/tools/hooks/gate-dangerous-commands.sh
@@ -67,6 +67,7 @@ Gated patterns (each returns permissionDecision "ask"):
     pkill * / killall *          (all forms; they select processes by pattern)
     kill <target> where any target is not a literal numeric PID
       (variable, command substitution, glob, job spec, -f, or a pattern)
+      (quoted strings, e.g. a search pattern containing 'kill', are not matched)
     xargs ... kill
     kill [-SIG] <numeric-pid>... and kill -0 * are not gated
 
@@ -125,6 +126,16 @@ jj_cmd_match() {
   echo "$COMMAND" | grep -qE "(^|[;&|]\s*|&&\s*|\|\|?\s*|\\\$\(\s*)jj${jj_opts}\s+$1"
 }
 
+# Remove single- and double-quoted spans from the command text. Used only by
+# the kill gate: shell operators inside a quoted search pattern (e.g. the `|`
+# alternations of an rg pattern) are not command operators, so a `kill`
+# appearing there is data, not a process-termination command. Escaped quote
+# characters inside a span are not handled; this is the quoted-pattern shape
+# only.
+strip_quoted() {
+  printf '%s' "$1" | sed -e "s/'[^']*'//g" -e 's/"[^"]*"//g'
+}
+
 # Return 0 only when every `kill` invocation in $COMMAND targets literal numeric
 # PIDs, optionally after one signal flag (-9, -TERM, -s TERM, --signal=TERM).
 # Anything else -- a variable, command substitution, glob, job spec, -f, or a
@@ -140,7 +151,7 @@ jj_cmd_match() {
 # literal-PID test.
 kill_targets_are_explicit_pids() {
   local segments segment
-  segments="${COMMAND//&&/$'\n'}"
+  segments="${1//&&/$'\n'}"
   segments="${segments//||/$'\n'}"
   segments="${segments//;/$'\n'}"
   segments="${segments//|/$'\n'}"
@@ -391,7 +402,8 @@ if [ -z "$REASON" ]; then
   cmd_match '(pkill|killall)\s' && REASON="pattern-matched process termination"
 fi
 if [ -z "$REASON" ]; then
-  if cmd_match 'kill(\s|$)' && ! kill_targets_are_explicit_pids; then
+  KILL_VIEW=$(strip_quoted "$COMMAND")
+  if printf '%s' "$KILL_VIEW" | grep -qE "(^|[;&|]\s*|&&\s*|\|\|?\s*|\\\$\(\s*)kill(\s|$)" && ! kill_targets_are_explicit_pids "$KILL_VIEW"; then
     REASON="process termination with a target that is not an explicit PID"
   fi
 fi


### PR DESCRIPTION
## Grounding

Observed 2026-08-12 on fm-test-cleanup-rmrf-before-stop: a scripted agent session was stopped by the gate-dangerous-commands kill arm ("process termination with a target that is not an explicit PID") while running two read-only ripgrep searches of the shape:

```
rg -n "process group|kill -.*-\$|setsid|pgid|kill_tree|_drain" bin/*.sh | head -40
```

The word kill appears only inside the quoted search pattern. `cmd_match 'kill(\s|$)'` matches a command token at start-of-line or after shell operators; the `|` alternations inside the quoted rg pattern satisfied that operator context, and `kill_targets_are_explicit_pids` then split on the same `|` and failed the literal-PID test on the pattern fragment as its own segment. Residual of vx-kill-gate-narrow (closed 2026-08-12), which did not cover this shape.

## What changed

- `modules/home/tools/hooks/gate-dangerous-commands.sh`: new `strip_quoted` helper removes single- and double-quoted spans from the command text; the kill arm now matches and segments against that stripped view (`KILL_VIEW`), so a `kill` inside a quoted argument cannot satisfy the shell-operator context. `kill_targets_are_explicit_pids` now takes its input as `$1` instead of reading `$COMMAND`. The pkill/killall and xargs-kill arms are untouched — this is the quoted-pattern shape only, not a general gate rework. Escaped quote characters inside a quoted span are not handled (documented in the helper comment).
- `modules/checks/hooks.nix`: three regression cases — the exact observed rg shape (allow), a single-quoted variant (allow), and a genuine `kill $WATCHER_PID` appended after a quoted search (ask, still gated).

## Verification

`nix build .#checks.aarch64-darwin.hook-gate-dangerous-commands` passes (all existing kill/push/git/gh cases plus the three new ones). Direct harness run of the hook script on four commands: observed rg shape → allow, quoted-pattern-plus-real-kill → ask, `kill -TERM 1308` → allow, `kill $PID` → ask. `shellcheck` clean.

Selection rationale: the nix check drives the exact hook file with the exact payload shape the PreToolUse path produces; it is the narrowest suite covering this change. Nothing else consumes the hook script (home-manager wires it verbatim via `writeShellApplication`).
