### PR TITLE
feat(darwin): declare sshd server enablement for stibnite

### DIFF
--- a/modules/darwin/sshd-server.nix
+++ b/modules/darwin/sshd-server.nix
@@ -1,0 +1,14 @@
+# SSH server (Apple Remote Login) for Darwin machines
+# The clan sshd service only provides nixosModule for the server role;
+# this module declares the darwin equivalent. nix-darwin's openssh module
+# enables Apple's built-in sshd (com.openssh.sshd) via launchd, which
+# listens on all interfaces including zerotier. Host keys are generated
+# by the nix-darwin defaults; per-user keys come from each host's
+# users.users.<name>.openssh.authorizedKeys.keys wiring (meta.sshKeys).
+{
+  flake.modules.darwin.sshd-server =
+    { ... }:
+    {
+      services.openssh.enable = true;
+    };
+}

--- a/modules/machines/darwin/stibnite/default.nix
+++ b/modules/machines/darwin/stibnite/default.nix
@@ -33,6 +33,7 @@ in
         base
         casks
         ssh-ca-trust
+        sshd-server
         ssh-known-hosts
         beads-ui
         colima


### PR DESCRIPTION
## Grounding

Diagnosed gap: nothing listens on port 22 on stibnite — launchd carries only ssh-agent. Root cause: the clan sshd service's server role is NixOS-only (`modules/clan/inventory/services/sshd.nix` restricts `roles.server` to the `nixos` tag; clan's sshd service has no darwinModule for the server), and no darwin module declared sshd enablement anywhere.

Investigation into rosegold/argentum (which do answer ssh when up): all four darwin hosts declare only `services.openssh.extraConfig` (MaxAuthTries); none sets `services.openssh.enable`, whose default `null` means "let macOS manage". Their sshd is a manual macOS Remote Login toggle from setup day that vanixiets never declared.

## What changed

- `modules/darwin/sshd-server.nix` (new): `flake.modules.darwin.sshd-server` setting `services.openssh.enable = true`. nix-darwin enables Apple's built-in sshd (`launchctl enable/bootstrap system/com.openssh.sshd` via `/System/Library/LaunchDaemons/ssh.plist` in the activation script), which listens on all interfaces including zerotier.
- `modules/machines/darwin/stibnite/default.nix`: imports `sshd-server`.

Authorized keys needed no new wiring: stibnite already sets `users.users.crs58.openssh.authorizedKeys.keys = inputs.self.users.crs58.meta.sshKeys`, which nix-darwin renders through `sshd_config.d/101-authorized-keys.conf` (`AuthorizedKeysCommand /bin/cat /etc/ssh/nix_authorized_keys.d/%u`). Host keys come from nix-darwin's openssh defaults.

rosegold/argentum should migrate onto this declaration later (out of scope here); blackphos likewise.

## Activation requirement on stibnite

Activating the change (`darwin-rebuild switch` / `clan machines update stibnite`) is sufficient: the activation script enables Remote Login itself when it is Off — no manual System Settings toggle needed. First activation generates the missing sshd host keys and writes `/etc/ssh/authorized_keys.d` wiring via the AuthorizedKeysCommand path. Post-activation check from cinnabar: `ssh stibnite.zt` (client trust already handled by the fleet CA known_hosts wiring in `modules/home/core/ssh.nix`).

## Verification

- `nix build .#darwinConfigurations.stibnite.system` — passes.
- Built activation script contains `launchctl enable system/com.openssh.sshd` / `launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist` (grep of the out-path `activate`).
- Built closure carries crs58's two `meta.sshKeys` keys in `etc/ssh/nix_authorized_keys.d/crs58` and `sshd_config.d/101-authorized-keys.conf`.
- No regression: `services.openssh.enable` evals unchanged for rosegold/argentum (null), cinnabar/magnetite (true, via the untouched clan sshd service).
- `nix build .#checks.aarch64-darwin.darwin-stibnite` and `.#checks.aarch64-darwin.clan-inventory-consistency` pass; `nix fmt` clean; pre-commit (gitleaks, treefmt) passed on commit.

Deliberately not run: the full `just check-fast` suite (all-machine eval matrix) — the change touches one darwin host's imports plus one new module; the stibnite + inventory-consistency checks plus per-host `openssh.enable` evals cover the diff and its immediate blast radius.
