### PR TITLE
feat(ai): enable pi-vim modal editing for pi only

### DIFF
--- a/docs/notes/development/ai-agents/pi-vim-modal-editing-probe.py
+++ b/docs/notes/development/ai-agents/pi-vim-modal-editing-probe.py
@@ -1,0 +1,149 @@
+"""Interactive probe: does pi's TUI editor actually enter and honour vim normal mode?
+
+The RPC smoke regulator (modules/checks/pi-agent-environment.nix) proves pi-vim
+loads without an extension_error, which is a load claim rather than a behaviour
+claim: pi-vim registers no slash command, so nothing in the RPC surface observes
+whether `ctx.ui.setEditorComponent` produced a working modal editor. That is only
+visible on a real terminal, so this probe allocates a pty, drives one keystroke
+sequence, and reads the rendered frames back.
+
+The sequence is `i`, `abc`, Esc, `x`. pi's prompt starts in insert mode, so the
+leading `i` is literal text and the buffer reads `iabc`; Esc leaves insert mode
+and `x` deletes the character under the cursor. The oracle is the discriminating
+difference against a run with pi-vim unregistered:
+
+  with pi-vim     buffer `iab`,  INSERT and NORMAL mode labels rendered
+  without pi-vim  buffer `iabcx`, no mode labels
+
+Deliberately not a flake check. Every wait here is a wall-clock sleep against TUI
+repaint, which is load-sensitive in a way a build sandbox running other
+derivations in parallel would make flaky. Promoting it would mean replacing the
+sleeps with a render-settled predicate first.
+
+Usage:
+    DRIVE_HOME=<scratch dir> DRIVE_OUT=<transcript path> \
+      python3 pi-vim-modal-editing-probe.py <pi executable> <pi-vim store path> \
+      [patched|novim]
+"""
+
+import json
+import os
+import pty
+import re
+import select
+import shutil
+import sys
+import time
+from pathlib import Path
+
+PI = sys.argv[1]
+VIM = sys.argv[2]
+REGISTER_VIM = (sys.argv[3] if len(sys.argv) > 3 else "patched") == "patched"
+
+STARTUP_SETTLE_SECONDS = 6.0
+KEYSTROKE_SETTLE_SECONDS = 1.5
+
+home = Path(os.environ["DRIVE_HOME"])
+if home.exists():
+    shutil.rmtree(home)
+agent = home / ".pi" / "agent"
+agent.mkdir(parents=True)
+(home / "proj").mkdir()
+(home / "tmp").mkdir()
+(agent / "settings.json").write_text(
+    json.dumps({"enableInstallTelemetry": False, "packages": [VIM] if REGISTER_VIM else []})
+)
+# Offline mode still requires a selectable model for the TUI to reach the prompt.
+(agent / "models.json").write_text(
+    json.dumps(
+        {
+            "providers": {
+                "smoke-local": {
+                    "baseUrl": "http://127.0.0.1:9/v1",
+                    "api": "openai-completions",
+                    "models": [{"id": "smoke-model"}],
+                }
+            }
+        }
+    )
+)
+
+env = {
+    "HOME": str(home),
+    "PI_CODING_AGENT_DIR": str(agent),
+    "XDG_CONFIG_HOME": str(home / ".config"),
+    "XDG_DATA_HOME": str(home / ".local" / "share"),
+    "XDG_CACHE_HOME": str(home / ".cache"),
+    "TMPDIR": str(home / "tmp"),
+    "PI_OFFLINE": "1",
+    "TERM": "xterm-256color",
+    "PATH": os.environ["PATH"],
+    "COLUMNS": "100",
+    "LINES": "30",
+}
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.chdir(str(home / "proj"))
+    os.execve(
+        PI,
+        [PI, "--no-session", "--no-approve", "--model", "smoke-local/smoke-model"],
+        env,
+    )
+
+frames = b""
+
+
+def pump(seconds):
+    global frames
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.2)
+        if not readable:
+            continue
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        frames += chunk
+
+
+pump(STARTUP_SETTLE_SECONDS)
+for keys in (b"iabc", b"\x1b", b"x"):
+    os.write(fd, keys)
+    pump(KEYSTROKE_SETTLE_SECONDS)
+try:
+    os.write(fd, b"\x03")
+    pump(0.5)
+    os.write(fd, b"\x03")
+    pump(1.0)
+except OSError:
+    pass
+os.close(fd)
+try:
+    os.waitpid(pid, 0)
+except ChildProcessError:
+    pass
+
+transcript = frames.decode("utf-8", "replace")
+Path(os.environ["DRIVE_OUT"]).write_text(transcript)
+plain = re.sub(
+    r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b[\]P][^\x07\x1b]*(\x07|\x1b\\)?|\x1b[()][A-B0-2]", "", transcript
+)
+
+observations = {
+    "insert_label": "INSERT" in plain,
+    "normal_label": "NORMAL" in plain,
+    "typed_text_reached_buffer": "iabc" in plain,
+    "normal_mode_x_deleted_rather_than_inserted": "iabcx" not in plain,
+}
+expected = dict.fromkeys(observations, REGISTER_VIM)
+expected["typed_text_reached_buffer"] = True
+
+for name, observed in observations.items():
+    print(f"{name}={observed} expected={expected[name]}")
+if observations != expected:
+    raise SystemExit(f"probe oracle violated; transcript at {os.environ['DRIVE_OUT']}")
+print("probe=ok")

