### PR TITLE
Adopt communication rules, log capture, and nix diagnostics into agent context

### DIFF
--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-prose-clarity/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-prose-clarity/SKILL.md
@@ -31,6 +31,20 @@ The grounding is Williams, Gopen & Swan, Pinker, Thomas & Turner, and McEnerney;
 12. Escape hatch: break any rule here sooner than write something awkward or ambiguous.
     When rules conflict, minimize reader processing cost.
 
+## Conversational register
+
+The rules above govern prose on the page; they govern a chat-style answer the same way, where the closing line is what the reader acts on.
+
+A factual investigation, asked as a yes-or-no question.
+Do: "No: `fetch_with_backoff` only retries on 5xx, a timeout raises immediately, and the caller in `sync.rs:112` doesn't catch it, so a slow network drops the sync silently."
+Do not: "I traced through `fetch_with_backoff`'s retry logic; there's handling for several error categories, and timeouts might fall into one that isn't fully covered, though it's hard to say without digging further."
+The do-not side never answers the question asked; the hedge substitutes for a decision the evidence already supports.
+
+An engineering recommendation.
+Do: "No. The handler is idempotent and the caller already retries with backoff; a second retry layer would double-process events on partial failure. Leave it as-is."
+Do not: "That's a good question — there are real tradeoffs either way, since a retry queue adds resilience but also complexity. It depends on your priorities."
+The do-not side opens with unearned agreement and closes by summarizing the tradeoff instead of choosing one.
+
 ## Highest-blast-radius prose
 
 Published, binding, or long-lived prose — repo-level AGENTS.md and CLAUDE.md files, specs, API-adjacent docs — gets strong care under this skill, not fast decisions.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
@@ -87,6 +87,22 @@ Create subdirectories when extractions form natural hierarchies or exceed 4-5 re
 
 Avoid splitting when it would fragment a genuinely cohesive unit or create excessive coupling through circular references.
 
+### Log capture and scratch output
+
+Log files captured with `tee` during long-running commands live in a repository's `logs/` directory, named with a lower-kebab-case identifier and a timestamp suffix, matching the command form given for long-running commands:
+
+```bash
+<command> 2>&1 | tee logs/<lower-kebab-identifier>-$(date +%Y%m%d-%H%M%S).log
+```
+
+Before writing there, verify that `logs/` is actually ignored by that repository.
+If it is not ignored, write to `$XDG_STATE_HOME/agent-logs/<repo>/` instead and report the missing ignore entry rather than adding it silently.
+Never leave an untracked, unignored file inside a jj working copy; see `~/.claude/skills/jj-version-control/hazards.md` for why a tracked log file is harmful once jj has begun snapshotting it.
+Never delete logs within a session.
+Pruning anything older than fourteen days is an explicit maintenance action only, never a side effect of other work.
+When writing code, follow the XDG Base Directory specification for config, cache, and data paths.
+Keep a scratch directory for agent working output rather than scattering it across the working tree.
+
 ## Development workflow and tooling
 
 ### Pre-implementation checkpoint

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
@@ -120,6 +120,12 @@ See `preferences-validation-assurance` for the severity criterion and confidence
 - Local test execution is the primary feedback loop during development.
   Run tests iteratively as you work, fixing issues before committing.
   CI workflow verification is a distinct stage that occurs when validating a branch for merge/pull request, not during routine local development.
+- Choose the narrowest verification that could actually falsify the change at hand.
+  An evaluation-only change — documentation, skill text, prose, a module option description, anything that alters no derivation — is verified by `nix eval` on the affected attribute, and a build adds nothing.
+  A change affecting one check is verified by `nix build .#checks.<name>` for that check.
+  The full parallel run over every check belongs to pre-pull-request validation, or to a change whose blast radius is genuinely repository-wide, and is not a routine iteration step.
+  The reason is cost against information: a full run takes minutes to hours and, for a one-file change, tells you almost nothing the targeted check does not, and spending it wantonly trains the habit of not knowing which check actually covers your change.
+  This is about scope for the moment rather than building individual tests instead of the check set — the parallel runner exists so that coverage never has to be traded for speed.
 
 ### CI workflow log verification
 

--- a/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-development/SKILL.md
@@ -52,6 +52,14 @@ Run `shellcheck <file>` directly on shell scripts before committing.
 This is faster than a full `nix build` and catches the same class of errors that `checkPhase` would surface.
 A full `nix build` (without `--dry-run`) of the relevant derivation remains the definitive verification, as it executes `checkPhase` with the exact shellcheck configuration the derivation specifies.
 
