### PR TITLE
docs(openspec): plan standing nixbot up beside buildbot on magnetite

### DIFF
--- a/openspec/changes/stand-up-nixbot-on-magnetite/.openspec.yaml
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: superpowers-bridge-wrspm
+created: 2026-08-27

--- a/openspec/changes/stand-up-nixbot-on-magnetite/brainstorm.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/brainstorm.md
@@ -1,0 +1,135 @@
+<!--
+Raw capture of the brainstorming step for this change.
+
+Procedural note, recorded rather than elided: the interactive `superpowers:brainstorming`
+dialogue was NOT run. This change was authored by an autonomous session whose launch brief
+pre-settled the scope decisions and instructed it not to wait for a human, so the
+schema-sanctioned manual-write path was taken. What follows is the decision log that the
+interactive skill would have produced: the questions that actually had to be answered, the
+options for each, the answer taken, and the evidence it rests on. Questions whose answer
+arrived pre-settled from the launch brief are marked `[given]`; the rest were decided from
+research evidence and are marked `[decided]`, with the evidence cited inline.
+-->
+
+# Background
+
+Two build services are in play, and one of them must not be disturbed.
+
+The incumbent is buildbot-nix, serving `buildbot.scientistexperience.net` from magnetite.
+Its composition path was genuinely unknown at the start of this work and is now established: `flake.nix:5` hands `modules/` to `import-tree`, `modules/nixos/buildbot.nix:20` assigns the aspect `flake.modules.nixos.buildbot`, `modules/machines/nixos/magnetite/default.nix:35-36` imports the upstream `inputs.buildbot-nix.nixosModules.buildbot-master` and `buildbot-worker` modules directly, and line 43 of the same file's aspect list names `buildbot`.
+`modules/clan/machines.nix:29-31` then binds `flake.modules.nixos."machines/nixos/magnetite"` into `clan.machines.magnetite`, which is what `clan machines update magnetite` deploys.
+No `machines/`-level import exists because host composition does not live there; it lives under `modules/machines/`.
+Magnetite is the only host importing the buildbot aspect.
+
+The candidate is nixbot, Mic92's single-process successor to the buildbot-nix master/worker pair.
+Its real NixOS surface is `nixosModules.nixbot` (`nixbot/flake.nix:65`); `buildbot-nix`, `buildbot-master`, and `buildbot-worker` are deprecated aliases that warn (`nixbot/flake.nix:56-68`).
+It is one systemd service plus a socket unit, evaluates with a bundled nix-eval-jobs, builds through the host nix daemon, scales out through ordinary nix remote builders, and has no worker concept at all (`nixbot/README.md:3-11, 46-55`; `nixbot/docs/MIGRATION.md:23-24`).
+
+Two migrated reference deployments exist.
+Mic92's own dotfiles is GitHub-backed like vanixiets and migrated in two phases: the module swap at `7e55c8a4` (2026-07-16) kept the old domain and the old check-name prefix, `7c99c63c` (2026-07-26) flipped the domain, and `0aa2dcc1`/`0b138e94` (2026-08-16) rewrote the deployment into Mic92's "flakelet" runtime shape.
+clan-infra is Gitea-backed and runs nixbot on `web01` through a wrapper module `flake.nixosModules.nixbot = [ inputs.nixbot.nixosModules.nixbot ./nixbot.nix ]` (`clan-infra/modules/flake-module.nix:59-62`), deployed by `clan machines update web01`, with credentials supplied by prompt-based `clan.core.vars` generators (`clan-infra/modules/nixbot.nix:9-84`).
+
+# Decision chain
+
+## Q1 [given]: does nixbot replace buildbot, or coexist with it?
+
+Coexist.
+Buildbot stays authoritative for every repository; nixbot is stood up beside it at `nixbot.scientistexperience.net`, and success is `clan machines update magnetite` deploying a working instance.
+This one answer propagates into almost every decision below, because both reference deployments assumed replacement and their choices invert under coexistence.
+
+## Q2 [decided]: which deployment shape — the upstream NixOS module, or Mic92's flakelet runtime?
+
+Taken: the upstream NixOS module, composed the way this repository already composes buildbot.
+
+The flakelet shape at dotfiles HEAD evaluates nixbot's units from the nixbot flake on the machine at runtime, decoupled from the NixOS generation, and needs three further Mic92-only inputs (`dotfiles/flake.nix:95-99`) plus a push-deploy path over step-ca SSH certificates (`dotfiles/machines/eve/modules/nixbot.nix:311-356`).
+Under that shape `clan machines update magnetite` would stop being the truth about what runs, which is exactly the property the brief names as success.
+The directly transferable precedent is the dotfiles snapshot at `df7be240` (2026-07-24): flake input, `inputs.nixbot.nixosModules.nixbot` imported at the host, a `services.nixbot` block, and a plain nginx vhost.
+That shape ran for a month before being replaced for reasons specific to Mic92's deploy tooling, and clan-infra still runs the equivalent today.
+
+Within that, one sub-fork: clan-infra bundles upstream and site config into a wrapper list, whereas vanixiets imports the upstream module at the machine and keeps site config in a named aspect (`modules/machines/nixos/magnetite/default.nix:29-51`).
+Follow vanixiets' own convention, since the buildbot precedent in this repository is exactly that and a second composition style would be a second convention beside an existing one.
+
+## Q3 [decided]: reuse buildbot's GitHub App, or register a second one?
+
+Taken: a second, dedicated GitHub App.
+
+dotfiles reused its App unchanged across the migration — same `appId` 915265, same OAuth client id, same three secret names — and that is strong evidence reuse works *when nixbot replaces buildbot*.
+Under coexistence the same move imports the incumbent's blast radius into the new service.
+nixbot needs Checks read-write and Pull requests read-only and the `check_run`/`check_suite` events (`nixbot/docs/GITHUB.md:23-33`), none of which buildbot-nix requires (`buildbot-nix/docs/GITHUB.md:23-36`), so reuse means editing the permissions of the App the running server depends on.
+Reuse also means one App-level webhook and one identity for both services; buildbot-nix creates per-repository webhooks pointing at `change_hook/github` (`buildbot-nix/buildbot_nix/buildbot_nix/github_projects.py:666-684`) while nixbot consumes the App-level webhook at `/webhooks/github` (`nixbot/docs/GITHUB.md:17-19`), so the two do not collide today, but a single App couples every later permission change to both.
+A second App costs one registration and three new credentials and keeps the incumbent's registration untouched, which is what "must keep working untouched" requires.
+
+## Q4 [decided]: how is "builds nothing yet" enforced?
+
+Taken: three independent boundaries, none of them claimed as end-to-end.
+
+nixbot's `github.topic` defaults to `build-with-buildbot` and performs a one-shot import on an empty database (`nixbot/nixosModules/nixbot.nix:434-444`).
+Left at its default against an App installed on this fleet's repositories, that default would sweep in precisely the repositories buildbot already builds, and double-build them.
+So: the forge application's installation selection bounds what nixbot can see at all; `github.topic = null` disables the topic import; and `repoAllowlist` names exactly the intended set.
+The first boundary lives in GitHub's UI, outside anything this repository can assert, which is why the interface capability states the boundary rather than claiming the guarantee.
+
+## Q5 [decided]: which check-name prefix?
+
+Taken: the default, `nixbot`.
+
+Both reference deployments set `statusContextPrefix = "buildbot"` (`clan-infra/modules/nixbot.nix`; `dotfiles/machines/eve/modules/nixbot.nix`), and both were right to, because nixbot inherited branch-protection rules that name `buildbot/...` contexts.
+Here the service those rules name is still running.
+Keeping the default `nixbot` prefix (`nixbot/nixosModules/nixbot.nix:326-337`) leaves the incumbent's verdicts as the only ones the forge's required checks name, which makes the new service's verdicts advisory by construction rather than by promise.
+
+## Q6 [decided]: reverse proxy and TLS
+
+Taken: the module-managed vhost with `nginx.enableACME = true`.
+
+nixbot's `nginx.enable` defaults true and creates the vhost proxying to `/run/nixbot/web.sock` (`nixbot/nixosModules/nixbot.nix:1122-1141`), but `nginx.enableACME` defaults **false** (`:866-869`), so TLS must be asked for explicitly.
+Every other vanixiets vhost on magnetite is `forceSSL` plus `enableACME` against one shared ACME account (`modules/machines/nixos/magnetite/default.nix:87-90`), so the flag reproduces the house pattern.
+Leaving nginx enabled also keeps the service off TCP entirely: the 8010 port is bound only when `nginx.enable = false` (`:937`), and 8010 happens to be the nixpkgs buildbot default, so disabling nginx would manufacture the one port collision available here.
+
+DNS is declarative through terranix, and there is no `nixbot` record today; the existing `buildbot` CNAME at `modules/terranix/cloudflare.nix:62-69` is the template, `proxied = false` so ACME's HTTP challenge reaches the host.
+
+## Q7 [decided]: database
+
+Taken: `database.createLocally = true` on magnetite's existing shared PostgreSQL.
+
+The host runs exactly one PostgreSQL instance, additively configured by gitea, matrix-synapse, cognee, niks3, and buildbot, listening on the local socket and loopback only.
+nixbot's local-database path adds database and role `nixbot` (`nixbot/nixosModules/nixbot.nix:1111-1120`) and connects over `/run/postgresql`, which merges into that instance rather than standing up a second one.
+No history carries over from buildbot (`nixbot/docs/MIGRATION.md:26-29`), which is irrelevant here because buildbot keeps its own database and its own history.
+
+## Q8 [decided]: credentials
+
+Taken: three `clan.core.vars` generators named after their consumer, mirroring the incumbent's naming.
+
+clan vars is this fleet's primary secrets system, with sops-nix retained for supplementary user secrets (`packages/docs/src/content/docs/guides/secrets-management.md:14-16`), and buildbot's own six generators are the in-repo pattern (`modules/nixos/buildbot.nix:22-100`), consumed as `...files."<file>".path`.
+nixbot takes every secret as a file path and passes it to the unit as a systemd credential (`nixbot/nixosModules/nixbot.nix:1028-1035`), so the same shape applies unchanged: App private key and OAuth secret are operator-populated slots, the webhook secret is generated.
+
+## Q9 [decided]: capacity
+
+Taken: size the new service explicitly and treat capacity, not naming, as the real coexistence risk.
+
+Names, units, users, databases, state directories, and GC-root directories are all disjoint between the two stacks by construction, which the mapping audit confirmed row by row.
+What is genuinely shared is finite: 32 GiB of memory against buildbot's four eval workers at 2 GiB each, one nix store under a 250 G ZFS quota with a `min-free`/`max-free` reaper and a 7-day GC window, one nginx, one PostgreSQL, one ACME account, and the same `/nix/var/nix/builds` sandbox tree that a June 2026 disk incident already taught this fleet about.
+So the change sizes nixbot's eval workers and build systems deliberately rather than accepting defaults derived from core count (`nixbot/nixosModules/nixbot.nix:271-287`).
+
+## Q10 [decided]: what about `buildbot-nix.toml`?
+
+Taken: leave it exactly as it is.
+
+The expectation going in was that everything carries over except artifacts like `buildbot-nix.toml`.
+That is refuted in its one named instance: the file is upstream buildbot-nix's own per-repository convention (`buildbot-nix/README.md:169-171`), vanixiets carries one at its root, and nixbot deliberately still parses that filename with the same schema plus a `build_branches` key (`nixbot/nixbot/nixbot/repo_config.py:14-15, 33-38`).
+Nothing needs renaming; a `nixbot.toml` is optional and belongs to a later migration change.
+
+## Q11 [given]: what is out of scope?
+
+Migrating vanixiets' own CI onto nixbot; migrating ironstar; finishing python-nix-template's migration, which never completed onto buildbot-nix and will retarget to nixbot; and retiring buildbot.
+Each is its own later change, named in the proposal's context and nowhere else in this change's artifacts.
+
+# Trade-offs accepted
+
+Two services doing the same job on one host is duplicated capability and duplicated resource draw, accepted because the alternative — cutting over — is the thing this change deliberately does not do.
+
+A second GitHub App is a second registration to keep track of and a second set of credentials to rotate, accepted because it is what keeps the incumbent's registration untouched.
+
+A service that builds nothing is, on the day it lands, unexercised beyond its own health: it serves its UI, receives authenticated webhook deliveries, and holds an empty project list.
+Accepted, because the first repository opted in is a reviewable step in a later change rather than a side effect of standing up infrastructure.
+
+Keeping the `nixbot` check-name prefix means that when a repository is later opted in, its required-checks configuration must be edited deliberately for nixbot's verdicts to matter.
+That is the cost of not silently inheriting the incumbent's authority, and it is the right way round.