--- a/docs/notes/development/ai-agents/pi-vim-modal-editing.md
+++ b/docs/notes/development/ai-agents/pi-vim-modal-editing.md
@@ -1,0 +1,57 @@
+# pi-vim modal editing: enablement evidence
+
+Records why `lajarre/pi-vim` 0.14.1 is registered for pi alone, and what evidence stands behind each half of that claim.
+Companion to [atomic npm-distribution compatibility findings](../atomic-npm-distribution-compat.md), which owns the per-extension load matrix.
+
+## The downstream patch
+
+`clipboard-mirror.ts:56` calls `import.meta.resolve("@earendil-works/pi-coding-agent")` at module scope, to embed the host agent's module URL in the source of a clipboard helper child process.
+pi satisfies that specifier through its virtual-module map rather than through `node_modules`, so `import.meta.resolve` throws, and a throw at module scope fails the whole extension rather than the clipboard mirror alone.
+`pkgs/by-name/pi-vim/package.nix` substitutes the bare specifier for the call.
+
+The remedy is re-derived per version bump: `substituteInPlace --replace-fail` turns a moved or reworded call site into a build failure rather than a silently unpatched output.
+
+The narrower upstream fix would resolve lazily at first clipboard use and degrade the OS-clipboard mirror, which is where this extension is already fragile — compare pi issue #3496, a macOS clipboard panic.
+Filing it upstream is worth more than carrying the substitution indefinitely: the defect breaks upstream's own documented `pi install npm:pi-vim` and has been present since 0.11.2.
+
+## Load evidence, and why the smoke regulator is severe
+
+`pi-agent-environment-smoke` drives the deployed pi wrapper over RPC and fails on any `extension_error` or non-zero exit.
+Its settings fixture takes `packageEntries` from pi's evaluated settings, so pi-vim entered its coverage with the wiring and no fixture edit.
+
+Falsified deliberately by dropping `postPatch` from the derivation and re-running:
+
+```
+AssertionError: Pi exited 1: Error: Failed to load extension ".../pi-vim-0.14.1/index.ts":
+Failed to load extension: ResolveMessage: Cannot find module '@earendil-works/pi-coding-agent'
+from ".../pi-vim-0.14.1/clipboard-mirror.ts"
+```
+
+So the regulator does discriminate the patched build from the unpatched one, and the patch is load-bearing rather than precautionary.
+Note the failure arrives at the driver's `returncode` guard, not at its `extension_error` conjunct: pi exits 1 having written zero bytes to stdout, so no RPC frame is ever emitted.
+
+## Behaviour evidence
+
+Loading is not working. pi-vim registers no slash command, so nothing on the RPC surface observes whether `ctx.ui.setEditorComponent` produced a live modal editor — the failure mode under atomic is exactly a clean load with a dead editor.
+`pi-vim-modal-editing-probe.py` beside this note allocates a pty, sends `i`, `abc`, Esc, `x`, and reads the rendered frames.
+
+pi's prompt starts in insert mode, so the leading `i` is literal text and the buffer reads `iabc`; Esc leaves insert mode and `x` deletes the character under the cursor.
+Both arms observed on aarch64-darwin against pi 0.84.2:
+
+| observation | pi-vim registered | pi-vim unregistered |
+|---|---|---|
+| INSERT mode label rendered | yes | no |
+| NORMAL mode label rendered | yes | no |
+| typed text reaches the buffer | yes | yes |
+| final buffer | `iab` | `iabcx` |
+
+The last row is the discriminating one: with modal editing live, `x` deleted a character; without it, `x` was inserted as literal text.
+
+The probe is deliberately not a flake check. Every wait in it is a wall-clock sleep against TUI repaint, which a build sandbox running other derivations in parallel would make flaky. Promoting it means replacing those sleeps with a render-settled predicate first.
+
+## Why pi only
+
+Registration goes through `aiAgentSettings.piOnlyPackages` rather than the shared `packages` list.
+That option's description in `modules/home/ai/agent-settings.nix` carries the mechanism and the reason; in short, atomic declaring its own `packages` key shadows pi's array wholesale, so the entry reaches pi alone with no force-exclude, and under atomic pi-vim would load, warn on the `setEditorComponent` stub, and leave the native editor in place with no modal keybindings.
+
+`modules/checks/atomic-agent-environment.nix` asserts both halves — present in pi's declared packages, absent from atomic's — because atomic's half is invisible from atomic's side alone.