+## Command-line diagnostics
+
+- Inspect a failed build's log with `nix log /nix/store/<drv-or-out>`, filtered for the relevant text, rather than re-running the build to see its output
+- Find which package provides a given path with `nix-locate`, for example `nix-locate bin/ip`
+- Look up flake attributes with `nix eval` rather than `nix flake show`
+- For cross-architecture builds, use `nix-build --eval-system <system>`; in flakes, address the system attribute directly, for example `.#packages.x86_64-linux.hello`
+- Generate or update a package patch by cloning the source, optionally applying the existing patch, making the edits, then producing the new patch with `git format-patch`
+
 ## Nix code style
 - Format with `nix fmt`
 - Use explicit function arguments, not `with` statements

--- a/modules/home/tools/agents-md.nix
+++ b/modules/home/tools/agents-md.nix
@@ -126,6 +126,46 @@
           - prose, any writing or editing: ${skillsPath}/preferences-prose-clarity/SKILL.md
           - code, specs, and proofs: ${skillsPath}/preferences-essential-complexity/SKILL.md
 
+          # Communication
+
+          When presenting three or more findings, decisions, options, risks,
+          questions, or actions, assign each a short reference code and reuse
+          the same codes for the rest of the conversation: D for decisions, O
+          for options, F for findings, R for risks, Q for questions, A for
+          actions. Do not create codes for short, simple answers. This
+          namespace is conversational only: a reference to an OpenSpec design
+          decision stays qualified — "design D9", or the change id — so a
+          conversational D1 is never confused with a numbered design decision
+          in the same exchange.
+
+          Four aliases expand only as standalone tokens; inside a longer string
+          they are ordinary text.
+          - `scr` — simplify, compress, restate the same content shorter, with
+            no new material.
+          - `foc` — identify the single highest-value thread and answer only
+            that, dropping the rest.
+          - `ref` — rewrite the previous response using reference codes.
+          - `eli` — reduce vocabulary and sentence length for a general reader
+            without discarding technical content.
+
+          Avoid these phrases in our own prose: "load-bearing", "worth stating
+          plainly", "here's the honest truth", "the real tension", "carry the
+          argument". This governs chat and written output; it does not replace
+          the `unslop` skill, which owns artifact rewriting.
+
+          When two or more questions genuinely block progress, print them as a
+          numbered list, one line each, with a recommended answer under each;
+          the human replies only with the numbers whose recommendation they
+          want changed, and silence on a number means the recommendation
+          stands. A single question stays inline in prose. Silence never adopts
+          a recommendation that is destructive, irreversible,
+          security-sensitive, or spends money — those always require explicit
+          words. The questions are printed in the response.
+
+          Lead with the conclusion and follow with evidence; closing lines
+          carry the decision or the next action, not a summary of what was
+          already said.
+
           # Engineering standards
 
           ## Compositional architecture and type discipline
@@ -217,6 +257,25 @@
           A command that will run for a long time, stream output, or need
           input later belongs in a managed background process, not a
           blocking foreground call that ties up the turn waiting on it.
+
+          The capture itself is absolute and the numeric thresholds are
+          advisory. Any command expected to run longer than roughly thirty
+          seconds or produce more than roughly ten lines is run as:
+
+              <command> 2>&1 | tee logs/<lower-kebab-identifier>-$(date +%Y%m%d-%H%M%S).log
+
+          A `tail` or filter may follow the `tee`, never replace it. A pipeline
+          reports the exit status of its last stage, so piping straight to
+          `tail` has already reported a real lint failure as success in this
+          fleet; output exists once, so a discarded portion is unrecoverable
+          and every later question costs a re-run; a state-mutating command
+          cannot be re-run at all, so its evidence is simply gone; and a human
+          cannot `tail -f` a pipeline, so skipping capture silently removes
+          their ability to watch work they delegated.
+
+          Where the log files live and how the directory is verified is owned
+          by the `preferences-style-and-conventions` skill's "File
+          organization" section.
 
           ## Subagent dispatch contract
 


### PR DESCRIPTION
Adopts a settled set of communication and log-capture rules into the generated agent context body and three skills. Agent instructions only, so no OpenSpec change and no Linear story.

## What changed

`modules/home/tools/agents-md.nix` gains a `# Communication` section: reference codes for presentations of three or more findings, decisions, options, risks, questions, or actions, with the bare letters reserved for conversation so `D1` never collides with a numbered OpenSpec design decision; the four standalone-token aliases `scr`, `foc`, `ref`, `eli`; five phrases to avoid in our own prose, governing chat and written output without displacing `unslop`; the numbered open-questions protocol where silence adopts the recommendation, carved out for anything destructive, irreversible, security-sensitive, or that spends money; and conclusion-first ordering with closing lines carrying the decision or next action.