--- a/openspec/changes/stand-up-nixbot-on-magnetite/design.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/design.md
@@ -1,0 +1,143 @@
+## Context
+
+Magnetite is a Hetzner CX53 cloud host (16 vCPU, 32 GiB, ZFS on one disk with a 250 G quota on `/nix`) that already carries most of this fleet's server-side services: buildbot-nix, gitea, gitea-actions-runner, kanidm, matrix, niks3, cognee, the SSO gateway, and omnigraph.
+Its composition is the repository's ordinary deferred-module pattern: `flake.nix:5` hands `modules/` to `import-tree`, each aspect file assigns a deferred module into `flake.modules.nixos.<aspect>`, `modules/machines/nixos/magnetite/default.nix:38-51` names the aspects this host takes, and `modules/clan/machines.nix:29-31` binds the resulting machine namespace into `clan.machines.magnetite`, which is what `clan machines update magnetite` deploys.
+The incumbent build service sits in that pattern twice over: the `buildbot` aspect at `modules/nixos/buildbot.nix:20` carries the site configuration, and the upstream master and worker modules are imported directly at the host (`modules/machines/nixos/magnetite/default.nix:35-36`).
+
+nixbot is the successor to buildbot-nix by the same maintainer, collapsing the master and worker pair into one service that evaluates with a bundled nix-eval-jobs, builds through the host nix daemon, and scales out through ordinary nix remote builders.
+Its option surface is `services.nixbot.*` in `nixosModules/nixbot.nix`, with `nixosModules.buildbot-nix`, `buildbot-master`, and `buildbot-worker` retained as deprecated aliases that warn.
+Roughly twenty options map one-for-one from buildbot-nix, and the migration surface is narrower than it looks: workers and `workersFile` are gone, `dbUrl` becomes `database.*` with no history carryover, `authBackend` and the oauth2-proxy `accessMode` are deleted, commit statuses become check runs, per-repository webhooks become one application-level webhook needing two further events and a further permission, and `admins` entries become provider-qualified.
+
+Two constraints frame every decision below.
+First, buildbot stays authoritative for every repository and must keep working untouched; this is what separates this change from both reference deployments, each of which replaced buildbot and could therefore inherit its identity, its check names, and its branch-protection rules.
+Second, the deliverable is a deployment provable by `clan machines update magnetite`, which rules out any shape where the running service is not a function of the machine's NixOS generation.
+
+Stakeholders are the fleet's single operator, who registers the forge application and populates two credential slots by hand, and the repositories whose CI will later migrate — none of which this change touches.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+A nixbot instance on magnetite, served at `nixbot.scientistexperience.net` over TLS, deployed by `clan machines update magnetite`.
+The incumbent buildbot server at `buildbot.scientistexperience.net` continuing to serve, with its module, aspect entry, credentials, vhost, database, and repository-root configuration file unedited.
+A service that builds no repository until a later change opts one in, with that boundary stated honestly rather than claimed as a guarantee.
+Verdicts published under a namespace distinct from the incumbent's, so no forge-side required check silently changes meaning.
+Credentials supplied through the fleet's existing clan vars mechanism, with no credential value in the repository.
+
+**Non-Goals:**
+
+Migrating vanixiets' own CI onto nixbot.
+Finishing python-nix-template's migration, which never completed onto buildbot-nix and now retargets to nixbot.
+Migrating ironstar.
+Retiring buildbot, or altering anything about it, including its `buildbot-nix.toml`.
+Adopting Mic92's flakelet runtime deployment shape.
+Multi-architecture builds: aarch64 work would come from the host's remote-builder configuration, which this change does not alter.
+
+## Decisions
+
+### D1: Compose nixbot the way this repository already composes buildbot
+
+- **Choice**: add the `nixbot` flake input, import `inputs.nixbot.nixosModules.nixbot` at the host in `modules/machines/nixos/magnetite/default.nix`, and put the site configuration in a new aspect `flake.modules.nixos.nixbot` at `modules/nixos/nixbot.nix`, named in the host's aspect list.
+- **Rationale**: this is the existing buildbot precedent in this repository line for line (`modules/machines/nixos/magnetite/default.nix:35-36, 43`; `modules/nixos/buildbot.nix:20`), it matches nixbot's documented NixOS surface, and it keeps the deployed service a function of the machine's generation, which is what makes `clan machines update magnetite` the acceptance test.
+- **Alternatives considered**: Mic92's flakelet shape at dotfiles HEAD, where nixbot's units are evaluated from the nixbot flake on the machine at runtime — rejected because it needs three further single-maintainer inputs and a push-deploy path over step-ca SSH certificates, and because it deliberately decouples what runs from the NixOS generation, which would make the named acceptance criterion untrue by construction. clan-infra's wrapper form, `flake.nixosModules.nixbot = [ upstream ./nixbot.nix ]` — rejected as a second composition convention beside an existing one; the same result is reached with this repository's own idiom.
+- **Boundary**: this decision sits on the vendored-versus-first-party boundary. The upstream module is vendored surface consumed through a flake input and never edited; the aspect file is first-party and is the only place site configuration lives.
+
+### D2: A dedicated forge application, not the incumbent's
+
+- **Choice**: register a second GitHub App for nixbot, with its own application id, private key, webhook secret, and interface-login client.
+- **Rationale**: nixbot requires check-run write access, pull-request read access, and the `check_run` and `check_suite` events, none of which buildbot-nix asks for. Adding them to the incumbent's application edits a registration the running service depends on. One shared application would also give both services one identity, one application-level webhook, and one coupled permission history.
+- **Alternatives considered**: reuse, which is exactly what the closest reference deployment did — the same application id, the same interface client id, and the same three credential names survived its migration untouched. That evidence is sound for replacement and inverts under coexistence, because there the incumbent stopped existing on the same day.
+- **Cost accepted**: one further registration and one further credential set to rotate.
+
+### D3: Three independent boundaries keep the new service from building anything
+
+- **Choice**: bound repository visibility by the forge application's installation selection; set the topic-based auto-import to null; and set an explicit repository allowlist naming exactly the intended set.
+- **Rationale**: the topic filter defaults to the same topic buildbot's repositories already carry and performs a one-shot import against an empty database, so the default would sweep in precisely the repositories the incumbent already builds and double-build them. The three boundaries are independent, so a mistake in one does not by itself produce a build.
+- **Alternatives considered**: relying on the allowlist alone — rejected because the auto-import runs against an empty database, which is exactly the state on the day of first deployment. Relying on the installation selection alone — rejected because it lives in a web UI outside anything this repository can assert or review.
+- **Boundary**: the first of the three sits outside the machine entirely, which is why the interface capability states it as a boundary rather than a property, and why nothing here is claimed end to end.
+
+### D4: Keep the default verdict namespace
+
+- **Choice**: leave the status-context prefix at its default, `nixbot`.
+- **Rationale**: the forge's required checks currently name the incumbent's contexts. A prefix collision would either capture those names or make two services fight over one verdict. Keeping the default makes the new service's verdicts advisory by construction rather than by promise.
+- **Alternatives considered**: adopting the incumbent's prefix, which both reference deployments did — correct in each case because nixbot had inherited branch-protection rules from a service that no longer ran, and wrong here for the same reason.
+
+### D5: Module-managed vhost with ACME asked for explicitly, and no TCP port
+
+- **Choice**: leave the module's nginx integration enabled and set its ACME flag true, so the vhost for the new hostname is created, `forceSSL` with its own certificate, proxying to the service's unix socket.
+- **Rationale**: the module's nginx integration defaults on but its ACME flag defaults off, and every other vhost on this host is `forceSSL` plus `enableACME` against one shared ACME account, so the flag reproduces the house pattern rather than inventing one. Leaving nginx enabled also keeps the service off TCP entirely; the module binds a TCP port only when its nginx integration is disabled, and that port's default happens to equal the nixpkgs buildbot default, so disabling nginx would manufacture the single port collision available on this host.
+- **Alternatives considered**: a hand-written vhost with the module's nginx integration disabled — rejected as more configuration for a worse result, since it would reintroduce a TCP listener and duplicate what the module already emits.
+
+### D6: The new hostname is declared where every other one is
+
+- **Choice**: add a `nixbot` CNAME to the terranix Cloudflare module, unproxied, following the existing `buildbot` record, applied with the repository's terraform recipes before the host is deployed.
+- **Rationale**: DNS for this zone is declarative in-repo, and the existing records are unproxied precisely so ACME's HTTP challenge reaches the host. Certificate issuance happens during activation, so the record must exist first; this is the one ordering constraint in the deployment.
+- **Alternatives considered**: a record added by hand in the provider's UI — rejected as undeclared state in a repository whose whole premise is the opposite.
+
+### D7: The new service's database joins the host's single PostgreSQL instance
+
+- **Choice**: use the module's local-database path, which adds a database and role named for the service and connects over the local socket.
+- **Rationale**: the host runs exactly one PostgreSQL instance, additively configured by five services already, loopback and socket only. The module's local path merges into it rather than standing up a second instance. There is no history to carry over, and none is wanted: the incumbent keeps its own database untouched.
+- **Alternatives considered**: a separate instance on another port — rejected as unjustified for a service that needs one database on a host that already runs one instance well.
+
+### D8: Credentials as clan vars generators named for their consumer
+
+- **Choice**: three generators — the application private key and the interface-login secret as operator-populated slots, the webhook secret generated — each consumed as a file path and restarting the service on rotation.
+- **Rationale**: clan vars is this fleet's primary secrets system, the incumbent's six generators are the in-repo pattern, and the service takes every secret as a file path which it passes to its unit as a systemd credential, so the shapes already match. The unit snapshots credentials at start, so rotation without a restart would leave a stale value; naming the service in each generator's restart list is therefore not optional.
+- **Alternatives considered**: legacy sops-nix, which this fleet retains only for supplementary user secrets — rejected as the non-primary mechanism for a machine-side service credential.
+- **Boundary**: this decision sits on the source-versus-delivered boundary. The generator declaration is source; the file the service reads exists only after activation, so verification is by inspecting the deployed path, never by reading the repository.
+
+### D9: Size the new service against the capacity the incumbent already uses
+
+- **Choice**: set the eval worker count and per-worker memory explicitly, and restrict build systems to the host's own platform.
+- **Rationale**: names are the easy part — units, users, groups, databases, state directories, and GC-root families are disjoint between the two stacks by construction, confirmed row by row. What is shared is finite: 32 GiB against the incumbent's four eval workers at 2 GiB each, one nix store under a 250 G quota with a free-space reaper and a seven-day collection window, one nginx, one PostgreSQL, one ACME account, and one sandbox tree that a prior disk incident on this host already made vivid. Defaults derived from core count would size the new service as though it were alone.
+- **Alternatives considered**: accepting defaults and observing — rejected because the observation would be an incident on the host that also serves the fleet's forge and chat.
+
+### D10: The repository-root per-repository configuration file stays exactly as it is
+
+- **Choice**: no change to `buildbot-nix.toml`, and no `nixbot.toml` added.
+- **Rationale**: the file is upstream buildbot-nix's own convention, and nixbot still parses that exact filename with the same schema plus one additional key. The expectation that it was the artifact that would not carry over is refuted; it is one of the things that carries over most cleanly. A `nixbot.toml` becomes meaningful only once a repository is actually built by nixbot, which is a later change.
+
+## Risks / Trade-offs
+
+[Risk] Capacity contention on a 32 GiB host: two eval-and-build services drawing from one memory pool, one nix store under quota, and one sandbox tree, with a prior disk incident as precedent → Mitigation: D9 sizes the new service explicitly rather than by core count; the service builds nothing on the day it lands (D3), so contention begins only when a later change opts a repository in, and that change owns re-observing the budget.
+
+[Risk] Certificate issuance fails at activation because the DNS record is absent or proxied → Mitigation: D6 makes the record declarative and unproxied, and the task order applies DNS and verifies resolution before the host is deployed.
+
+[Risk] The topic-based auto-import runs against an empty database and adopts the incumbent's repositories → Mitigation: D3's three independent boundaries, of which the topic setting is the one that directly disables this specific behavior.
+
+[Risk] A verdict-name collision changes what a forge-side required check means → Mitigation: D4 keeps the namespaces distinct; the incumbent's contexts are never emitted by the new service.
+
+[Risk] The operator populates a credential slot and the service holds the stale value → Mitigation: D8 names the service in each generator's restart list, because the unit snapshots credentials at start.
+
+[Risk] The upstream module's documentation claims an option-rename translation layer from buildbot-nix that this revision does not implement → Mitigation: the new service is configured under its own option namespace only; the incumbent keeps its own module and namespace, so the two never meet and the stale claim cannot bite.
+
+[Trade-off] Two services doing the same job on one host is duplicated capability and duplicated draw → accepted, because the alternative is the cutover this change deliberately is not.
+
+[Trade-off] A service that builds nothing is unexercised beyond its own health on the day it lands → accepted, because opting the first repository in is a reviewable decision that belongs to a later change.
+
+[Trade-off] A second forge application is a second registration and credential set to hold → accepted, because it is what leaves the incumbent's registration untouched.
+
+## Migration Plan
+
+Deployment order, each step reviewable and none of them touching the incumbent.
+Register the forge application and record its identifiers, since two credential slots cannot be populated before it exists.
+Add the flake input.
+Declare the three credential generators and populate them, so activation has something to resolve.
+Write the aspect and name it in the host's aspect list, alongside importing the upstream module at the host.
+Apply the DNS record and confirm resolution, because certificate issuance depends on it.
+Build the host's configuration as a check before deploying it.
+Deploy with `clan machines update magnetite`.
+
+Rollback is the ordinary one for this fleet and is what makes the sequence safe: remove the aspect from the host's list and redeploy, which withdraws the unit, the vhost, and the socket while leaving the incumbent untouched throughout.
+The database and role, the state directory, and the credential entries persist after such a rollback and are harmless; removing them is a deliberate cleanup, not part of a rollback.
+
+Acceptance is the integration verification in tasks.md: the new hostname serves over TLS, the incumbent's hostname still serves, the service's unit is running with an empty project list, a webhook delivery is accepted and authenticated, and both databases exist on the one instance.
+
+## Open Questions
+
+Whether the forge application can be installed with no repositories selected at all, or whether the provider requires at least one selection, which would make the allowlist and the disabled auto-import the operative boundaries on day one.
+This is a property of the provider's UI, recorded as an assumption to check during implementation rather than asserted here; either answer is compatible with the requirements, and the task order verifies the actual project list after deployment rather than inferring it.
+
+Whether the interface-login client is wanted at all on day one, since a service that builds nothing has little to show a logged-in viewer.
+The credential pair is asserted together by the upstream module, so it is either both or neither; this change plans both, and dropping to neither is a smaller edit than adding one later.