--- a/modules/checks/atomic-agent-environment.nix
+++ b/modules/checks/atomic-agent-environment.nix
@@ -6,7 +6,10 @@
 #
 # What this guards. modules/home/ai/agent-settings.nix generates one settings
 # payload for two agents, and `packages` is the single key they do not share
-# verbatim: atomic takes packagesForAtomic, which appends
+# verbatim. It diverges twice over, through two different mechanisms that this
+# check asserts separately because a change can break either one alone.
+#
+# Within a shared package entry, atomic takes packagesForAtomic, which appends
 # atomicExtensionExclusions as `-`-prefixed force-excludes. The divergence is
 # deliberate and one-sided, and both halves have to hold at once — atomic must
 # exclude statusline because atomic 0.9.13's isolated interactive engine refuses
@@ -14,9 +17,18 @@
 # Asserting only atomic's half would pass a change that silently disarmed the
 # extension for both agents.
 #
+# At the level of whole entries, pi's list is the shared one plus
+# aiAgentSettings.piOnlyPackages, which needs no force-exclude: atomic declaring
+# its own `packages` shadows pi's array wholesale. pi-vim is the entry that
+# relies on this, and the claim is two-sided for the same reason — an entry that
+# reached atomic too would load, warn on the setEditorComponent stub, and leave
+# atomic's native editor in place with no modal keybindings, which is invisible
+# from atomic's side alone.
+#
 # Falsifiability: dropping "statusline/index.ts" from atomicExtensionExclusions
 # flips atomicNegativeExtensions against the literal below; propagating the
-# exclusion to pi flips piNegativeExtensions.
+# exclusion to pi flips piNegativeExtensions. Moving pi-vim from piOnlyPackages
+# into packages flips atomicPiOnlyPackages; dropping it flips piOnlyPackages.
 #
 # The retraction claim is why atomicDeclaresPackages is asserted separately
 # rather than inferred from the selector lists. modules/home/ai/atomic/
@@ -58,6 +70,28 @@
       piSelectors = selectorsFor piConfig.settings;
       positive = builtins.filter (selector: !lib.hasPrefix "-" selector);
       negative = builtins.filter (selector: lib.hasPrefix "-" selector);
+      # A piOnlyPackages entry is a bare store-path string. It is reported by
+      # package name rather than by path: a hash in the oracle would churn on
+      # every unrelated rebuild, and mkStructuralCheck serializes `actual` into a
+      # derivation attribute, which refuses a string carrying store-path context.
+      piOnlyPaths = map toString homeConfig.aiAgentSettings.piOnlyPackages;
+      nameOf =
+        path:
+        let
+          base = builtins.unsafeDiscardStringContext (builtins.baseNameOf path);
+          stripped = builtins.match "[a-z0-9]+-(.*)" base;
+        in
+        lib.getName (if stripped == null then base else builtins.head stripped);
+      piOnlyNamesIn =
+        settings:
+        let
+          declared = settings.packages or [ ];
+        in
+        map nameOf (
+          builtins.filter (
+            path: lib.any (entry: !builtins.isAttrs entry && entry == path) declared
+          ) piOnlyPaths
+        );
     in
     {
       checks = {
@@ -73,6 +107,11 @@
             # two sources would make the lists incomparable and the exclusion
             # meaningless.
             sharedExtensionSource = atomicSelectors != [ ] && piSelectors != [ ];
+            # Whole-entry divergence, the channel that carries no force-exclude
+            # and is therefore invisible in the selector lists above.
+            piOnlyPackages = map nameOf piOnlyPaths;
+            piPiOnlyPackages = piOnlyNamesIn piConfig.settings;
+            atomicPiOnlyPackages = piOnlyNamesIn atomicConfig.settings;
           };
           expected = {
             atomicDeclaresPackages = true;
@@ -105,6 +144,9 @@
               "-notify/index.ts"
             ];
             sharedExtensionSource = true;
+            piOnlyPackages = [ "pi-vim" ];
+            piPiOnlyPackages = [ "pi-vim" ];
+            atomicPiOnlyPackages = [ ];
           };
         };
       };