The existing `## Long-running commands` section is extended rather than duplicated, since capture is the same decision point as backgrounding. Capture is absolute, thresholds advisory: past roughly thirty seconds or ten lines, tee to `logs/`. A `tail` may follow the `tee`, never replace it, because a pipeline reports its last stage's status and piping straight to `tail` has already reported a real lint failure as success in this fleet.

`preferences-style-and-conventions` takes ownership of where those logs live, under the "File organization" section that already owns where files go: `logs/` with a lower-kebab identifier and timestamp, verified ignored before anything is written, otherwise `$XDG_STATE_HOME/agent-logs/<repo>/` with the missing ignore entry reported rather than silently added. Retention is never-delete-within-a-session and fourteen-day pruning as an explicit maintenance action. Plus XDG Base Directory paths when writing code, and a scratch directory for agent working output.

`preferences-nix-development` gains five command-line diagnostics: `nix log` instead of re-running a failed build, `nix-locate`, `nix eval` over `nix flake show`, `--eval-system` and direct system attributes for cross-architecture builds, and `git format-patch` for regenerating a package patch.

`preferences-style-and-conventions` also gains, beside the existing testing bullets in "Development workflow and tooling", the rule for choosing a verification: pick the narrowest one that could actually falsify the change at hand. An evaluation-only change — documentation, skill text, prose, a module option description, anything that alters no derivation — is verified by `nix eval` on the affected attribute. A change affecting one check is verified by `nix build .#checks.<name>`. The full parallel run belongs to pre-pull-request validation or a genuinely repository-wide blast radius, not to routine iteration, because it takes minutes to hours and tells you almost nothing extra about a one-file change while training the habit of not knowing which check covers it. This is not a rule to build individual tests instead of the check set: the parallel runner exists so coverage is never traded for speed. It lands in this skill because it is the only one with `@` auto-loading, so it reaches the moment of decision; `nix-flake-pr-cycle`, which takes the opposite default, is untouched.

`preferences-prose-clarity` gains two do-versus-do-not pairs for conversational register, one factual investigation and one engineering recommendation.

Deliberately not adopted: the reply-name prefix; "avoid semicolons, fragments, and non-standard punctuation" (contradicts our own permission to use fragments); "avoid analogies"; the sources' Purpose section; aliases beyond the four; and the claim that `nix flake check` is too slow and individual tests should be built instead, since `just check-fast` already fans the full set out in parallel. `nix-flake-pr-cycle`, `ci-log-verification`, and `unslop` are untouched: they carry specialized instances of the general capture rule rather than competing statements of it.

## Verification and test selection

Targeted `nix build` of the seven checks that consume the edited paths, all passing:

`treefmt`, `eval-agents-md`, `eval-md-format`, `pi-agent-environment-structural`, `pi-agent-environment-policy`, `atomic-agent-environment-structural`, `package-apm-skills-compose`.

That selection is severe for this diff: the two `*-agent-environment-*` structural checks assert `piConfig.context == programs.agents-md.settings.text`, so a nix-string escaping error or a broken generator fails them; `package-apm-skills-compose` composes the three edited `SKILL.md` files, so malformed frontmatter fails it; `treefmt` covers formatting of all four files.

Additionally verified out of band: `nix eval` of `programs.agents-md.settings.text` and a `nix build` of the `~/.claude/CLAUDE.md` derivation both carry the new text; the three skills' frontmatter parses as valid YAML with `name` and `description` intact.

Deliberately left out: `home-manager-crs58` and the five sibling user configurations, because they exercise the same generator through the same code path the derivation build above already exercised, and this diff adds no new file targets that could trip a home-manager assertion; and the `package-agent-plugins-*` family, which vendors external plugin trees this diff does not touch. A full `just check-fast` was started and abandoned as oversized for the change; its partial log shows no real failures.

The verification-scope commit is verified as its own rule requires. It alters no derivation, so `nix eval` on the affected attribute is the whole of it: `.#checks.aarch64-darwin.package-apm-skills-compose.drvPath` resolves and the frontmatter still parses. No check set was run for it.

## Two things to note rather than fix

The conclusion-first rule was specified as an amendment to existing guidance. A repository-wide search found no conclusion-first, evidence-second, or closing-line guidance anywhere in this repository, so it lands as new text.

"load-bearing" is now on the avoid list and already occurs three times in pre-existing body prose of `agents-md.nix` (the comment-policy paragraph twice, the jj squash-flags paragraph once) and repeatedly in `preferences-style-and-conventions`, where it names a protected category of comments. Reported, not changed: scrubbing it is a separate editorial pass, and in the style skill "load-bearing comment" is arguably a term of art rather than filler.