--- a/openspec/changes/stand-up-nixbot-on-magnetite/plan.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/plan.md
@@ -1,0 +1,640 @@
+# Nixbot on magnetite implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a nixbot instance on magnetite at `nixbot.scientistexperience.net`, deployed by `clan machines update magnetite`, coexisting with the buildbot-nix server that stays authoritative for every repository.
+
+**Architecture:** A new first-party aspect `flake.modules.nixos.nixbot` at `modules/nixos/nixbot.nix` carries the site configuration; the upstream `inputs.nixbot.nixosModules.nixbot` module is imported at the host alongside the existing upstream imports, exactly as the incumbent buildbot modules are. nixbot is one service unit fronted by the host's existing nginx over a unix socket, with its own database on the host's existing PostgreSQL instance and its own credentials as clan vars. The incumbent's module, aspect entry, generators, vhost, database, and the repository-root `buildbot-nix.toml` are not edited.
+
+**Tech Stack:** nix flakes with flake-parts and import-tree; clan-core for deployment and vars; nixbot (`github:Mic92/nixbot`, `nixosModules.nixbot`); nginx with ACME; PostgreSQL; terranix against Cloudflare for DNS.
+
+## Global Constraints
+
+- Nothing under `modules/nixos/buildbot.nix`, its entry in magnetite's aspect list, its clan vars generators, its nginx vhost, its database, or the repository-root `buildbot-nix.toml` is edited, added to, or removed. Verified per task by `git diff --stat`.
+- The verdict namespace stays at the module default: never set `services.nixbot.statusContextPrefix`. The incumbent's contexts are `buildbot/...` and the forge's required checks name them.
+- `services.nixbot.github.topic = null`. Its default is `"build-with-buildbot"`, which is the topic the incumbent's repositories carry, and it performs a one-shot import against an empty database.
+- No credential value in any file in the repository. Credentials are `clan.core.vars` generators consumed as `...files."<file>".path`.
+- Every generator that feeds the service names `restartUnits = [ "nixbot.service" ]`, because the unit snapshots credentials at start.
+- `services.nixbot.nginx.enable` stays at its default `true`, so the service listens on `/run/nixbot/web.sock` and binds no TCP port. Its TCP fallback default is 8010, which is also the nixpkgs buildbot default.
+- Host budget: Hetzner CX53, 16 vCPU, 32 GiB RAM, `/nix` under a 250 G ZFS quota. The incumbent already sizes 4 eval workers at 2 GiB (`modules/nixos/buildbot.nix:150-154`). nixbot takes `evalWorkerCount = 2` and `evalMaxMemorySize = 2048`.
+- `buildSystems = [ "x86_64-linux" ]`, matching the incumbent (`modules/nixos/buildbot.nix:111`).
+- `admins` entries are provider-qualified for nixbot (`github:cameronraysmith`), unlike buildbot's bare `cameronraysmith`.
+- Long or output-heavy commands are captured: `<command> 2>&1 | tee logs/<identifier>-$(date +%Y%m%d-%H%M%S).log`, with any filter after the `tee`.
+
+---
+
+### Task 1: Dedicated GitHub App
+
+**Files:**
+- Modify: `openspec/changes/stand-up-nixbot-on-magnetite/verify.md` (record the application id, OAuth client id, and installation selection)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the numeric application id used as `services.nixbot.github.appId` in Task 5; the OAuth client id used as `services.nixbot.github.oauthId`; and three secret values consumed by Task 4 — the application's PEM private key, its OAuth client secret, and the webhook secret this task sets on the application to the value Task 4 generates.
+
+- [ ] **Step 1: Register the application**
+
+At `https://github.com/settings/apps/new` (or the organization equivalent), create an application named for nixbot with:
+
+- Homepage URL: `https://nixbot.scientistexperience.net/`
+- Webhook URL: `https://nixbot.scientistexperience.net/webhooks/github`
+- User authorization callback URL: `https://nixbot.scientistexperience.net/auth/github/callback`
+- Repository permissions: Contents read-only, Checks read and write, Metadata read-only, Pull requests read-only
+- Organization permissions: Members read-only
+- Subscribe to events: Push, Pull request, Check run, Check suite
+
+These are nixbot's documented requirements (`~/ghq/github.com/Mic92/nixbot/docs/GITHUB.md:17-33`). Do not touch the incumbent application (id `3305657`, `modules/nixos/buildbot.nix:129`).
+
+- [ ] **Step 2: Record identifiers and generate the private key**
+
+Record the numeric App ID and the OAuth client id in verify.md. Generate a private key and keep the downloaded PEM available for Task 4 Step 4; do not commit it anywhere.
+
+- [ ] **Step 3: Install with a narrow repository selection**
+
+Install the application on the account with "Only select repositories", choosing only repositories intended for nixbot. Record the exact selection in verify.md, together with the answer to the design's open question: whether the provider permits an installation with no repository selected at all.
+
+- [ ] **Step 4: Confirm the incumbent application is unchanged**
+
+Open the incumbent application's settings and record its permissions, events, webhook URL, and installation selection in verify.md, confirming they match the pre-change state.
+
+- [ ] **Step 5: Commit the record**
+
+```bash
+git add openspec/changes/stand-up-nixbot-on-magnetite/verify.md
+git commit -m "docs(nixbot): record dedicated GitHub App registration"
+```
+
+---
+
+### Task 2: Flake input
+
+**Files:**
+- Modify: `flake.nix:62-64` region (add the input beside `buildbot-nix`)
+- Modify: `flake.lock`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `inputs.nixbot`, whose `nixosModules.nixbot` Task 6 imports.
+
+- [ ] **Step 1: Add the input**
+
+In `flake.nix`, immediately after the `buildbot-nix` block at lines 62-64, add:
+
+```nix
+    nixbot.url = "github:Mic92/nixbot";
+    nixbot.inputs.nixpkgs.follows = "nixpkgs";
+    nixbot.inputs.treefmt-nix.follows = "treefmt-nix";
+```
+
+- [ ] **Step 2: Lock it**
+
+Run: `nix flake lock 2>&1 | tee logs/flake-lock-nixbot-$(date +%Y%m%d-%H%M%S).log`
+Expected: the log reports adding input `nixbot` and no other input changing.
+
+- [ ] **Step 3: Verify the lock**
+
+Run:
+
+```bash
+nix flake metadata --json | python3 -c 'import json,sys; d=json.load(sys.stdin); n=d["locks"]["nodes"]; print("nixbot", n["nixbot"]["locked"]["rev"]); print("buildbot-nix", n["buildbot-nix"]["locked"]["rev"])'
+```
+
+Expected: a revision printed for `nixbot`, and the `buildbot-nix` revision identical to the one before this task (compare against `git show HEAD:flake.lock`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add flake.nix flake.lock
+git commit -m "feat(nixbot): add nixbot flake input"
+```
+
+---
+
+### Task 3: Aspect skeleton with credential generators
+
+**Files:**
+- Create: `modules/nixos/nixbot.nix`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks at evaluation time.
+- Produces: `flake.modules.nixos.nixbot`, and three generators whose file paths Task 5 consumes: `nixbot-github-app-secret-key.files."key.pem"`, `nixbot-github-webhook-secret.files."secret"`, and `nixbot-github-oauth-secret.files."secret"`.
+
+- [ ] **Step 1: Write the aspect with its generators only**
+
+Create `modules/nixos/nixbot.nix` with exactly this content; the service block arrives in Task 5, so this step is complete and evaluable on its own:
+
+```nix
+# nixbot CI service for magnetite, standing beside the buildbot-nix server.
+#
+# Coexistence constraints (buildbot stays authoritative for every repository):
+#   - statusContextPrefix is left at its default "nixbot"; buildbot's contexts
+#     are "buildbot/..." and the forge's required checks name those.
+#   - github.topic is null; its default "build-with-buildbot" is the topic
+#     buildbot's repositories carry, and it one-shot-imports on an empty DB.
+#   - nginx.enable stays true, so the service listens only on
+#     /run/nixbot/web.sock and binds no TCP port (its TCP fallback default
+#     8010 is also the nixpkgs buildbot default).
+#   - A dedicated GitHub App, not buildbot's (id 3305657, buildbot.nix:129):
+#     nixbot needs Checks write and the check_run/check_suite events, which
+#     buildbot-nix does not, so sharing would edit a running service's
+#     registration.
+#
+# Credential generator catalog (slots; values populated as marked):
+#   - nixbot-github-app-secret-key: manual `clan vars set` (GitHub App PEM key)
+#   - nixbot-github-oauth-secret: manual `clan vars set` (OAuth client secret)
+#   - nixbot-github-webhook-secret: auto-generated
+{
+  flake.modules.nixos.nixbot =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    {
+      # GitHub App private key (populated manually via clan vars set)
+      clan.core.vars.generators.nixbot-github-app-secret-key = {
+        files."key.pem" = {
+          owner = "nixbot";
+          restartUnits = [ "nixbot.service" ];
+        };
+        script = ''
+          echo "nixbot GitHub App private key: populate via clan vars set" >&2
+          exit 1
+        '';
+      };
+
+      # GitHub App OAuth client secret (populated manually via clan vars set)
+      clan.core.vars.generators.nixbot-github-oauth-secret = {
+        files."secret" = {
+          owner = "nixbot";
+          restartUnits = [ "nixbot.service" ];
+        };
+        script = ''
+          echo "nixbot GitHub OAuth secret: populate via clan vars set" >&2
+          exit 1
+        '';
+      };
+
+      clan.core.vars.generators.nixbot-github-webhook-secret = {
+        files."secret" = {
+          owner = "nixbot";
+          restartUnits = [ "nixbot.service" ];
+        };
+        runtimeInputs = [ pkgs.openssl ];
+        script = ''
+          openssl rand -hex 32 > $out/secret
+        '';
+      };
+    };
+}
+```
+
+- [ ] **Step 2: Verify the aspect is discovered**
+
+Run:
+
+```bash
+nix eval .#modules.nixos --apply 'm: builtins.elem "nixbot" (builtins.attrNames m)'
+```
+
+Expected: `true`. import-tree discovers any tracked `.nix` file under `modules/`, so the file must be added to git for this to pass (`modules/README.md:6-12`).
+
+- [ ] **Step 3: Format and lint**
+
+Run: `just lint 2>&1 | tee logs/lint-nixbot-aspect-$(date +%Y%m%d-%H%M%S).log`
+Expected: passes, including the secret scan.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/nixos/nixbot.nix
+git commit -m "feat(nixbot): add nixbot aspect with credential generators"
+```
+
+---
+
+### Task 4: Populate the credentials
+
+**Files:**
+- Create: `vars/per-machine/magnetite/nixbot-github-app-secret-key/key.pem/` (generated, committed encrypted)
+- Create: `vars/per-machine/magnetite/nixbot-github-oauth-secret/secret/` (generated, committed encrypted)
+- Create: `vars/per-machine/magnetite/nixbot-github-webhook-secret/secret/` (generated, committed encrypted)
+
+**Interfaces:**
+- Consumes: the three secret values from Task 1; the generator names from Task 3.
+- Produces: three deployable credential entries; the webhook secret value must be entered into the forge application's webhook configuration in Step 5.
+
+This task depends on Task 6 having placed the aspect on the host before `clan vars` can see the generators. If `clan vars list magnetite` does not show them, do Task 6 first and return here; the two are independent in content and only ordered by that visibility.
+
+- [ ] **Step 1: List what exists now**
+
+Run: `clan vars list magnetite 2>&1 | tee logs/clan-vars-list-before-$(date +%Y%m%d-%H%M%S).log`
+Expected: the incumbent's six `buildbot-*` generators, and the three `nixbot-*` generators reported as not yet set.
+
+- [ ] **Step 2: Generate the webhook secret**
+
+Run: `clan vars generate magnetite 2>&1 | tee logs/clan-vars-generate-$(date +%Y%m%d-%H%M%S).log`
+Expected: `nixbot-github-webhook-secret` is generated; the two manual generators fail their scripts by design with the "populate via clan vars set" message, which is the slot marker and not an error to fix.
+
+- [ ] **Step 3: Set the application private key**
+
+Run: `clan vars set magnetite nixbot-github-app-secret-key/key.pem`
+Paste the PEM from Task 1 Step 2 at the prompt.
+
+- [ ] **Step 4: Set the OAuth client secret**
+
+Run: `clan vars set magnetite nixbot-github-oauth-secret/secret`
+Paste the client secret generated on the application's settings page.
+
+- [ ] **Step 5: Put the webhook secret on the application**
+
+Read the generated value on the deploy host after Task 8, or read it out of the vars store with `clan vars get magnetite nixbot-github-webhook-secret/secret`, and enter it as the application's webhook secret. The forge and the host must hold the same value or every delivery is rejected.
+
+- [ ] **Step 6: Verify all three are set and encrypted**
+
+Run:
+
+```bash
+clan vars list magnetite 2>&1 | tee logs/clan-vars-list-after-$(date +%Y%m%d-%H%M%S).log
+head -c 64 vars/per-machine/magnetite/nixbot-github-app-secret-key/key.pem/secret
+```
+
+Expected: all three reported set; the second command prints a sops-encrypted blob header, not PEM text.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add vars/per-machine/magnetite
+git commit -m "feat(nixbot): add nixbot credential vars for magnetite"
+```
+
+---
+
+### Task 5: Service configuration
+
+**Files:**
+- Modify: `modules/nixos/nixbot.nix` (append the service block inside the aspect)
+
+**Interfaces:**
+- Consumes: the generator paths from Task 3; `appId` and `oauthId` from Task 1.
+- Produces: `services.nixbot.*` on magnetite, which Task 7 builds and Task 8 deploys.
+
+- [ ] **Step 1: Append the service block**
+
+Inside the aspect body in `modules/nixos/nixbot.nix`, after the third generator, add — substituting the two recorded identifiers from Task 1 for `<APP_ID>` and `<OAUTH_CLIENT_ID>`:
+
+```nix
+      services.nixbot = {
+        enable = true;
+        domain = "nixbot.scientistexperience.net";
+
+        admins = [ "github:cameronraysmith" ];
+
+        buildSystems = [ "x86_64-linux" ];
+
+        # Sized beside the incumbent's 4 workers x 2 GiB (buildbot.nix:150-154)
+        # on a 16 vCPU / 32 GiB host: 2 x 2 GiB here keeps the pair inside the
+        # same headroom the incumbent's comment budgets for.
+        evalWorkerCount = 2;
+        evalMaxMemorySize = 2048;
+
+        github = {
+          enable = true;
+          appId = <APP_ID>;
+          appSecretKeyFile =
+            config.clan.core.vars.generators.nixbot-github-app-secret-key.files."key.pem".path;
+          webhookSecretFile =
+            config.clan.core.vars.generators.nixbot-github-webhook-secret.files."secret".path;
+          oauthId = "<OAUTH_CLIENT_ID>";
+          oauthSecretFile =
+            config.clan.core.vars.generators.nixbot-github-oauth-secret.files."secret".path;
+
+          # Default is "build-with-buildbot", the topic the incumbent's
+          # repositories carry, and it one-shot-imports against an empty DB.
+          topic = null;
+
+          # No repository is built by this service until a later change opts
+          # one in. Empty-list semantics are verified by observing the project
+          # list after deployment, not assumed.
+          repoAllowlist = [ ];
+        };
+
+        # The module creates the vhost proxying to /run/nixbot/web.sock and this
+        # flag makes it forceSSL + enableACME. The incumbent aspect writes that
+        # vhost override by hand only because buildbot-nix has no such option.
+        nginx.enableACME = true;
+
+        database.createLocally = true;
+      };
+```
+
+- [ ] **Step 2: Verify the option values**
+
+Run:
+
+```bash
+nix eval --json .#nixosConfigurations.magnetite.config.services.nixbot \
+  --apply 'c: { inherit (c) enable domain buildSystems evalWorkerCount evalMaxMemorySize statusContextPrefix; topic = c.github.topic; allow = c.github.repoAllowlist; acme = c.nginx.enableACME; nginx = c.nginx.enable; db = c.database.createLocally; }'
+```
+
+Expected: `enable` true, `domain` `"nixbot.scientistexperience.net"`, `topic` null, `allow` `[]`, `acme` true, `nginx` true, `db` true, `statusContextPrefix` `"nixbot"`, `evalWorkerCount` 2.
+
+- [ ] **Step 3: Verify the incumbent is untouched**
+
+Run:
+
+```bash
+nix eval --raw .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.domain
+git diff --stat HEAD~4 -- modules/nixos/buildbot.nix buildbot-nix.toml
+```
+
+Expected: `buildbot.scientistexperience.net`, and an empty diff for both paths.
+
+- [ ] **Step 4: Verify resource disjointness in the evaluated configuration**
+
+Run:
+
+```bash
+nix eval --json .#nixosConfigurations.magnetite.config \
+  --apply 'c: { units = builtins.filter (n: n == "nixbot" || n == "buildbot-master" || n == "buildbot-worker") (builtins.attrNames c.systemd.services); users = builtins.filter (n: n == "nixbot" || n == "buildbot" || n == "buildbot-worker") (builtins.attrNames c.users.users); }'
+```
+
+Expected: all three units and all three users present as distinct names.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/nixos/nixbot.nix
+git commit -m "feat(nixbot): configure nixbot service for magnetite"
+```
+
+---
+
+### Task 6: Host composition
+
+**Files:**
+- Modify: `modules/machines/nixos/magnetite/default.nix:29-53`
+
+**Interfaces:**
+- Consumes: `inputs.nixbot` from Task 2; `flake.modules.nixos.nixbot` from Task 3.
+- Produces: the evaluated magnetite configuration Tasks 5, 7, and 8 act on.
+
+- [ ] **Step 1: Import the upstream module**
+
+In the `imports` list at lines 29-37, after `inputs.buildbot-nix.nixosModules.buildbot-worker` on line 36, add:
+
+```nix
+        inputs.nixbot.nixosModules.nixbot
+```
+
+Import the real module name. `nixosModules.buildbot-nix`, `buildbot-master`, and `buildbot-worker` in the nixbot flake are deprecated aliases that warn (`~/ghq/github.com/Mic92/nixbot/flake.nix:56-68`), and importing one of those from nixbot alongside the genuine buildbot-nix modules would be actively confusing.
+
+- [ ] **Step 2: Name the aspect**
+
+In the aspect list at lines 38-53, add `nixbot` on its own line immediately after `buildbot` on line 43:
+
+```nix
+        buildbot
+        nixbot
+```
+
+- [ ] **Step 3: Verify composition**
+
+Run:
+
+```bash
+nix eval .#nixosConfigurations.magnetite.config.services.nixbot.enable
+nix eval .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.enable
+```
+
+Expected: `true` for both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/machines/nixos/magnetite/default.nix
+git commit -m "feat(nixbot): compose nixbot onto magnetite"
+```
+
+---
+
+### Task 7: Hostname
+
+**Files:**
+- Modify: `modules/terranix/cloudflare.nix` (after the `buildbot` record at lines 61-69)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: public resolution for `nixbot.scientistexperience.net`, without which certificate issuance in Task 9 cannot complete.
+
+- [ ] **Step 1: Add the record**
+
+After the `buildbot` record ending at line 69, add:
+
+```nix
+      # DNS CNAME record for nixbot CI endpoint (resolves to magnetite)
+      resource.cloudflare_dns_record.nixbot = {
+        zone_id = config.data.cloudflare_zone.scientistexperience "id";
+        name = "nixbot";
+        type = "CNAME";
+        content = "magnetite.scientistexperience.net";
+        ttl = 1; # automatic
+        proxied = false;
+      };
+```
+
+`proxied = false` matches every sibling record and is what lets the ACME HTTP challenge reach the host.
+
+- [ ] **Step 2: Plan**
+
+Run: `just --list | grep -i terraform` to identify this repository's terraform recipes, then run the plan recipe: `just terraform-plan 2>&1 | tee logs/terraform-plan-nixbot-$(date +%Y%m%d-%H%M%S).log`
+Expected: exactly one resource to add, none to change, none to destroy.
+
+- [ ] **Step 3: Apply**
+
+Run: `just terraform-apply 2>&1 | tee logs/terraform-apply-nixbot-$(date +%Y%m%d-%H%M%S).log`
+Expected: one resource added.
+
+- [ ] **Step 4: Verify resolution**
+
+Run: `dig +short nixbot.scientistexperience.net`
+Expected: resolves through `magnetite.scientistexperience.net` to the host's address, with no Cloudflare proxy address in the chain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/terranix/cloudflare.nix
+git commit -m "feat(nixbot): declare nixbot DNS record"
+```
+
+---
+
+### Task 8: Build gate
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: everything from Tasks 2, 3, 5, and 6.
+- Produces: the built host toplevel Task 9 deploys.
+
+- [ ] **Step 1: Build the host's configuration**
+
+Run:
+
+```bash
+nix build .#checks.x86_64-linux.nixos-magnetite 2>&1 | tee logs/nixos-magnetite-$(date +%Y%m%d-%H%M%S).log
+```
+
+Expected: succeeds. This check is `config.system.build.toplevel` for every non-deferred NixOS machine on the system (`modules/checks/machines.nix:19-34`), so it is the narrowest thing that can falsify the whole configuration without touching the host.
+
+- [ ] **Step 2: Confirm no other check regressed by this change**
+
+Run:
+
+```bash
+nix eval .#checks.x86_64-linux --apply builtins.attrNames --json
+```
+
+Expected: the same check names as before this change, plus nothing removed. A full `just check-fast` run belongs to pre-pull-request validation, not to this step.
+
+---
+
+### Task 9: Deploy and verify
+
+**Files:**
+- Modify: `openspec/changes/stand-up-nixbot-on-magnetite/verify.md` (record every observation below)
+
+**Interfaces:**
+- Consumes: Task 8's built configuration; Task 4's credentials; Task 7's DNS record.
+- Produces: the deployed service and the recorded evidence the change's acceptance rests on.
+
+- [ ] **Step 1: Deploy**
+
+Run:
+
+```bash
+clan machines update magnetite 2>&1 | tee logs/clan-update-magnetite-$(date +%Y%m%d-%H%M%S).log
+```
+
+Expected: completes without error.
+
+- [ ] **Step 2: Confirm the unit and socket**
+
+Run:
+
+```bash
+ssh root@magnetite.zt 'systemctl is-active nixbot.service nixbot.socket; systemctl is-active buildbot-master.service buildbot-worker.service'
+```
+
+Expected: `active` for the nixbot unit and socket, and `active` for both incumbent units.
+
+- [ ] **Step 3: Confirm both hostnames serve**
+
+Run:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code} %{ssl_verify_result}\n' https://nixbot.scientistexperience.net/
+curl -sS -o /dev/null -w '%{http_code} %{ssl_verify_result}\n' https://buildbot.scientistexperience.net/
+```
+
+Expected: a success or redirect status with `ssl_verify_result` 0 for both.
+
+- [ ] **Step 4: Confirm no port was claimed**
+
+Run:
+
+```bash
+ssh root@magnetite.zt 'ss -ltnp | grep -E ":8010|nixbot" || echo "no nixbot tcp listener"'
+```
+
+Expected: `no nixbot tcp listener`.
+
+- [ ] **Step 5: Confirm both databases exist**
+
+Run:
+
+```bash
+ssh root@magnetite.zt "sudo -u postgres psql -lqt | cut -d'|' -f1,2 | grep -E 'nixbot|buildbot'"
+```
+
+Expected: both databases listed, each owned by its own role.
+
+- [ ] **Step 6: Confirm the service builds nothing**
+
+Run:
+
+```bash
+curl -sS https://nixbot.scientistexperience.net/api/v1/projects | head -c 400
+```
+
+Expected: an empty project collection. If the endpoint path differs at the pinned revision, read it from the service's own interface and record the actual path in verify.md.
+
+- [ ] **Step 7: Exercise delivery authentication both ways**
+
+Redeliver the most recent delivery from the application's Advanced settings page and record the response status. Then run:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST -H 'Content-Type: application/json' \
+  -d '{}' https://nixbot.scientistexperience.net/webhooks/github
+```
+
+Expected: the redelivery is accepted with a 2xx; the unsigned request is rejected with a 4xx.
+
+- [ ] **Step 8: Record the capacity baseline**
+
+Run:
+
+```bash
+ssh root@magnetite.zt 'free -g; zfs list -o name,used,avail,quota zroot/root/nix; systemctl status nixbot.service --no-pager | head -20'
+```
+
+Record memory in use, the store dataset's usage against its quota, and the nixbot unit's memory in verify.md as the baseline the first repository opt-in will be measured against.
+
+- [ ] **Step 9: Confirm the rollback path**
+
+On a scratch branch, remove `nixbot` from magnetite's aspect list and run:
+
+```bash
+nix build .#checks.x86_64-linux.nixos-magnetite 2>&1 | tee logs/nixos-magnetite-rollback-$(date +%Y%m%d-%H%M%S).log
+```
+
+Expected: builds cleanly, establishing that withdrawal is a redeploy rather than a repair. Discard the scratch branch.
+
+- [ ] **Step 10: Commit the evidence**
+
+```bash
+git add openspec/changes/stand-up-nixbot-on-magnetite/verify.md
+git commit -m "docs(nixbot): record deployment verification for magnetite"
+```
+
+---
+
+### Task 10: Documentation
+
+**Files:**
+- Create or modify: a page under `packages/docs/src/content/docs/` recording the two-service topology
+
+**Interfaces:**
+- Consumes: the decisions in design.md and the observations in verify.md.
+- Produces: the documented topology a later migration change reads before opting a repository in.
+
+- [ ] **Step 1: Write the page**
+
+Document: the two build services and their hostnames; that buildbot remains authoritative for every repository; the dedicated forge application and why it is not shared; the three boundaries that keep nixbot from building anything; the verdict-namespace distinction and what it means for required checks; and the shared surfaces that remain common-mode (nginx, PostgreSQL, the nix store and its quota, the ACME account, capacity).
+
+- [ ] **Step 2: Verify the docs build**
+
+Run: `just docs-build 2>&1 | tee logs/docs-build-nixbot-$(date +%Y%m%d-%H%M%S).log`
+Expected: succeeds.
+
+- [ ] **Step 3: Verify links**
+
+Run: `nix build .#checks.x86_64-linux.package-vanixiets-docs-test-linkcheck 2>&1 | tee logs/docs-linkcheck-$(date +%Y%m%d-%H%M%S).log`
+Expected: succeeds. If the check's attribute name differs on this system, resolve it from `nix eval .#checks.x86_64-linux --apply builtins.attrNames`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/docs
+git commit -m "docs(nixbot): document the two-service build topology on magnetite"
+```

--- a/openspec/changes/stand-up-nixbot-on-magnetite/proposal.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/proposal.md
@@ -1,0 +1,73 @@
+---
+linear_story_id: CAM-40
+linear_story_identifier: CAM-40
+linear_story_title: "Stand up nixbot on magnetite alongside buildbot"
+linear_story_url: https://linear.app/cameronraysmith/issue/CAM-40/stand-up-nixbot-on-magnetite-alongside-buildbot
+linear_story_state: Todo
+linear_team: CAM
+linear_project: nixbot-herculesci-cicd
+last_synced_state: Todo
+last_synced_at: 2026-08-27T18:20:00Z
+review_round: 0
+max_review_rounds: 3
+attempt_log:
+  - { at: "2026-08-27T18:20:00Z", transition: "Backlog->Todo", outcome: "posted", note: "T1 bind; issue created in the existing project and seeded from this proposal" }
+---
+
+## Why
+
+Magnetite's CI is buildbot-nix, whose master/worker pair upstream has succeeded with nixbot: one service, no workers, building through the host nix daemon.
+Migrating anything onto nixbot requires an instance to migrate onto, and standing that instance up carries every genuinely uncertain question — a second forge application, a second hostname and certificate, a second database on a shared instance, and capacity on a host already running the incumbent.
+This change plans that instance beside buildbot, which stays authoritative for every repository, so each later migration becomes a small reviewable opt-in rather than a cutover.
+
+## What Changes
+
+This change is planning-only.
+It writes the artifacts a later change implements against; no module code, no host configuration, and no deployment happen here.
+
+**A second build service on magnetite, at its own hostname**
+- From: magnetite runs one build service, buildbot-nix, reachable at `buildbot.scientistexperience.net`, composed through the `buildbot` aspect named in the host's aspect list and the upstream master and worker modules imported at the host.
+- To: a second build service, nixbot, reachable at `nixbot.scientistexperience.net`, composed the same way — a new `nixbot` aspect plus the upstream `nixosModules.nixbot` imported at the host — with the incumbent's composition untouched.
+- Reason: a migration target must exist before anything can migrate onto it, and the incumbent must keep serving while it does.
+- Impact: non-breaking for the incumbent by construction; the two services share the host's nginx, PostgreSQL, nix store, and ACME account, which is where the residual risk lives.
+
+**A dedicated forge application rather than the incumbent's**
+- From: one GitHub App serves buildbot, holding the permissions buildbot-nix needs and creating per-repository webhooks.
+- To: a second GitHub App dedicated to nixbot, holding the additional permissions and events nixbot requires and receiving deliveries at the application-level webhook endpoint, with the incumbent's application unedited.
+- Reason: nixbot needs check-run write access and check events the incumbent does not; adding them to the incumbent's application would edit the registration a running service depends on, and one shared application would couple both services' identities and blast radii.
+- Impact: one more registration to hold and one more credential set to rotate, in exchange for leaving the incumbent's registration alone.
+
+**No repository is built by the new service in this change**
+- From: nothing; the service does not exist.
+- To: the service stands up able to serve its interface and receive authenticated deliveries while building no repository, bounded by the forge application's installation selection, by disabling the topic-based auto-import whose default would otherwise sweep in every repository the incumbent already builds, and by an explicit repository allowlist.
+- Reason: opting a repository in is a reviewable decision belonging to a later change, not a side effect of standing up infrastructure.
+- Impact: the service is deliberately unexercised beyond its own health on the day it lands.
+
+**Verdicts that do not gate merges**
+- From: the incumbent's verdicts are the ones the forge's required checks name.
+- To: the new service publishes verdicts under a distinct name prefix, so the forge's required checks continue to name only the incumbent until someone edits them deliberately.
+- Reason: both reference deployments adopted the incumbent's prefix precisely because they replaced it; under coexistence the same move would collide with a service that is still running.
+- Impact: when a repository is later opted in, its required-checks configuration must be edited explicitly for the new service's verdicts to matter.
+
+**Credentials through the fleet's primary secrets system**
+- From: the incumbent's forge credentials are clan vars generators consumed as file paths.
+- To: three further generators of the same shape for the new service's application key, webhook secret, and interface login secret, each reaching the service as a file path resolved at activation.
+- Reason: the fleet already has one answer for this and the service consumes credentials as file paths, so no new mechanism is warranted.
+- Impact: three encrypted entries added under the machine's vars tree; no credential value enters the repository.
+
+## Capabilities
+
+### New Capabilities
+- `nixbot-build-service` (stratum: `behavioral`): what the fleet requires of a second build service standing beside an incumbent one — that it is reachable at its own hostname, that the incumbent keeps working, that it builds no repository until opted in, that its verdicts do not gate merges, that its forge credentials are operator-supplied and never legible in the repository, that one ordinary activation establishes it, and that it is sized so the incumbent keeps the capacity it uses.
+- `build-service-interface` (stratum: `interface`): the properties at the machine's interface that discharge those requirements — a distinct hostname served over TLS, a distinct verdict namespace, authenticated delivery at an application-level endpoint, disjoint unit, user, database, state and GC-root paths with no TCP port bound, credentials present only as activation-resolved file paths, and a repository-visibility boundary set by the forge application's installation selection. Its trust boundary is stated in the capability: the installation selection is set by hand in the forge and is not something this machine can assert, capacity outcomes are not guaranteed, and the shared nginx, PostgreSQL, nix store and ACME account remain common-mode surfaces.
+
+### Modified Capabilities
+- `world-assumptions` (stratum: `world`): four assumptions are added — forge-application scoping and delivery authentication, hostname resolution and certificate issuance, the finiteness of one host's build capacity, and the fact that which service's verdict gates a merge is the forge's configuration rather than ours — and the designation table gains the terms the new behavioral requirements use.
+
+## Impact
+
+Implementation, in a later change, touches: a new `flake.modules.nixos.nixbot` aspect under `modules/nixos/`; the `nixbot` flake input in `flake.nix`; `modules/machines/nixos/magnetite/default.nix` to import the upstream module and name the new aspect in its aspect list; three `clan.core.vars` generators and their entries under `vars/per-machine/magnetite/`; a `nixbot` CNAME in `modules/terranix/cloudflare.nix` applied with the repository's terraform recipes; and a documentation note recording the two-service topology.
+Nothing under the incumbent's `modules/nixos/buildbot.nix`, its aspect entry, its generators, its vhost, its database, or the repository-root `buildbot-nix.toml` is edited, added to, or removed.
+The root `buildbot-nix.toml` in particular stays as it is: nixbot still parses that exact filename with the same schema, so the expectation that it would have to be replaced does not hold.
+
+Out of scope here, each its own later change, sequenced after this one: migrating vanixiets' own CI onto nixbot; finishing python-nix-template's migration, which never completed onto buildbot-nix and now retargets to nixbot; migrating ironstar; and retiring buildbot once nothing depends on it.

--- a/openspec/changes/stand-up-nixbot-on-magnetite/specs/build-service-interface/spec.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/specs/build-service-interface/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: A distinct hostname is served with its own certificate
+
+The machine SHALL serve the second build service at one hostname of its own, distinct from the incumbent's, with a certificate obtained for that hostname, and SHALL reach the service over a local socket rather than a network port, so that no port on the host is claimed on the second service's behalf.
+
+#### Scenario: A request arrives for the second service's hostname
+
+- **WHEN** a request arrives for the second build service's hostname on the host's public interface
+- **THEN** it is answered over a connection secured by a certificate issued for that hostname, and forwarded to the service across a local socket
+
+#### Scenario: A port scan of the host is taken
+
+- **WHEN** the host's listening ports are enumerated after activation
+- **THEN** the second build service holds none of them, and in particular the port its own configuration would bind if its proxy integration were disabled — which is also the port the incumbent's own upstream defaults to — is unbound
+
+### Requirement: The two build services hold disjoint host resources
+
+The machine SHALL give the second build service its own service unit, its own user and group, its own database on the host's existing database instance, its own state directory, and its own root-retention directory, each named differently from the incumbent's, so that neither service's operation reads or writes the other's.
+
+#### Scenario: Both services are running
+
+- **WHEN** both build services are running on the host
+- **THEN** each has its own unit, user, group, database, state directory, and root-retention directory, and no path or name among them is shared
+
+#### Scenario: One service's state is destroyed
+
+- **WHEN** the state directory or database of one build service is emptied
+- **THEN** the other service's state directory and database are unaffected, because they are different objects on the same host rather than one object with two consumers
+
+### Requirement: Repository visibility is bounded outside the machine and narrowed within it
+
+The set of forge-hosted repositories the second build service can see SHALL be bounded by its forge application's installation selection, which is set on the forge and not by this machine, and SHALL be narrowed further by the machine's own configuration, which disables the topic-based adoption of repositories and names an explicit set instead.
+
+#### Scenario: The machine's configuration is read
+
+- **WHEN** the second build service's configuration is read
+- **THEN** the topic-based adoption of repositories is off, and the set of repositories it may build is named explicitly rather than implied
+
+#### Scenario: The forge application is installed more broadly than intended
+
+- **WHEN** the forge application is installed on repositories beyond those intended for the second build service
+- **THEN** the machine's two remaining boundaries are what stand between that installation and a build, and the outermost boundary is not one this machine can assert
+
+### Requirement: Deliveries are accepted only at an authenticated endpoint
+
+The machine SHALL accept deliveries for the second build service only at that service's own endpoint, authenticated by a secret held on the host, and that endpoint SHALL be the forge application's single endpoint rather than the per-repository endpoints the incumbent registers.
+
+#### Scenario: A delivery is presented at the second service's endpoint
+
+- **WHEN** a delivery is presented at the second build service's endpoint carrying the secret held on the host for it
+- **THEN** the delivery is accepted
+
+#### Scenario: A delivery is presented without the host's secret
+
+- **WHEN** a delivery is presented at that endpoint without the secret held on the host for that service
+- **THEN** it is rejected, and no repository event is acted on as a result of it
+
+### Requirement: Verdict namespaces are distinct
+
+The machine SHALL publish the second build service's check runs under a name prefix distinct from the incumbent's, and SHALL never emit a check run under the incumbent's prefix.
+
+#### Scenario: The second service publishes a verdict
+
+- **WHEN** the second build service publishes a check run
+- **THEN** its name carries the second service's prefix, and no check run bearing the incumbent's prefix originates from the second service
+
+#### Scenario: The prefix is configured to the incumbent's value
+
+- **WHEN** the second build service's prefix is set to the incumbent's value
+- **THEN** this property is violated, which is why the prefix is left at its own default rather than adopted from the migration recipes written for deployments where the incumbent no longer runs
+
+### Requirement: Credentials exist only as activation-resolved paths
+
+Each forge credential the second build service uses SHALL reach it as a path resolved when the host's configuration is activated, readable only by that service, and the service SHALL be restarted when the value behind such a path is replaced.
+
+#### Scenario: The service starts
+
+- **WHEN** the second build service starts
+- **THEN** each credential it needs is presented to it from a path that exists on the host, and no credential value exists in the configuration that produced it
+
+#### Scenario: A credential's value is replaced
+
+- **WHEN** the value behind one of those paths is replaced
+- **THEN** the service is restarted, because the value it holds was taken when it started and would otherwise remain the superseded one
+
+### Requirement: The service is a consequence of the host's declared configuration
+
+What the second build service runs SHALL be determined by the host's declared configuration at the moment it was activated, and SHALL NOT be fetched or updated independently of that activation.
+
+#### Scenario: The host's declaration is built without deploying it
+
+- **WHEN** the host's declared configuration is built as a check, before any deployment
+- **THEN** the build either succeeds, establishing that the declaration is coherent, or fails, and no state on the host has changed either way
+
+#### Scenario: The declaration is unchanged but time passes
+
+- **WHEN** time passes with no change to the host's declared configuration
+- **THEN** the version of the second build service that runs does not change, because nothing outside activation selects it
+
+### Requirement: This capability states its own trust boundary
+
+This capability SHALL state what its properties guarantee and what they do not, and SHALL NOT be described, by itself or in any downstream report, as an end-to-end guarantee that the incumbent build service is unaffected.
+
+#### Scenario: The properties above are read as a set
+
+- **WHEN** the properties of this capability are read as a set
+- **THEN** what they establish is that the second build service is reached at its own hostname over its own certificate through a local socket with no port bound, that its unit, user, database, state, and root-retention paths are its own, that its deliveries are authenticated at its own endpoint, that its verdict namespace is its own, that its credentials exist only as activation-resolved paths, and that what runs is a consequence of the host's declared configuration
+
+#### Scenario: A guarantee about the incumbent is sought from this capability
+
+- **WHEN** someone asks whether these properties guarantee the incumbent build service is unaffected
+- **THEN** the answer is no: the two services share the host's web front end, its database instance, its store and the disk under it, its certificate account, and its finite capacity, so disjoint names bound the ways they can interfere without eliminating them
+
+#### Scenario: A guarantee about repository visibility is sought from this capability
+
+- **WHEN** someone asks whether these properties guarantee that no unintended repository is ever built
+- **THEN** the answer is no: the outermost boundary is the forge application's installation selection, which is set on the forge by a person and is not observable to this machine, so the machine's contribution is the two boundaries it can assert and no more

--- a/openspec/changes/stand-up-nixbot-on-magnetite/specs/nixbot-build-service/spec.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/specs/nixbot-build-service/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: A second build service is reachable at its own hostname
+
+The fleet SHALL provide a second build service on the host that already runs one, reachable at a hostname distinct from the incumbent's and served with a certificate for that hostname, so that a person can reach the second service without reaching the first.
+
+**Discharged by**: `build-service-interface` requirement `A distinct hostname is served with its own certificate`, resting on world assumption `A10 — A hostname that resolves to a host and is reachable can obtain a certificate, and issuance is rate-limited`.
+
+#### Scenario: A person opens the second build service's hostname
+
+- **WHEN** a person opens `nixbot.scientistexperience.net` after the host's configuration has been activated
+- **THEN** the second build service answers at that hostname over a connection accepted without a certificate warning, and the incumbent's hostname `buildbot.scientistexperience.net` continues to answer independently
+
+#### Scenario: The second service's hostname does not resolve
+
+- **WHEN** the hostname for the second build service does not resolve to the host at the time of activation
+- **THEN** no certificate can be obtained for it and the requirement is unmet, which is why declaring that hostname precedes activating the host rather than following it
+
+### Requirement: The incumbent build service continues to serve
+
+The incumbent build service SHALL continue, across and after the introduction of the second one, to accept the deliveries it accepted before, to publish check runs under the names it published before, and to answer at its own hostname, with no interruption attributable to the second service's introduction.
+
+**Discharged by**: `build-service-interface` requirement `The two build services hold disjoint host resources`, whose disjointness claim is bounded by the shared surfaces that requirement names.
+
+#### Scenario: The second build service is introduced
+
+- **WHEN** the host's configuration is activated with the second build service present for the first time
+- **THEN** the incumbent's hostname still answers, its check runs still appear under their existing names for the repositories it builds, and nothing about the incumbent's own configuration was changed to make that so
+
+#### Scenario: The second build service is withdrawn
+
+- **WHEN** the second build service is removed from the host's configuration and the host is activated again
+- **THEN** the incumbent is unaffected by the withdrawal, because nothing it depends on was ever shared with the second service beyond what the interface capability names as common
+
+### Requirement: Repositories are built only once opted in
+
+The second build service SHALL build no forge-hosted repository until a later change opts that repository in, and the fleet SHALL enforce that through more than one independent boundary, so that a single mistaken setting does not by itself produce a build.
+
+**Discharged by**: `build-service-interface` requirement `Repository visibility is bounded outside the machine and narrowed within it`, resting on world assumption `A9 — A forge application's installation selection bounds what a build service can see, and its delivery secret authenticates what it is told`; the outermost boundary is not machine-assertable, which that requirement states rather than conceals.
+
+#### Scenario: The second build service starts for the first time
+
+- **WHEN** the second build service starts with no prior state, on a forge whose repositories carry the topic the incumbent's repositories were opted in with
+- **THEN** it adopts none of them, holds an empty set of repositories, and builds nothing
+
+#### Scenario: A repository is later opted in
+
+- **WHEN** a later change opts one forge-hosted repository in to the second build service
+- **THEN** that repository, and only that repository, becomes one the second service builds, and the incumbent continues to build whatever it built before for that same repository
+
+### Requirement: Deliveries a build service acts on are authenticated
+
+The second build service SHALL act only on deliveries authenticated by a secret shared between it and the forge, and that secret SHALL be distinct from the incumbent's.
+
+**Discharged by**: `build-service-interface` requirement `Deliveries are accepted only at an authenticated endpoint`, resting on world assumption `A9`.
+
+#### Scenario: An authenticated delivery arrives
+
+- **WHEN** the forge sends the second build service a delivery carrying the secret shared with it
+- **THEN** the second service accepts the delivery and acts on it within the bounds of the repositories it may see
+
+#### Scenario: An unauthenticated delivery arrives
+
+- **WHEN** a delivery reaches the second build service without the shared secret, or carrying the incumbent's secret instead of its own
+- **THEN** the second service does not act on it
+
+### Requirement: A second build service's verdicts do not gate merges
+
+The check runs the second build service publishes SHALL carry a namespace distinct from the incumbent's, so that a repository's required checks continue to name only the incumbent until a person edits that repository's forge-side configuration deliberately.
+
+**Discharged by**: `build-service-interface` requirement `Verdict namespaces are distinct`, resting on world assumptions `A9` and `A12 — Which service's verdict gates a merge is the forge's configuration, not the host's`.
+
+#### Scenario: Both services publish against the same commit
+
+- **WHEN** both build services publish a check run against the same commit of the same forge-hosted repository
+- **THEN** the two appear under different names, the repository's required checks still name the incumbent's, and a change may merge on the incumbent's verdict alone
+
+#### Scenario: A repository's required checks are edited to name the second service
+
+- **WHEN** a person edits a repository's forge-side configuration to require a check run in the second service's namespace
+- **THEN** the second service's verdict gates merges for that repository from then on, which is a deliberate act outside this requirement rather than a consequence of standing the service up
+
+### Requirement: Forge credentials are operator-supplied and never legible in the repository
+
+Every forge credential the second build service uses SHALL be supplied by the operator and SHALL be unreadable in the repository that declares it, and rotating one SHALL take effect on the running service rather than leaving it holding the superseded value.
+
+**Discharged by**: `build-service-interface` requirement `Credentials exist only as activation-resolved paths`.
+
+#### Scenario: The repository is read by anyone with access to it
+
+- **WHEN** a person reads the repository that declares the second build service
+- **THEN** they find the names of its forge credentials and where each is consumed, and no credential value
+
+#### Scenario: A credential is rotated
+
+- **WHEN** the operator replaces the value behind one of the second service's forge credentials
+- **THEN** the running service comes to use the new value rather than continuing with the superseded one
+
+### Requirement: One activation establishes the second build service
+
+The second build service SHALL be established on the host by the fleet's ordinary activation act, with no step performed by hand on the host itself, so that what runs there remains a consequence of the declared configuration.
+
+**Discharged by**: `build-service-interface` requirement `The service is a consequence of the host's declared configuration`.
+
+#### Scenario: The host is activated
+
+- **WHEN** the operator activates the host's declared configuration once, after the forge application exists and its credentials have been populated
+- **THEN** the second build service is running, reachable at its hostname, and holding its own state, with nothing further done by hand on the host
+
+#### Scenario: The host is activated again from the same declaration
+
+- **WHEN** the operator activates the same declared configuration a second time
+- **THEN** the second build service is in the same condition as after the first activation, because no by-hand step exists for a repeat activation to lose
+
+### Requirement: A second build service is sized against the capacity the incumbent uses
+
+The second build service SHALL be sized explicitly against the build capacity the incumbent already uses on that host, rather than against the host's capacity as though it were alone.
+
+**Discharged by**: world assumption `A11 — One host's build capacity is finite and shared by everything on it`, together with the sizing recorded in this change's design; no interface property can discharge this one, because capacity is a property of the host rather than of the machine's interface.
+
+#### Scenario: The second service's sizing is chosen
+
+- **WHEN** the memory and concurrency of the second build service's evaluation work are chosen
+- **THEN** they are chosen as a share of what remains beside the incumbent's existing draw, and the reasoning is recorded rather than left to a default derived from the host's processor count
+
+#### Scenario: A repository is later opted in and the pair actually contends
+
+- **WHEN** a later change opts a repository in, so that both services evaluate and build on the same host in earnest
+- **THEN** that change re-observes the capacity the pair actually draws, because a sizing argument made while one service builds nothing establishes nothing about the pair under load