--- a/modules/checks/pi-agent-environment.nix
+++ b/modules/checks/pi-agent-environment.nix
@@ -74,6 +74,8 @@
       extensionSource = if extensionPackage == null then null else toString extensionPackage;
       compactionPackage = self'.packages.pi-openai-server-compaction or null;
       compactionSource = if compactionPackage == null then null else toString compactionPackage;
+      vimPackage = self'.packages.pi-vim or null;
+      vimSource = if vimPackage == null then null else toString vimPackage;
       packageEntries = piConfig.settings.packages or [ ];
       extensionEntry = lib.findFirst (
         entry: builtins.isAttrs entry && (entry.source or null) == extensionSource
@@ -2193,6 +2195,15 @@
             compactionRetained =
               compactionSource != null
               && lib.any (entry: !builtins.isAttrs entry && entry == compactionSource) packageEntries;
+            # pi's `packages` is the shared list plus aiAgentSettings.piOnlyPackages.
+            # This claims only that pi receives the vim entry through that channel;
+            # modules/checks/atomic-agent-environment.nix owns the other half, that
+            # atomic does not.
+            vimRetained =
+              vimSource != null && lib.any (entry: !builtins.isAttrs entry && entry == vimSource) packageEntries;
+            vimViaPiOnlyChannel = builtins.elem vimSource (
+              map toString homeConfig.aiAgentSettings.piOnlyPackages
+            );
             inherit globalInstructionsNixOwned piSpecificSkillsPresent;
             canonicalSkills = if canonicalSkillsScript == "" then null else "~/.agents/skills";
             slowModeSettingsShape = builtins.attrNames piConfig.settings;
@@ -2287,6 +2298,8 @@
               "rip2"
             ];
             compactionRetained = true;
+            vimRetained = true;
+            vimViaPiOnlyChannel = true;
             globalInstructionsNixOwned = true;
             canonicalSkills = "~/.agents/skills";
             piSpecificSkillsPresent = false;

--- a/modules/home/ai/agent-settings.nix
+++ b/modules/home/ai/agent-settings.nix
@@ -94,6 +94,45 @@
           description = "Extension packages registered with every pi-lineage agent, in pi's settings.json packages format.";
         };
 
+        piOnlyPackages = lib.mkOption {
+          type = lib.types.listOf (lib.types.either lib.types.str jsonFormat.type);
+          default = [ "${pkgs.pi-vim}" ];
+          description = ''
+            Extension packages registered with pi and with no other pi-lineage agent.
+
+            This is a third divergence channel, distinct from both
+            `packagesForAtomic` and `extensionsForAtomic`, and it needs no
+            force-exclude at all. `readMergedSettings` deep-merges the two
+            settings files (core/settings-storage.ts:70-81) and `deepMergeObjects`
+            treats an array as unmergeable (core/settings-merge.ts:3-5), so it
+            assigns the override wholesale: atomic declaring its own `packages`
+            key shadows pi's outright and an entry here reaches pi alone.
+            modules/checks/atomic-agent-environment.nix asserts that atomic keeps
+            declaring the key, which is the premise this relies on. Contrast
+            `piOnlyExtensions`, which needs force-excludes precisely because the
+            `~/.pi/agent/extensions/` directory is scanned unconditionally by both
+            agents (core/package-manager-auto-resources.ts:188).
+
+            pi-vim is here because modal editing is pi-only in practice, not
+            because atomic fails to load it. Under the npm distribution
+            pkgs/by-name/atomic now builds, atomic resolves
+            `@earendil-works/pi-coding-agent` through the `_aliases` map and
+            pi-vim 0.14.1 loads with exit status 0. What is dead is the editor:
+            `ctx.ui.setEditorComponent` is a warn-once stub in every atomic
+            distribution, never remoted to the isolated interactive engine child
+            the way `EngineCustomUiService` remotes `ctx.ui.custom`, so under
+            atomic the extension registers, warns, and leaves the native editor
+            in place with no modal keybindings. Registering it there would spend
+            a startup warning and a 58 KB source tree to change nothing an
+            operator can observe. Restoring it under atomic is an upstream fix
+            (route `setEditorComponent` through the existing remoting machinery)
+            or a ground-up atomic-native extension on `ctx.ui.custom`, not a
+            packaging change here. See
+            docs/notes/development/atomic-npm-distribution-compat.md for the
+            per-extension load matrix this rests on.
+          '';
+        };
+
         atomicExtensionExclusions = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ "statusline/index.ts" ];