--- a/openspec/changes/stand-up-nixbot-on-magnetite/specs/world-assumptions/spec.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/specs/world-assumptions/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: A9 — A forge application's installation selection bounds what a build service can see, and its delivery secret authenticates what it is told
+
+It is true of the forge this fleet uses, independent of what this fleet builds, that a build service acting through a forge application sees only the repositories that application's installation selection covers, that a delivery announcing a repository event is authenticated by a secret shared between the forge and the recipient, and that a published check run is namespaced by the name the publishing service supplies rather than by any identity the forge assigns it.
+Any requirement whose discharge depends on this fact SHALL name it explicitly, and SHALL be treated as losing its discharge once this assumption's violation condition below is observed.
+
+#### Scenario: A forge stops bounding visibility by installation selection, stops authenticating deliveries, or stops honoring supplied verdict names
+
+- **WHEN** the forge grants a build service visibility of a repository outside its forge application's installation selection, accepts or forwards a delivery that carries no valid shared secret, or publishes a check run under a name the publishing service did not supply
+- **THEN** this assumption is void, and the `nixbot-build-service` requirements `Repositories are built only once opted in`, `Deliveries a build service acts on are authenticated`, and `A second build service's verdicts do not gate merges` lose the discharge argument that rests on installation selection, on a shared delivery secret, and on service-supplied verdict names respectively
+
+### Requirement: A10 — A hostname that resolves to a host and is reachable can obtain a certificate, and issuance is rate-limited
+
+It is true of the public naming system and of the certificate authority this fleet uses, independent of what this fleet builds, that a hostname resolving to a reachable host can obtain a certificate for that name without a person intervening, that a name whose traffic is intercepted by an intermediary before reaching the host cannot complete that issuance, and that the number of certificates obtainable in a period is finite.
+Any requirement whose discharge depends on this fact SHALL name it explicitly, and SHALL be treated as losing its discharge once this assumption's violation condition below is observed.
+
+#### Scenario: Issuance for a resolvable, reachable hostname stops being automatic or stops being available
+
+- **WHEN** a hostname that resolves to the host and is reachable from the public network cannot obtain a certificate without a person intervening, or issuance is refused because the period's limit is exhausted
+- **THEN** this assumption is void, and the `nixbot-build-service` requirement `A second build service is reachable at its own hostname` loses the discharge argument that a declared, unintercepted hostname yields a served certificate at activation
+
+### Requirement: A11 — One host's build capacity is finite and shared by everything on it
+
+It is true of a host in this fleet, independent of what this fleet builds, that its memory, its processor time, and the disk its store occupies are finite, that every service on that host draws from those same quantities, and that a second service evaluating and building draws from the pool the first one already uses.
+Capacity is therefore a property of the host rather than of any one service's configuration, and sizing one service in isolation establishes nothing about the pair.
+Any requirement whose discharge depends on this fact SHALL name it explicitly, and SHALL be treated as losing its discharge once this assumption's violation condition below is observed.
+
+#### Scenario: A second build service's draw stops coming from the same pool
+
+- **WHEN** a build service on the host performs its evaluation and its builds somewhere other than that host, so that its draw no longer comes from the same memory, processor, and store as the incumbent's
+- **THEN** this assumption no longer governs the pair, and the `nixbot-build-service` requirement `A second build service is sized against the capacity the incumbent uses` loses the reason its sizing argument exists, becoming a statement about a quantity the two services no longer share
+
+### Requirement: A12 — Which service's verdict gates a merge is the forge's configuration, not the host's
+
+It is true of the forge this fleet uses, independent of what this fleet builds, that a repository's own configuration names which check runs must pass before a change may merge, so a verdict published under a name that configuration does not name is advisory no matter how authoritative the service publishing it believes itself to be.
+Any requirement whose discharge depends on this fact SHALL name it explicitly, and SHALL be treated as losing its discharge once this assumption's violation condition below is observed.
+
+#### Scenario: A repository's configuration comes to name a second build service's verdicts
+
+- **WHEN** a repository's forge-side configuration is edited to require a check run published under a second build service's namespace, or the forge begins gating merges on verdicts its configuration does not name
+- **THEN** this assumption no longer holds for that repository, and the `nixbot-build-service` requirement `A second build service's verdicts do not gate merges` loses its discharge for that repository, because the distinctness of the namespace no longer implies the verdict is advisory
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: Grounded vocabulary for behavioral requirements
+
+The corpus SHALL provide one designation record per content term this repository's `behavioral`-stratum requirements use, recording the term, the sense in which it is used when a term carries more than one, the world phenomenon it denotes, and whether that phenomenon is world-only, shared with the machine, or machine-only.
+A term found to denote two distinct phenomena within this repository's vocabulary SHALL be recorded as two rows rather than collapsed into one.
+Twelve terms carry two senses in this repository today and are disambiguated below rather than left to context: `session`, `package`, `policy`, `@`, `mutation`, `activation`, `probe`, `machine`, `host`, `interface`, `repository`, and `build service`.
+
+| Term | Sense | World phenomenon it denotes | Status |
+|---|---|---|---|
+| session | autonomous | a bounded episode during which an agent acts without a human present to answer a prompt | world-only |
+| session | Pi-persisted | Pi's own stored record of a run (a session file, or the absence of one under `--no-session`) | machine-only |
+| package | fleet | a named unit of externally sourced code with recorded provenance (commit, hash, license) this fleet vets before use | world-only |
+| package | nix | a Nix derivation output with a store path | machine-only |
+| policy | fleet | the organization's decision about which mutations are acceptable, independent of what enforces it | world-only |
+| policy | machine | the running decision core (permission-gate, or the first-party pure core) that classifies a tool call | machine-only |
+| `@` | Pi | Pi's own path-prefix sigil in its path-resolution grammar | machine-only |
+| `@` | jj | jj's revset symbol for the current working-copy commit | machine-only |
+| mutation | world | an irreversible-to-a-person change made to a file or a repository someone maintains | world-only |
+| mutation | machine | the specific tool-call class the policy core classifies (`edit`, `write`, a semantic HTTP verb) | machine-only |
+| activation | world | the human act of authorizing a new configuration to take effect on a real machine | world-only |
+| activation | machine | the nix-darwin system-profile-link switch a `just activate` run performs | machine-only |
+| probe | measurement | the act of interrogating actual repository state to learn something true about it | shared |
+| probe | machine | a specific subprocess invocation (for example `jj --ignore-working-copy log ...`) with a literal argv and exit code | machine-only |
+| machine | WRSPM | M, whatever executes the program, in this framework's own vocabulary | machine-only |
+| machine | fleet | a nix-darwin laptop or cloud server this fleet manages | world-only |
+| host | fleet | a physical or virtual machine in the fleet that runs a configuration | world-only |
+| host | nix | the build or target platform designation nixpkgs cross-compilation vocabulary uses (`buildHost`/`hostPlatform`) | machine-only |
+| interface | WRSPM | the alphabet of phenomena shared between world and machine, at which the specification is stated | shared |
+| interface | nix/code | a module option interface, or a TypeScript interface type in extension source | machine-only |
+| permission system | — | a native mechanism that gates a tool call pending human interactive approval | world-only |
+| dialog | — | an interactive prompt awaiting a human's answer | world-only |
+| UI channel | — | the means by which a Pi session can present a dialog to a human at all, independent of whether one is actually present to answer it | world-only |
+| repository | recoverability | a version-controlled tree whose history can potentially recover a prior state of a file within it | shared |
+| repository | forge-hosted | a version-controlled tree kept on a forge, whose declared outputs a build service can be asked to build | shared |
+| history | — | the sequence of recorded prior states a repository's version-control system retains | shared |
+| target | — | the file or path a proposed mutation would act on | shared |
+| path | — | the string identifying a target's location, in whatever form the tool that opens it accepts | shared |
+| untracked file | — | a file present in a repository's working tree that its version-control system has never recorded | shared |
+| gitignored file | — | a file a repository's ignore rules exclude from being tracked even if added | shared |
+| diagnostic | — | the textual output a probe emits describing the state it found | shared |
+| `Hint:` line | — | a trailing advisory line jj appends after certain diagnostics | machine-only |
+| configuration root | — | the directory atomic inherits from Pi and treats as the source of its own settings | machine-only |
+| extension directory | — | the directory Pi loads extensions from unconditionally once a harness inherits its configuration root | machine-only |
+| build service | fleet | a service that evaluates a forge-hosted repository's declared outputs, builds them, and publishes the outcome back to that forge | world-only |
+| build service | machine | one running service unit and the state it owns, distinguished by its own user, database, and state directory | machine-only |
+| forge | — | the hosted service where a forge-hosted repository lives, which announces its events and displays the outcomes published about it | world-only |
+| forge application | — | a registered identity on a forge through which a build service acts, whose installation selection bounds the repositories that identity can see | shared |
+| delivery | — | a message a forge sends a build service announcing that something happened in a repository | shared |
+| check run | — | a named pass-or-fail outcome a build service publishes on a forge against a repository's commit | shared |
+| required check | — | the repository's own forge-side configuration naming which check runs must pass before a change may merge | world-only |
+| hostname | — | the public name at which a person reaches a service over the network | shared |
+| certificate | — | the credential that lets a hostname be served over a connection a browser accepts without warning | shared |
+| forge credential | — | a secret value that authenticates a build service to a forge, or authenticates a forge's delivery to that service | shared |
+| build capacity | — | the finite memory, processor time, and store disk available on one host at one time, shared by everything running on it | world-only |
+| operator | — | the person who maintains this fleet's hosts and holds the credentials its services use | world-only |
+
+#### Scenario: A term resolves to two phenomena
+
+- **WHEN** a content term used in a behavioral requirement denotes two distinct phenomena within this repository's vocabulary
+- **THEN** this designation table records both senses as separate rows rather than collapsing them into one
+
+#### Scenario: A behavioral requirement uses an unlisted term
+
+- **WHEN** the designation lint finds a content noun in a behavioral requirement that resolves to no row in this table
+- **THEN** the noun is either added here as a world or shared phenomenon, or the requirement using it is redirected toward the interface stratum, and neither disposition is applied silently