--- a/modules/home/ai/pi/default.nix
+++ b/modules/home/ai/pi/default.nix
@@ -46,15 +46,21 @@
 
           # https://pi.dev/docs/latest/settings
           #
-          # These four keys are declared in modules/home/ai/agent-settings.nix
-          # so pi's file and atomic's are generated from one expression.
+          # These keys are declared in modules/home/ai/agent-settings.nix so
+          # pi's file and atomic's are generated from one expression.
+          #
+          # `packages` is the exception: pi's value is the shared list plus
+          # piOnlyPackages, which atomic never sees because its own `packages`
+          # declaration shadows pi's rather than merging with it. See that
+          # option's description for the mechanism and for why pi-vim is scoped
+          # this way.
           settings = {
             inherit (config.aiAgentSettings)
               theme
               enableInstallTelemetry
               hideThinkingBlock
-              packages
               ;
+            packages = config.aiAgentSettings.packages ++ config.aiAgentSettings.piOnlyPackages;
           };
         };
 

--- a/pkgs/by-name/pi-vim/package.nix
+++ b/pkgs/by-name/pi-vim/package.nix
@@ -1,0 +1,72 @@
+# lajarre/pi-vim, packaged from the published npm distribution.
+#
+# The npm tarball rather than fetchFromGitHub, for three independent reasons.
+# The repository ships a top-level `doc/` directory, which stdenv's
+# `forceShare = [ "man" "doc" "info" ]` silently relocates to share/doc during
+# fixup; the tarball's `files` list excludes it. Upstream has 7 git tags against
+# 24 npm versions with a hole from 0.3.2 to 0.13.0, so a tag-tracking
+# nix-update-script would never fire. And upstream publishes no GitHub releases,
+# so a `changelog` meta line would 404.
+#
+# The tarball unpacks to `package/`, hence sourceRoot; its sha256 is
+# cross-checkable against the registry's published dist.integrity.
+{
+  fetchurl,
+  lib,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "pi-vim";
+  version = "0.14.1";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/pi-vim/-/pi-vim-${finalAttrs.version}.tgz";
+    hash = "sha256-gAsnQvbaNS7ug9tQPFQhwhXtHLrrO2mHBiNQLh9ZGQs=";
+  };
+
+  sourceRoot = "package";
+
+  dontConfigure = true;
+  dontBuild = true;
+  strictDeps = true;
+
+  # clipboard-mirror.ts resolves the host agent's module URL at module scope, to
+  # embed it in the source of a clipboard helper child process. `import.meta.resolve`
+  # throws on a specifier pi satisfies through its virtual-module map rather than
+  # through node_modules, and a throw at module scope is a fatal extension-load
+  # error for the whole extension, not just the clipboard mirror. The bare
+  # specifier is what the child would need anyway; it degrades the OS-clipboard
+  # mirror instead of the editor. Re-derive this call site on every version bump:
+  # --replace-fail turns a moved or reworded call into a build failure rather
+  # than a silently unpatched output.
+  postPatch = ''
+    substituteInPlace clipboard-mirror.ts --replace-fail \
+      'import.meta.resolve(
+      "@earendil-works/pi-coding-agent",
+    )' \
+      '"@earendil-works/pi-coding-agent"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    sourceNodeModules=$(find . -type d -name node_modules -print -quit)
+    if [ -n "$sourceNodeModules" ]; then
+      echo "pi-vim source contains node_modules: $sourceNodeModules" >&2
+      exit 1
+    fi
+
+    mkdir -p "$out"
+    cp -R . "$out/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Vim-style modal editing for Pi's TUI editor";
+    homepage = "https://github.com/lajarre/pi-vim";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Registers `lajarre/pi-vim` 0.14.1 with pi through a new `aiAgentSettings.piOnlyPackages` option, packaged from the npm tarball with one downstream `substituteInPlace`.
atomic stays excluded, with the reason recorded beside the exclusion.

## The derivation

`pkgs/by-name/pi-vim/package.nix` fetches the npm tarball rather than the git tree, for three independent reasons: the repository ships a top-level `doc/` that stdenv's `forceShare` silently relocates; upstream has 7 tags against 24 npm versions, so a tag-tracking `nix-update-script` would never fire; and upstream publishes no releases, so a `changelog` meta line would 404.

The one patch is load-bearing rather than cosmetic.
`clipboard-mirror.ts:56` calls `import.meta.resolve("@earendil-works/pi-coding-agent")` at module scope, to embed the host agent's module URL in the source of a clipboard helper child process.
pi satisfies that specifier through its virtual-module map rather than through `node_modules`, so the call throws, and a throw at module scope fails the whole extension rather than the clipboard mirror alone.
`--replace-fail` turns a moved or reworded call site into a build failure on the next version bump rather than a silently unpatched output.

## Why pi only

`piOnlyPackages` is a third divergence channel beside `packagesForAtomic` and `extensionsForAtomic`, and unlike both it needs no force-exclude: `deepMergeObjects` treats an array as unmergeable, so atomic declaring its own `packages` key shadows pi's wholesale and an entry reaches pi alone.

The exclusion's reason is *not* the one the earlier investigation recorded.
Under the npm-dist atomic build this repo now ships, atomic resolves `@earendil-works/pi-coding-agent` through the `_aliases` map and pi-vim loads at exit 0.
What is dead is the editor: `ctx.ui.setEditorComponent` is a warn-once stub never remoted to the isolated interactive engine child the way `EngineCustomUiService` remotes `ctx.ui.custom`, so under atomic the extension would register, warn, and leave the native editor in place with no modal keybindings.
That is recorded on the option itself and in `docs/notes/development/ai-agents/pi-vim-modal-editing.md`.

`modules/checks/atomic-agent-environment.nix` now asserts both halves — present in pi's declared packages, absent from atomic's — because atomic's half is invisible from atomic's side alone.

## Verification

Checks run: `package-pi-vim`, `pi-agent-environment-{structural,policy,smoke}`, `atomic-agent-environment-structural`, `home-manager-crs58`, `naming-conventions`, `eval-md-format`, `treefmt`. All green.
That is the new option, its two consumers, the two regulators asserting the divergence, the derivation, and the only home configuration that takes the `ai` aggregate — `crs58` is the sole user whose `meta.nix` lists it.

The smoke regulator was falsified deliberately rather than merely observed passing. With `postPatch` dropped it fails at its `returncode` guard:

```
AssertionError: Pi exited 1: Error: Failed to load extension ".../pi-vim-0.14.1/index.ts":
ResolveMessage: Cannot find module '@earendil-works/pi-coding-agent'
from ".../pi-vim-0.14.1/clipboard-mirror.ts"
```

Loading is not working, and pi-vim registers no slash command, so nothing on the RPC surface observes whether `setEditorComponent` produced a live editor — which is exactly atomic's failure mode.
Behaviour is covered by `docs/notes/development/ai-agents/pi-vim-modal-editing-probe.py`, a pty driver sending `i`, `abc`, Esc, `x`, run on both arms:

| observation | pi-vim registered | pi-vim unregistered |
|---|---|---|
| INSERT / NORMAL labels rendered | yes | no |
| final buffer | `iab` | `iabcx` |

With modal editing live, `x` deleted a character; without it, `x` was inserted as literal text.

## Judgement calls worth a second opinion

The probe is deliberately **not** a flake check. Every wait in it is a wall-clock sleep against TUI repaint, which a build sandbox running other derivations in parallel would make flaky; promoting it means replacing those sleeps with a render-settled predicate first. If you would rather have it in CI on those terms, say so.

Left out of the test selection: the `darwin-*` system closures, and `home-manager-cameron`, an alias resolving to the same `crs58` aggregates.

Not touched, per the standing context guard: `AGENTS.md` / `CLAUDE.md` anywhere in the tree.