--- a/openspec/changes/stand-up-nixbot-on-magnetite/tasks.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/tasks.md
@@ -1,0 +1,56 @@
+## 1. Forge application
+
+- [ ] 1.1 Register a dedicated GitHub App for nixbot with repository permissions Contents read, Checks write, Metadata read, Pull requests read, organization permission Members read, and subscribed events push, pull request, check run, and check suite; set its webhook URL to `https://nixbot.scientistexperience.net/webhooks/github` and its user-authorization callback to `https://nixbot.scientistexperience.net/auth/github/callback` — verify: the application's settings page lists exactly those permissions and events, and its numeric id and OAuth client id are recorded in this change's verify.md
+- [ ] 1.2 Install that application with a repository selection covering only repositories intended for nixbot, and record the resulting selection — verify: the application's installations page shows that selection, recorded verbatim in verify.md, and the resolution of the design's open question about whether an empty selection is permitted is recorded with it
+- [ ] 1.3 Open the incumbent buildbot application's settings and confirm its permissions, events, webhook URL, and installation selection are unchanged — verify: the recorded incumbent settings match the pre-change state, with the application id noted in verify.md
+
+## 2. Flake input
+
+- [ ] 2.1 Add the `nixbot` flake input to `flake.nix`, following this repository's `nixpkgs`, and lock it — verify: `nix flake metadata --json` reports a `nixbot` node pinned to a specific revision, and `nix eval .#modules.nixos --apply builtins.attrNames` still evaluates
+- [ ] 2.2 Confirm the existing `buildbot-nix` input is untouched — verify: `git diff flake.nix` shows only the added `nixbot` input, and `nix flake metadata --json` reports the `buildbot-nix` node at its previous revision
+
+## 3. Credentials
+
+- [ ] 3.1 Declare three `clan.core.vars` generators in the new aspect — an operator-populated application private key, a generated webhook secret, and an operator-populated interface-login secret — each owned by the service user with the service named in its restart list — verify: `nix eval .#nixosConfigurations.magnetite.config.clan.core.vars.generators --apply builtins.attrNames` lists the three new generators alongside the incumbent's six
+- [ ] 3.2 Generate the webhook secret and populate the two operator slots with the values from task 1.1 — verify: `clan vars list magnetite` reports all three as set, and `vars/per-machine/magnetite/` carries one encrypted entry per generator file
+- [ ] 3.3 Confirm no credential value entered the repository — verify: `just lint` passes, including its secret scan, and reading each new `vars/` entry shows an encrypted blob rather than a value
+
+## 4. First-party aspect
+
+- [ ] 4.1 Write `modules/nixos/nixbot.nix` defining `flake.modules.nixos.nixbot`, configuring the service with its own hostname, its GitHub integration referencing the three credential paths, the topic-based repository adoption disabled, an explicit repository allowlist, provider-qualified administrators, the host's own platform as the only build system, explicitly chosen evaluation worker count and per-worker memory, the local database path, and the module's proxy integration left enabled with certificate issuance requested — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot` sub-attributes return those values, specifically `domain`, `github.topic` as null, `github.repoAllowlist`, `buildSystems`, `evalWorkerCount`, `database.createLocally`, `nginx.enable`, and `nginx.enableACME`
+- [ ] 4.2 Confirm the verdict namespace is left at the module's default rather than set to the incumbent's — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot.statusContextPrefix` returns the module default and not the incumbent's prefix
+- [ ] 4.3 Give the aspect file a header documenting its generators and its coexistence constraints, following the incumbent aspect's header form — verify: the file's header names each generator and its consumer, and `just lint` passes
+
+## 5. Host composition
+
+- [ ] 5.1 Import the upstream `inputs.nixbot.nixosModules.nixbot` module in `modules/machines/nixos/magnetite/default.nix` alongside the existing upstream imports, and name `nixbot` in that host's aspect list — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot.enable` returns true
+- [ ] 5.2 Confirm the incumbent's composition is unchanged — verify: `git diff --stat` reports no change under `modules/nixos/buildbot.nix` or the repository-root `buildbot-nix.toml`, and `nix eval .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.domain` still returns the incumbent's hostname
+- [ ] 5.3 Confirm the two services claim disjoint host resources in the evaluated configuration — verify: `nix eval` of the magnetite configuration shows distinct unit names, distinct users and groups, distinct state directories, and distinct root-retention directories for the two services, and that no TCP port is bound on the new service's behalf
+
+## 6. Hostname
+
+- [ ] 6.1 Add an unproxied `nixbot` CNAME to `modules/terranix/cloudflare.nix` following the existing incumbent record — verify: the repository's terraform plan recipe reports exactly one record to add and none to change or destroy
+- [ ] 6.2 Apply the plan and confirm public resolution — verify: `dig +short nixbot.scientistexperience.net` resolves through to the host's address, and the record is not intercepted by the provider's proxy
+
+## 7. Build gate
+
+- [ ] 7.1 Build the host's configuration without deploying it — verify: `nix build .#checks.x86_64-linux.nixos-magnetite 2>&1 | tee logs/nixos-magnetite-$(date +%Y%m%d-%H%M%S).log` succeeds
+
+## 8. Deployment
+
+- [ ] 8.1 Deploy the host — verify: `clan machines update magnetite 2>&1 | tee logs/clan-update-magnetite-$(date +%Y%m%d-%H%M%S).log` completes, and on the host `systemctl is-active nixbot.service` reports active with its socket unit present
+
+## 9. Documentation
+
+- [ ] 9.1 Record the two-service topology, the dedicated forge application, and the boundaries that keep the new service from building anything, in the repository's documentation tree — verify: `just docs-build` succeeds and the documentation link check passes
+
+## 10. Integration Verification
+
+- [ ] 10.1 Verify the new service answers at its own hostname over an accepted connection — verify: an HTTPS request to `https://nixbot.scientistexperience.net/` returns a successful response with a certificate issued for that hostname
+- [ ] 10.2 Verify the incumbent still serves — verify: an HTTPS request to `https://buildbot.scientistexperience.net/` returns a successful response, and the incumbent's units on the host report active
+- [ ] 10.3 Verify the new service builds nothing — verify: its interface reports an empty repository set, and no build has been recorded since deployment
+- [ ] 10.4 Verify delivery authentication both ways — verify: a redelivery from the forge application's advanced settings is accepted with a successful response, and a request to the same endpoint without the shared secret is rejected
+- [ ] 10.5 Verify both databases exist on the one instance — verify: listing databases on the host shows the incumbent's and the new service's side by side, each owned by its own role
+- [ ] 10.6 Verify no verdict namespace collision — verify: no check run bearing the incumbent's prefix originates from the new service, and no repository's required checks name the new service's prefix
+- [ ] 10.7 Verify the capacity picture after deployment — verify: memory in use, the store dataset's free space against its quota, and the incumbent's evaluation and build activity are recorded in verify.md as the baseline the first repository opt-in will be measured against
+- [ ] 10.8 Verify the rollback path is available — verify: removing the aspect from the host's list builds cleanly as a check, establishing that withdrawal is a redeploy rather than a repair

--- a/openspec/linear.yaml
+++ b/openspec/linear.yaml
@@ -51,3 +51,12 @@ projects:
         id: "ba0ffa20-a82b-40db-b292-d04f6a83eed2"
       "graphical-desktop-session":
         id: "8cf07dd5-2a48-4f45-bcd4-1add748aee46"
+  "nixbot-herculesci-cicd":
+    # slugId, not the project UUID (6fce4cfd-4c9b-4ca4-b797-9d91ccb4b669), for the
+    # reason recorded on the sibling entries: `linear document list --project`
+    # silently returns zero nodes with exit 0 for a UUID, so the archive-time
+    # UPSERT's title scan misses and duplicates every document.
+    id: "82a27ad740f7"
+    name: "Migrate to nixbot and herculesCI CI/CD"
+    teams: ["CAM"]
+    archive_documents: {}


### PR DESCRIPTION
Planning artifacts only. One OpenSpec change, `stand-up-nixbot-on-magnetite`, plus the Linear project registry entry it binds through. No module code, no host configuration, no deployment. Bound to [CAM-40](https://linear.app/cameronraysmith/issue/CAM-40/stand-up-nixbot-on-magnetite-alongside-buildbot), now Todo, with its description seeded from the proposal's business-facing content.

## What the change covers, and where it stops

A nixbot instance on magnetite at `nixbot.scientistexperience.net`, coexisting with the buildbot-nix server at `buildbot.scientistexperience.net` which stays authoritative for every repository. Success for the eventual implementation is `clan machines update magnetite` deploying a working instance.

Out of scope, named in the proposal's context and nowhere else: migrating vanixiets' own CI; finishing python-nix-template's migration, which never completed onto buildbot-nix and now retargets to nixbot; migrating ironstar; retiring buildbot.

## How the running buildbot server is actually composed

This was genuinely unknown going in, and `buildbot` does not appear under `machines/` because host composition does not live there.

`flake.nix:5` hands `modules/` to import-tree. `modules/nixos/buildbot.nix:20` assigns the aspect `flake.modules.nixos.buildbot`. `modules/machines/nixos/magnetite/default.nix:35-36` imports the upstream `inputs.buildbot-nix.nixosModules.buildbot-master` and `buildbot-worker` directly, and line 43 of the aspect list at `:38-53` names `buildbot`. `modules/clan/machines.nix:29-31` binds the machine namespace into `clan.machines.magnetite`, which `clan machines update magnetite` deploys. Magnetite is the only host importing that aspect (grep across `modules/machines/` matches only its file).

## Mapping from the prior buildbot-nix work

Most of it carries, and the one artifact named as expected not to carry is the one that carries most cleanly.

| buildbot-nix | nixbot | Verdict |
|---|---|---|
| `github.appId`, `appSecretKeyFile`, `webhookSecretFile`, `oauthId`, `oauthSecretFile` | same names (`nixbot/nixosModules/nixbot.nix:389-420`) | maps |
| `domain`, `useHTTPS`, `outputsPath`, `failedBuildReportLimit`, `evalMaxMemorySize`, `evalWorkerCount`, `buildMaxSilentTime`, `buildTimeout`, `showTrace`, `cacheFailedBuilds`, `allowUnauthenticatedControl`, `branches`, `pullBased`, `postBuildSteps`, `effects.*` | present one-for-one | maps |
| `enableNginx` | `nginx.enable`, plus a new `nginx.enableACME` (default **false**, `:866-869`) | maps, renamed |
| `buildbot-nix.toml` | still parsed by that exact filename, same schema plus `build_branches` (`nixbot/nixbot/nixbot/repo_config.py:14-15, 33-38`) | maps — **the expectation that this would not carry over is refuted**; it is upstream buildbot-nix's own convention (`buildbot-nix/README.md:169-171`) and this repository's root copy stays untouched |
| `workersFile`, the worker module, `workerPasswordFile` | none; one service, builds through the host nix daemon, scale-out via nix remote builders (`nixbot/docs/MIGRATION.md:23-24`) | no counterpart |
| `authBackend`, `accessMode.fullyPrivate` with its oauth2-proxy | deleted; built-in forge login plus `privateRepoViewers` | no counterpart |
| `dbUrl` | `database.createLocally` / `url` / `urlFile`; PostgreSQL only, no history carryover | maps, fresh database |
| commit statuses | check runs, namespaced by `statusContextPrefix` (default `nixbot`) | partially maps |
| per-repository webhooks at `change_hook/github` | one application-level webhook at `/webhooks/github`, needing `check_run` + `check_suite` events and Checks write | partially maps |
| `admins = [ "cameronraysmith" ]` | provider-qualified, `github:cameronraysmith` | maps, format change |
| `github.topic` as a live filter | one-shot import aid on an empty database, then a UI toggle | partially maps, semantics demoted |

Three of those inversions matter specifically because we coexist rather than replace, and both reference deployments (Mic92/dotfiles, clan-infra) made the opposite choice for exactly that reason. dotfiles reused its GitHub App unchanged across its migration — same app id, same OAuth client, same three secret names — and set `statusContextPrefix = "buildbot"` so inherited branch-protection rules kept working. Here the service those rules name is still running, so the change takes a dedicated App, keeps the default `nixbot` prefix, and sets `github.topic = null`.

## Coexistence constraints found on magnetite

Disjoint by construction: units (`nixbot` + `nixbot.socket` vs `buildbot-master` + `buildbot-worker`), users and groups, databases and roles, state directories (`/var/lib/nixbot` vs `/var/lib/buildbot`), and GC-root families (`per-user/nixbot` with the module's own 90-day rule vs the aspect's depth-corrected 7-day/30-day rules for `per-user/buildbot-worker`).

Latent port clash, avoided: nixbot binds TCP `8010` only when its nginx integration is disabled, and `8010` is also the nixpkgs buildbot default. Keeping `nginx.enable = true` leaves it on `/run/nixbot/web.sock` with no port bound. The zt-interface port 9989 stays the incumbent's worker protocol; nixbot has no worker concept, so the firewall is unchanged.

Genuinely shared, and where the residual risk lives: one nginx (distinct vhosts by hostname), one PostgreSQL instance already configured additively by five services, one nix store under a 250 G ZFS quota with a free-space reaper and a seven-day collection window, one `/nix/var/nix/builds` sandbox tree, one ACME account across seven certificates, and 32 GiB of memory against the incumbent's four eval workers at 2 GiB. The change sizes nixbot at two workers explicitly rather than by core count, and records a post-deploy capacity baseline for the first repository opt-in to be measured against.

DNS is declarative and has no `nixbot` record today; the existing unproxied `buildbot` CNAME (`modules/terranix/cloudflare.nix:62-69`) is the template, and unproxied is what lets the ACME challenge reach the host. Secrets follow the fleet's primary mechanism, clan vars, mirroring the incumbent's six generators; the sops-nix tree is not involved.

## Strata

Kept honest per this repository's WRSPM rules rather than flattened. Four world assumptions are added with violation conditions — forge-application scoping and delivery authentication (A9), hostname resolution and certificate issuance (A10), the finiteness of one host's build capacity (A11), and the fact that the forge's own configuration decides which verdict gates a merge (A12) — and the designation table gains the terms the behavioral requirements use, disambiguating `repository` and `build service` into two senses each. What the configuration must do is the interface capability, which states its trust boundary explicitly: the forge application's installation selection is set by hand outside the machine and is not machine-assertable, capacity outcomes are not guaranteed, and the shared surfaces above remain common-mode. Nothing is claimed end to end.

## Verification, and what was deliberately not run

Ran: `openspec validate --all --strict`. `change/stand-up-nixbot-on-magnetite` is valid. Ten spec items fail, all pre-existing Purpose-placeholder warnings in main capability specs this change does not touch — `git status openspec/specs/` is empty. Also ran a YAML parse of `openspec/linear.yaml` confirming the new project key resolves to the slugId, name, and team key, and `gitleaks` plus `treefmt` via the pre-commit hooks on both commits.

Not run, deliberately: the flake check set. This change adds no nix attribute and edits no nix file, and no flake check consumes the `openspec/` corpus, so there is nothing for `nix eval` or `nix build` to falsify here. A run over the check set would take minutes to hours and tell us nothing about a markdown-and-YAML diff. Every command the eventual implementation must run is written into `tasks.md` and `plan.md`, ending at `nix build .#checks.x86_64-linux.nixos-magnetite` and then `clan machines update magnetite`.

## Recommendation on the long-running PR

Land this planning PR first; open a fresh PR for implementation. Two reasons rather than a preference.

First, this diff is already complete and reviewable, and the implementation is not: `tasks.md` opens with registering a GitHub App and populating two credential slots, both out-of-band operator acts. A single long-running PR would hold the plan and the registry entry unlanded behind an operator action, and would present a reviewer with a diff where planning cannot be accepted without also accepting whatever infrastructure state the implementation has reached.

Second, precedent in this repository supports it: `annotate-discharge-evidence`, `declarative-cognee-endpoint`, and `sso-gateway` all sit on main as active changes with their artifacts landed and their implementation in progress, and the archive step that moves a change directory and regenerates the satisfaction projection belongs to the cycle that completes the work, not to the one that plans it.

The implementation PR is then the right vehicle to be long-running, since its own steps genuinely stage (input, secrets, aspect, composition, DNS, build gate, deploy, docs) and its per-task verifications are written to be checked off in order.
