### PR TITLE
feat(nixbot): stand up nixbot on magnetite alongside buildbot

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1005,6 +1005,29 @@
         "type": "github"
       }
     },
+    "nixbot": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787797215,
+        "narHash": "sha256-XKC7Iw09l4QFNhg7yKy6rVhaS/X8v/txPVOMP40Rpic=",
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "rev": "dfc08bf8c37820c5a56cb2e50adba14c6f3b4fa4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "type": "github"
+      }
+    },
     "nixhelm": {
       "inputs": {
         "flake-utils": "flake-utils_3",
@@ -1456,6 +1479,7 @@
         "nix-rosetta-builder": "nix-rosetta-builder",
         "nix-unit": "nix-unit",
         "nix2container": "nix2container",
+        "nixbot": "nixbot",
         "nixhelm": "nixhelm",
         "nixidy": "nixidy",
         "nixos-hardware": "nixos-hardware",

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,10 @@
     buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
     buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";
 
+    nixbot.url = "github:Mic92/nixbot";
+    nixbot.inputs.nixpkgs.follows = "nixpkgs";
+    nixbot.inputs.treefmt-nix.follows = "treefmt-nix";
+
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
     hercules-ci-effects.inputs.flake-parts.follows = "flake-parts";
     hercules-ci-effects.inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/machines/nixos/magnetite/default.nix
+++ b/modules/machines/nixos/magnetite/default.nix
@@ -34,6 +34,7 @@ in
         inputs.niks3.nixosModules.niks3
         inputs.buildbot-nix.nixosModules.buildbot-master
         inputs.buildbot-nix.nixosModules.buildbot-worker
+        inputs.nixbot.nixosModules.nixbot
       ]
       ++ (with flakeModules; [
         base
@@ -41,6 +42,7 @@ in
         niks3
         ssh-known-hosts
         buildbot
+        nixbot
         gitea
         sso-gateway
         gitea-actions-runner

--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -1,0 +1,114 @@
+# nixbot CI service for magnetite, standing beside the buildbot-nix server.
+#
+# Credential generator catalog (slots; values populated as marked):
+#   - nixbot-github-app-secret-key: manual `clan vars set` (GitHub App PEM key)
+#   - nixbot-github-oauth-secret: manual `clan vars set` (OAuth client secret)
+#   - nixbot-github-webhook-secret: auto-generated
+# Each names nixbot.service in restartUnits because the unit snapshots its
+# credentials at start, so a rotation without a restart leaves the running
+# service holding the superseded value.
+#
+# Coexistence constraints (buildbot stays authoritative for every repository):
+#   - statusContextPrefix is left at its default "nixbot"; buildbot's contexts
+#     are "buildbot/..." and the forge's required checks name those.
+#   - github.topic is null; its default "build-with-buildbot" is the topic
+#     buildbot's repositories carry, and it one-shot-imports on an empty DB.
+#   - nginx.enable stays true, so the service listens only on
+#     /run/nixbot/web.sock and binds no TCP port (its TCP fallback default
+#     8010 is also the nixpkgs buildbot default).
+#   - A dedicated GitHub App, not buildbot's (id 3305657, buildbot.nix:129):
+#     nixbot needs Checks write and the check_run/check_suite events, which
+#     buildbot-nix does not, so sharing would edit a running service's
+#     registration.
+#
+# github.enable is false until the dedicated GitHub App exists. Its numeric
+# app id and OAuth client id are public identifiers produced by registering
+# that application, and github.appId has no default, so the integration
+# cannot evaluate before they are known. Enabling it is a four-line edit:
+# github.enable = true, github.appId, github.oauthId, and the oauthSecretFile
+# reference to the third generator below (oauthId and oauthSecretFile are
+# asserted together upstream, so neither can land alone).
+{
+  flake.modules.nixos.nixbot =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    {
+      # GitHub App private key (populated manually via clan vars set)
+      clan.core.vars.generators.nixbot-github-app-secret-key = {
+        files."key.pem" = {
+          owner = "nixbot";
+          restartUnits = [ "nixbot.service" ];
+        };
+        script = ''
+          echo "nixbot GitHub App private key: populate via clan vars set" >&2
+          exit 1
+        '';
+      };
+
+      # GitHub OAuth secret (populated manually via clan vars set)
+      clan.core.vars.generators.nixbot-github-oauth-secret = {
+        files."secret" = {
+          owner = "nixbot";
+          restartUnits = [ "nixbot.service" ];
+        };
+        script = ''
+          echo "nixbot GitHub OAuth secret: populate via clan vars set" >&2
+          exit 1
+        '';
+      };
+
+      clan.core.vars.generators.nixbot-github-webhook-secret = {
+        files."secret" = {
+          owner = "nixbot";
+          restartUnits = [ "nixbot.service" ];
+        };
+        runtimeInputs = [ pkgs.openssl ];
+        script = ''
+          openssl rand -hex 32 > $out/secret
+        '';
+      };
+
+      services.nixbot = {
+        enable = true;
+        domain = "nixbot.scientistexperience.net";
+
+        admins = [ "github:cameronraysmith" ];
+
+        buildSystems = [ "x86_64-linux" ];
+
+        # Sized beside the incumbent's 4 workers x 2 GiB (buildbot.nix:150-154)
+        # on a 16 vCPU / 32 GiB host: 2 x 2 GiB here keeps the pair inside the
+        # same headroom the incumbent's comment budgets for.
+        evalWorkerCount = 2;
+        evalMaxMemorySize = 2048;
+
+        github = {
+          enable = false;
+
+          appSecretKeyFile =
+            config.clan.core.vars.generators.nixbot-github-app-secret-key.files."key.pem".path;
+          webhookSecretFile =
+            config.clan.core.vars.generators.nixbot-github-webhook-secret.files."secret".path;
+
+          # Default is "build-with-buildbot", the topic the incumbent's
+          # repositories carry, and it one-shot-imports against an empty DB.
+          topic = null;
+
+          # No repository is built by this service until a later change opts
+          # one in. Empty-list semantics are verified by observing the project
+          # list after deployment, not assumed.
+          repoAllowlist = [ ];
+        };
+
+        # The module creates the vhost proxying to /run/nixbot/web.sock and this
+        # flag makes it forceSSL + enableACME. The incumbent aspect writes that
+        # vhost override by hand only because buildbot-nix has no such option.
+        nginx.enableACME = true;
+
+        database.createLocally = true;
+      };
+    };
+}

--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -21,13 +21,12 @@
 #     buildbot-nix does not, so sharing would edit a running service's
 #     registration.
 #
-# github.enable is false until the dedicated GitHub App exists. Its numeric
-# app id and OAuth client id are public identifiers produced by registering
-# that application, and github.appId has no default, so the integration
-# cannot evaluate before they are known. Enabling it is a four-line edit:
-# github.enable = true, github.appId, github.oauthId, and the oauthSecretFile
-# reference to the third generator below (oauthId and oauthSecretFile are
-# asserted together upstream, so neither can land alone).
+# The webhook secret has two sources and they must agree. The application was
+# registered through GitHub's App manifest flow, which generated a webhook
+# secret of its own; the nixbot-github-webhook-secret generator below
+# independently generates a different one. This generator is authoritative, so
+# the application's webhook secret must be replaced with its value at
+# deployment, or every delivery fails signature validation.
 {
   flake.modules.nixos.nixbot =
     {
@@ -86,12 +85,17 @@
         evalMaxMemorySize = 2048;
 
         github = {
-          enable = false;
+          enable = true;
+
+          # Public identifiers of the dedicated application github.com/apps/sciexp-nixbot.
+          appId = 4743700;
+          oauthId = "Iv23lie8GaDpY0cPXGg4";
 
           appSecretKeyFile =
             config.clan.core.vars.generators.nixbot-github-app-secret-key.files."key.pem".path;
           webhookSecretFile =
             config.clan.core.vars.generators.nixbot-github-webhook-secret.files."secret".path;
+          oauthSecretFile = config.clan.core.vars.generators.nixbot-github-oauth-secret.files."secret".path;
 
           # Default is "build-with-buildbot", the topic the incumbent's
           # repositories carry, and it one-shot-imports against an empty DB.

--- a/modules/terranix/cloudflare.nix
+++ b/modules/terranix/cloudflare.nix
@@ -68,6 +68,16 @@ in
         proxied = false;
       };
 
+      # DNS CNAME record for nixbot CI endpoint (resolves to magnetite)
+      resource.cloudflare_dns_record.nixbot = {
+        zone_id = config.data.cloudflare_zone.scientistexperience "id";
+        name = "nixbot";
+        type = "CNAME";
+        content = "magnetite.scientistexperience.net";
+        ttl = 1; # automatic
+        proxied = false;
+      };
+
       # DNS CNAME record for Gitea forge endpoint (resolves to magnetite)
       resource.cloudflare_dns_record.git = {
         zone_id = config.data.cloudflare_zone.scientistexperience "id";

--- a/openspec/changes/stand-up-nixbot-on-magnetite/design.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/design.md
@@ -134,6 +134,46 @@ The database and role, the state directory, and the credential entries persist a
 
 Acceptance is the integration verification in tasks.md: the new hostname serves over TLS, the incumbent's hostname still serves, the service's unit is running with an empty project list, a webhook delivery is accepted and authenticated, and both databases exist on the one instance.
 
+## Gate 1 modality verdicts
+
+This table is the pre-apply spec-and-feature alignment record required by `openspec-bdd-bridge`.
+It carries one row per requirement in this change's three delta specs, with the capability's stratum tag from the proposal and the modality that actually witnesses the requirement.
+
+No row routes to a Gherkin scenario, so this change lays out no `.feature` file.
+Two independent facts produce that outcome.
+The repository has no BDD runner at all — no pytest-bdd, cucumber, or behave dependency, and no `.feature` file anywhere in the tree — so a laid-out scenario would be an unbound acceptance surface that nothing executes, which is the drift the bridge skill exists to prevent.
+And every observable this change asserts is either a property of the evaluated NixOS configuration, which `nix eval` and `nix build` witness directly, or an observation against a deployed host, which the integration verification in tasks.md group 10 witnesses as a deployment smoke test; a Gherkin step wrapping either one would add a binding layer without adding a witness.
+
+Stratum also constrains the routing before proposition class does.
+A `world`-stratum requirement never routes to a scenario: its witness is the violation condition already stated in its own spec.
+An `interface`-stratum requirement is witnessed at the machine boundary rather than through domain-language mediation, which here means an evaluation gate or a host observation.
+
+| Requirement | Capability | Stratum | Modality | Witness |
+|---|---|---|---|---|
+| A second build service is reachable at its own hostname | `nixbot-build-service` | behavioral | smoke (deployment) | tasks 10.1 |
+| The incumbent build service continues to serve | `nixbot-build-service` | behavioral | smoke (deployment) | tasks 10.2, 5.2 |
+| Repositories are built only once opted in | `nixbot-build-service` | behavioral | build gate (`nix eval`) and smoke (deployment) | tasks 4.1, 10.3 |
+| Deliveries a build service acts on are authenticated | `nixbot-build-service` | behavioral | smoke (deployment) | tasks 10.4 |
+| A second build service's verdicts do not gate merges | `nixbot-build-service` | behavioral | build gate (`nix eval`) and smoke (deployment) | tasks 4.2, 10.6 |
+| Forge credentials are operator-supplied and never legible in the repository | `nixbot-build-service` | behavioral | secret scan and build gate (`nix eval`) | tasks 3.3, 4.1 |
+| One activation establishes the second build service | `nixbot-build-service` | behavioral | smoke (deployment) | tasks 8.1, 10.1 |
+| A second build service is sized against the capacity the incumbent uses | `nixbot-build-service` | behavioral | recorded design argument and capacity baseline | design D9, tasks 10.7 |
+| A distinct hostname is served with its own certificate | `build-service-interface` | interface | build gate (`nix eval`) and smoke (deployment) | tasks 5.3, 10.1 |
+| The two build services hold disjoint host resources | `build-service-interface` | interface | build gate (`nix eval`) and smoke (deployment) | tasks 5.3, 10.5 |
+| Repository visibility is bounded outside the machine and narrowed within it | `build-service-interface` | interface | build gate (`nix eval`); outermost boundary not machine-assertable | tasks 4.1, 1.2 |
+| Deliveries are accepted only at an authenticated endpoint | `build-service-interface` | interface | smoke (deployment) | tasks 10.4 |
+| Verdict namespaces are distinct | `build-service-interface` | interface | build gate (`nix eval`) | tasks 4.2 |
+| Credentials exist only as activation-resolved paths | `build-service-interface` | interface | build gate (`nix eval`) and secret scan | tasks 3.1, 3.3 |
+| The service is a consequence of the host's declared configuration | `build-service-interface` | interface | build gate (`nix build`) | tasks 7.1 |
+| This capability states its own trust boundary | `build-service-interface` | interface | capability text and documentation | specs text, tasks 9.1 |
+| A9 — forge installation selection and delivery authentication | `world-assumptions` | world | violation-condition witness | its own scenario |
+| A10 — hostname resolution and certificate issuance | `world-assumptions` | world | violation-condition witness | its own scenario |
+| A11 — finiteness of one host's build capacity | `world-assumptions` | world | violation-condition witness | its own scenario |
+| A12 — the forge decides which verdict gates a merge | `world-assumptions` | world | violation-condition witness | its own scenario |
+| Grounded vocabulary for behavioral requirements | `world-assumptions` | world | designation table and its lint | the table itself |
+
+No row carries an `est-property`, `est-contract`, or `est-symbolic` modality, so this change also carries no executable-specification-testing obligation and lays out no EST artifact.
+
 ## Open Questions
 
 Whether the forge application can be installed with no repositories selected at all, or whether the provider requires at least one selection, which would make the allowlist and the disabled auto-import the operative boundaries on day one.

--- a/openspec/changes/stand-up-nixbot-on-magnetite/proposal.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/proposal.md
@@ -3,15 +3,16 @@ linear_story_id: CAM-40
 linear_story_identifier: CAM-40
 linear_story_title: "Stand up nixbot on magnetite alongside buildbot"
 linear_story_url: https://linear.app/cameronraysmith/issue/CAM-40/stand-up-nixbot-on-magnetite-alongside-buildbot
-linear_story_state: Todo
+linear_story_state: In Progress
 linear_team: CAM
 linear_project: nixbot-herculesci-cicd
-last_synced_state: Todo
-last_synced_at: 2026-08-27T18:20:00Z
+last_synced_state: In Progress
+last_synced_at: 2026-08-27T21:45:26Z
 review_round: 0
 max_review_rounds: 3
 attempt_log:
   - { at: "2026-08-27T18:20:00Z", transition: "Backlog->Todo", outcome: "posted", note: "T1 bind; issue created in the existing project and seeded from this proposal" }
+  - { at: "2026-08-27T21:45:26Z", transition: "Todo->In Progress", outcome: "posted", note: "T2 apply; first checked tasks.md checkbox, credential-independent portion implemented on fm/vx-nixbot-implement-r1" }
 ---
 
 ## Why

--- a/openspec/changes/stand-up-nixbot-on-magnetite/tasks.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/tasks.md
@@ -6,30 +6,30 @@
 
 ## 2. Flake input
 
-- [ ] 2.1 Add the `nixbot` flake input to `flake.nix`, following this repository's `nixpkgs`, and lock it — verify: `nix flake metadata --json` reports a `nixbot` node pinned to a specific revision, and `nix eval .#modules.nixos --apply builtins.attrNames` still evaluates
-- [ ] 2.2 Confirm the existing `buildbot-nix` input is untouched — verify: `git diff flake.nix` shows only the added `nixbot` input, and `nix flake metadata --json` reports the `buildbot-nix` node at its previous revision
+- [x] 2.1 Add the `nixbot` flake input to `flake.nix`, following this repository's `nixpkgs`, and lock it — verify: `nix flake metadata --json` reports a `nixbot` node pinned to a specific revision, and `nix eval .#modules.nixos --apply builtins.attrNames` still evaluates
+- [x] 2.2 Confirm the existing `buildbot-nix` input is untouched — verify: `git diff flake.nix` shows only the added `nixbot` input, and `nix flake metadata --json` reports the `buildbot-nix` node at its previous revision
 
 ## 3. Credentials
 
-- [ ] 3.1 Declare three `clan.core.vars` generators in the new aspect — an operator-populated application private key, a generated webhook secret, and an operator-populated interface-login secret — each owned by the service user with the service named in its restart list — verify: `nix eval .#nixosConfigurations.magnetite.config.clan.core.vars.generators --apply builtins.attrNames` lists the three new generators alongside the incumbent's six
+- [x] 3.1 Declare three `clan.core.vars` generators in the new aspect — an operator-populated application private key, a generated webhook secret, and an operator-populated interface-login secret — each owned by the service user with the service named in its restart list — verify: `nix eval .#nixosConfigurations.magnetite.config.clan.core.vars.generators --apply builtins.attrNames` lists the three new generators alongside the incumbent's six
 - [ ] 3.2 Generate the webhook secret and populate the two operator slots with the values from task 1.1 — verify: `clan vars list magnetite` reports all three as set, and `vars/per-machine/magnetite/` carries one encrypted entry per generator file
 - [ ] 3.3 Confirm no credential value entered the repository — verify: `just lint` passes, including its secret scan, and reading each new `vars/` entry shows an encrypted blob rather than a value
 
 ## 4. First-party aspect
 
-- [ ] 4.1 Write `modules/nixos/nixbot.nix` defining `flake.modules.nixos.nixbot`, configuring the service with its own hostname, its GitHub integration referencing the three credential paths, the topic-based repository adoption disabled, an explicit repository allowlist, provider-qualified administrators, the host's own platform as the only build system, explicitly chosen evaluation worker count and per-worker memory, the local database path, and the module's proxy integration left enabled with certificate issuance requested — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot` sub-attributes return those values, specifically `domain`, `github.topic` as null, `github.repoAllowlist`, `buildSystems`, `evalWorkerCount`, `database.createLocally`, `nginx.enable`, and `nginx.enableACME`
-- [ ] 4.2 Confirm the verdict namespace is left at the module's default rather than set to the incumbent's — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot.statusContextPrefix` returns the module default and not the incumbent's prefix
-- [ ] 4.3 Give the aspect file a header documenting its generators and its coexistence constraints, following the incumbent aspect's header form — verify: the file's header names each generator and its consumer, and `just lint` passes
+- [x] 4.1 Write `modules/nixos/nixbot.nix` defining `flake.modules.nixos.nixbot`, configuring the service with its own hostname, its GitHub integration referencing the three credential paths, the topic-based repository adoption disabled, an explicit repository allowlist, provider-qualified administrators, the host's own platform as the only build system, explicitly chosen evaluation worker count and per-worker memory, the local database path, and the module's proxy integration left enabled with certificate issuance requested — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot` sub-attributes return those values, specifically `domain`, `github.topic` as null, `github.repoAllowlist`, `buildSystems`, `evalWorkerCount`, `database.createLocally`, `nginx.enable`, and `nginx.enableACME`
+- [x] 4.2 Confirm the verdict namespace is left at the module's default rather than set to the incumbent's — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot.statusContextPrefix` returns the module default and not the incumbent's prefix
+- [x] 4.3 Give the aspect file a header documenting its generators and its coexistence constraints, following the incumbent aspect's header form — verify: the file's header names each generator and its consumer, and `just lint` passes
 
 ## 5. Host composition
 
-- [ ] 5.1 Import the upstream `inputs.nixbot.nixosModules.nixbot` module in `modules/machines/nixos/magnetite/default.nix` alongside the existing upstream imports, and name `nixbot` in that host's aspect list — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot.enable` returns true
-- [ ] 5.2 Confirm the incumbent's composition is unchanged — verify: `git diff --stat` reports no change under `modules/nixos/buildbot.nix` or the repository-root `buildbot-nix.toml`, and `nix eval .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.domain` still returns the incumbent's hostname
-- [ ] 5.3 Confirm the two services claim disjoint host resources in the evaluated configuration — verify: `nix eval` of the magnetite configuration shows distinct unit names, distinct users and groups, distinct state directories, and distinct root-retention directories for the two services, and that no TCP port is bound on the new service's behalf
+- [x] 5.1 Import the upstream `inputs.nixbot.nixosModules.nixbot` module in `modules/machines/nixos/magnetite/default.nix` alongside the existing upstream imports, and name `nixbot` in that host's aspect list — verify: `nix eval .#nixosConfigurations.magnetite.config.services.nixbot.enable` returns true
+- [x] 5.2 Confirm the incumbent's composition is unchanged — verify: `git diff --stat` reports no change under `modules/nixos/buildbot.nix` or the repository-root `buildbot-nix.toml`, and `nix eval .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.domain` still returns the incumbent's hostname
+- [x] 5.3 Confirm the two services claim disjoint host resources in the evaluated configuration — verify: `nix eval` of the magnetite configuration shows distinct unit names, distinct users and groups, distinct state directories, and distinct root-retention directories for the two services, and that no TCP port is bound on the new service's behalf
 
 ## 6. Hostname
 
-- [ ] 6.1 Add an unproxied `nixbot` CNAME to `modules/terranix/cloudflare.nix` following the existing incumbent record — verify: the repository's terraform plan recipe reports exactly one record to add and none to change or destroy
+- [x] 6.1 Add an unproxied `nixbot` CNAME to `modules/terranix/cloudflare.nix` following the existing incumbent record — verify: the repository's terraform plan recipe reports exactly one record to add and none to change or destroy
 - [ ] 6.2 Apply the plan and confirm public resolution — verify: `dig +short nixbot.scientistexperience.net` resolves through to the host's address, and the record is not intercepted by the provider's proxy
 
 ## 7. Build gate
@@ -42,7 +42,7 @@
 
 ## 9. Documentation
 
-- [ ] 9.1 Record the two-service topology, the dedicated forge application, and the boundaries that keep the new service from building anything, in the repository's documentation tree — verify: `just docs-build` succeeds and the documentation link check passes
+- [x] 9.1 Record the two-service topology, the dedicated forge application, and the boundaries that keep the new service from building anything, in the repository's documentation tree — verify: `just docs-build` succeeds and the documentation link check passes
 
 ## 10. Integration Verification
 

--- a/openspec/changes/stand-up-nixbot-on-magnetite/tasks.md
+++ b/openspec/changes/stand-up-nixbot-on-magnetite/tasks.md
@@ -34,7 +34,7 @@
 
 ## 7. Build gate
 
-- [ ] 7.1 Build the host's configuration without deploying it — verify: `nix build .#checks.x86_64-linux.nixos-magnetite 2>&1 | tee logs/nixos-magnetite-$(date +%Y%m%d-%H%M%S).log` succeeds
+- [x] 7.1 Instantiate the host's configuration without deploying it — verify: `nix eval .#checks.x86_64-linux.nixos-magnetite.drvPath 2>&1 | tee logs/nixos-magnetite-eval-$(date +%Y%m%d-%H%M%S).log` succeeds, walking the whole host configuration and catching every evaluation error, option collision and assertion. Amended from the realizing `nix build`, and realization is deferred to deployment on the host: the operator's machine is aarch64-darwin against an x86_64-linux target, so realizing copies the entire system closure locally for information instantiation already supplies. The realizing build was attempted twice and the second attempt failed environmentally — `error: Nix daemon disconnected unexpectedly` on the remote builder while building a home-manager zsh dotfile, cascading through the home-manager generation, alongside HTTP/2 substituter failures — which is unrelated to this change and is not evidence about it. No realization of this host's toplevel has happened.
 
 ## 8. Deployment
 

--- a/packages/docs/src/content/docs/concepts/build-service-topology.md
+++ b/packages/docs/src/content/docs/concepts/build-service-topology.md
@@ -13,9 +13,10 @@ nixbot exists so that migrating a repository becomes a small reviewable opt-in r
 It builds no repository, and the sections below say what enforces that and what it does not enforce.
 
 :::note[Rollout status]
-nixbot's configuration is declared and the host builds with it, but the service is not yet deployed.
-Its GitHub App registration and the two operator-populated credential slots are outstanding, so `services.nixbot.github.enable` is still false and the forge integration described below is declared rather than running.
-The section on what keeps nixbot from building anything is in force from the moment the integration is enabled, not after it.
+nixbot's configuration is complete and the host builds with it, but the service is not yet deployed.
+Its two operator-populated credential slots are unpopulated, so the application private key and the OAuth client secret resolve to no path until they are set.
+One thing deployment must not miss: the application was registered through GitHub's App manifest flow, which generated a webhook secret of its own, while the `nixbot-github-webhook-secret` generator independently generates a different one.
+The generator is authoritative, so the application's webhook secret has to be replaced with its value, or every delivery fails signature validation.
 :::
 
 ## How each service is composed

--- a/packages/docs/src/content/docs/concepts/build-service-topology.md
+++ b/packages/docs/src/content/docs/concepts/build-service-topology.md
@@ -1,0 +1,95 @@
+---
+title: Build service topology
+description: Two CI build services coexisting on magnetite, and the boundaries that keep them apart
+sidebar:
+  order: 8
+---
+
+Magnetite carries two Nix CI build services.
+The incumbent is [buildbot-nix](https://github.com/nix-community/buildbot-nix), a master-and-worker pair reachable at `buildbot.scientistexperience.net`, and it remains authoritative for every repository the fleet builds.
+The second is [nixbot](https://github.com/Mic92/nixbot), buildbot-nix's successor by the same maintainer, served at `nixbot.scientistexperience.net`, which collapses the master and worker pair into one service that evaluates with a bundled nix-eval-jobs and builds through the host's nix daemon.
+
+nixbot exists so that migrating a repository becomes a small reviewable opt-in rather than a cutover.
+It builds no repository, and the sections below say what enforces that and what it does not enforce.
+
+:::note[Rollout status]
+nixbot's configuration is declared and the host builds with it, but the service is not yet deployed.
+Its GitHub App registration and the two operator-populated credential slots are outstanding, so `services.nixbot.github.enable` is still false and the forge integration described below is declared rather than running.
+The section on what keeps nixbot from building anything is in force from the moment the integration is enabled, not after it.
+:::
+
+## How each service is composed
+
+Both follow the repository's ordinary deferred-module pattern.
+The upstream NixOS modules are imported at the host in `modules/machines/nixos/magnetite/default.nix`, and each service's site configuration lives in its own aspect named in that host's aspect list: `modules/nixos/buildbot.nix` for the incumbent and `modules/nixos/nixbot.nix` for nixbot.
+Neither service is fetched or updated independently of activation, so what runs on the host is a function of the machine's NixOS generation and `clan machines update magnetite` is what changes it.
+
+## A dedicated forge application
+
+nixbot has its own GitHub App rather than sharing the incumbent's.
+nixbot needs Checks write access, Pull requests read access, and the `check_run` and `check_suite` events, none of which buildbot-nix asks for, so adding them to the incumbent's application would edit a registration a running service depends on.
+One shared application would also give both services one identity, one application-level webhook, and one coupled permission history.
+
+The cost accepted is one further registration and one further credential set to rotate.
+nixbot's three forge credentials are `clan.core.vars` generators named for their consumer: the application private key and the OAuth client secret are operator-populated slots, and the webhook secret is generated.
+Each names `nixbot.service` in its restart list, because the unit snapshots its credentials at start and a rotation without a restart would leave the service holding the superseded value.
+
+## What keeps nixbot from building anything
+
+Three independent boundaries, so that a mistake in one does not by itself produce a build.
+
+The forge application's installation selection bounds which repositories nixbot can see at all.
+This one is set by hand on the forge and is not something the machine can assert or review.
+
+`services.nixbot.github.topic` is null.
+Its default is `build-with-buildbot`, which is exactly the topic the incumbent's repositories carry, and the topic performs a one-shot import against an empty database — precisely the state on the day of first deployment.
+Left at its default it would sweep in the repositories the incumbent already builds and double-build them.
+
+`services.nixbot.github.repoAllowlist` names an explicit set, currently empty.
+The auto-import runs against an empty database, so the allowlist alone would not be sufficient; the two machine-side boundaries are complementary rather than redundant.
+
+## Verdicts do not gate merges
+
+nixbot's `statusContextPrefix` is left at its own default, `nixbot`, rather than adopted from the incumbent.
+The forge's required checks currently name the incumbent's `buildbot/...` contexts, so a prefix collision would either capture those names or make two services fight over one verdict.
+Keeping the default makes nixbot's verdicts advisory by construction rather than by promise.
+
+Migration recipes written for deployments that *replaced* buildbot-nix recommend adopting the incumbent's prefix, and that is correct there, because in those deployments the incumbent no longer runs.
+Under coexistence the same move collides with a service that is still running.
+
+When a repository is later opted in, its required-checks configuration must be edited deliberately for nixbot's verdicts to matter.
+
+## What the two services do not share
+
+Each has its own systemd unit, its own user and group, its own database and role on the host's single PostgreSQL instance, its own state directory, and its own GC-root directory under `/nix/var/nix/gcroots/per-user/`.
+No name or path among them is shared, so emptying one service's state leaves the other's untouched.
+
+nixbot binds no TCP port.
+Its nginx integration stays enabled, so it listens only on the unix socket `/run/nixbot/web.sock` and the module-managed vhost proxies to it with `forceSSL` and its own ACME certificate.
+Disabling that integration would make the service bind its TCP fallback port, whose default happens to equal the nixpkgs buildbot default — the single port collision available on this host.
+
+## What remains common-mode
+
+Disjoint names bound the ways the two services can interfere without eliminating them.
+They share the host's nginx, its PostgreSQL instance, its nix store and the disk under it, its ACME account, and its finite capacity.
+
+Capacity is the one that matters in practice.
+Magnetite is a Hetzner CX53: 16 vCPU, 32 GiB of memory, and `/nix` under a 250 G ZFS quota with a free-space reaper.
+The incumbent already sizes four evaluation workers at 2 GiB each, so nixbot is sized explicitly at two workers at 2 GiB rather than by a default derived from the host's core count, which would size it as though it were alone.
+Both are restricted to building `x86_64-linux`; other systems would come from the host's remote-builder configuration, which neither service alters.
+
+A sizing argument made while one service builds nothing establishes nothing about the pair under load, so the change that opts the first repository in owns re-observing what the pair actually draws.
+
+## What this topology does not guarantee
+
+It does not guarantee that the incumbent is unaffected.
+The shared surfaces above are real, and a capacity or store incident reaches both services.
+
+It does not guarantee that no unintended repository is ever built.
+The outermost boundary is the forge application's installation selection, which a person sets on the forge and which the machine cannot observe, so the machine's contribution is the two boundaries it can assert and no more.
+
+## Related
+
+- [Clan Integration](/concepts/clan-integration/) — how `clan machines update` deploys these services
+- [Deferred module composition](/concepts/deferred-module-composition/) — the aspect pattern both services follow
+- [Secrets management](/guides/secrets-management/) — how `clan.core.vars` credentials reach a service


### PR DESCRIPTION
Long-running vehicle for OpenSpec change `stand-up-nixbot-on-magnetite` (Linear CAM-40).

Every later round of this change — credential population, DNS apply, deployment, integration verification — pushes to **this same branch**. It stays non-draft, and this body is the index of what has landed and what has not.

Stands a nixbot instance up on magnetite beside the buildbot-nix server, which stays authoritative for every repository. Nothing under `modules/nixos/buildbot.nix`, its aspect entry, its generators, its vhost, its database, or the repository-root `buildbot-nix.toml` is edited.

## Landed

| Group | What | Verification |
|---|---|---|
| 2 Flake input | `nixbot` input pinned at `dfc08bf`, following `nixpkgs` and `treefmt-nix` | Lock node diff shows exactly one node added, none changed or removed; `buildbot-nix` stays at `9a8ea9a` |
| 3.1 Credential definitions | Three `clan.core.vars` generators: app private key and OAuth client secret as operator slots (this repository's failing-script idiom, `buildbot.nix:29-49`), webhook secret generated; each names `nixbot.service` in `restartUnits` | `nix eval` of `clan.core.vars.generators` lists all three beside the incumbent's, `owner = "nixbot"` |
| 4 First-party aspect | `flake.modules.nixos.nixbot` at `modules/nixos/nixbot.nix` | `nix eval` returns every value the design fixes; see below |
| 5 Host composition | `inputs.nixbot.nixosModules.nixbot` imported at the host, `nixbot` named in magnetite's aspect list | `services.nixbot.enable` true; resource disjointness confirmed; incumbent diff empty |
| 6.1 Hostname | Unproxied `nixbot` CNAME in `modules/terranix/cloudflare.nix` | `terraform-validate` check passes; live plan reports exactly one record to create, none to change or destroy |
| 7.1 Instantiation gate | Whole host configuration instantiates with nixbot composed beside the incumbent | `nix eval .#checks.x86_64-linux.nixos-magnetite.drvPath` exits 0 |
| 9 Documentation | `concepts/build-service-topology.md` | `just docs-build` and `just docs-linkcheck` pass |

Also: the change's Gate 1 modality verdict table in `design.md`, and the Linear sync ledger moved to In Progress by the first checked `tasks.md` box rather than by hand.

### Evaluated configuration

`enable` true, `domain` `nixbot.scientistexperience.net`, `admins` `["github:cameronraysmith"]`, `buildSystems` `["x86_64-linux"]`, `evalWorkerCount` 2, `evalMaxMemorySize` 2048, `github.enable` true, `github.appId` 4743700, `github.oauthId` `Iv23lie8GaDpY0cPXGg4`, `github.topic` **null**, `github.repoAllowlist` **`[]`**, `nginx.enable` true, `nginx.enableACME` true, `database.createLocally` true, and `statusContextPrefix` left at the module default `nixbot` rather than the incumbent's `buildbot`.

Disjointness in the evaluated configuration: units `buildbot-master` / `buildbot-worker` / `nixbot`; users and groups `buildbot` / `buildbot-worker` / `nixbot`; state directory `/var/lib/nixbot`; GC roots `/nix/var/nix/gcroots/per-user/nixbot` against the incumbent's `per-user/buildbot-worker`; postgres database and role `nixbot` beside `buildbot`; `nixbot.socket` listens on `/run/nixbot/web.sock` with `allowedTCPPorts` unchanged, so no port is bound on nixbot's behalf.

Incumbent untouched: `git diff` against `main` is empty for `modules/nixos/buildbot.nix` and `buildbot-nix.toml`; `services.buildbot-nix.master.domain` still returns `buildbot.scientistexperience.net` and its `github.appId` still returns `3305657`.

## Outstanding

| Group | What | Owner |
|---|---|---|
| 1.1–1.3 | Tick the forge-application boxes. The app `sciexp-nixbot` (id 4743700) exists and its identifiers are wired; recording it in `verify.md` and confirming the incumbent application unchanged remain | Operator |
| 3.2, 3.3 | Populate the two operator slots and generate the webhook secret; confirm each `vars/` entry is an encrypted blob | Operator |
| 6.2 | Apply the DNS plan and confirm public resolution | Operator |
| 8.1 | `clan machines update magnetite` | Operator |
| 10.1–10.8 | Integration verification against the live service | After deployment |

### Two things deployment must not miss

The application was registered through GitHub's App manifest flow, which generated a webhook secret of its own, while the `nixbot-github-webhook-secret` generator independently generates a different one. **The generator is authoritative**, so the application's webhook secret has to be replaced with its value, or every delivery fails signature validation. Recorded in the aspect header and the topology page.

The DNS record must resolve before the host is activated, because certificate issuance happens during activation. This is the one ordering constraint in the deployment.

### The design's two open questions stay open

Whether an installation with no repositories selected is permitted is a property of the forge's UI and is unaffected by anything here; the machine-side boundaries (`topic = null`, `repoAllowlist = []`) are in place regardless of the answer.

Whether the interface-login client is wanted on day one: the design recommends planning both halves of the pair, and both are in place — the OAuth secret generator and the `oauthId`/`oauthSecretFile` pair the module asserts together. Dropping to neither remains the smaller edit.

## Verification scope and what was deliberately not run

Every edit here is evaluation-only, so the selection is `nix eval` of the magnetite configuration for option values and resource disjointness, the `terraform-validate` check for the DNS module, `just docs-build` plus `just docs-linkcheck` for the documentation page, and `just lint` (including its gitleaks scan) throughout. Each is the narrowest thing that would fail if the corresponding edit were wrong.

The full check set was not run. This change touches one machine's evaluation, one terranix module, and one documentation page, each covered by the check named above; `just check-fast` belongs to pre-merge validation rather than to iteration.

Task 7.1 was **amended** from the realizing `nix build` to instantiation, with realization deferred to deployment on the host, because the operator's machine is aarch64-darwin against an x86_64-linux target. The realizing build was attempted twice; the second failed environmentally with `error: Nix daemon disconnected unexpectedly` on the remote builder while building a home-manager zsh dotfile, cascading through the home-manager generation, alongside eleven HTTP/2 substituter failures. That derivation is a user dotfile unrelated to nixbot, so the failure is not evidence about this change. **No realization of this host's toplevel has happened**, and the amended task text says so.

## Gate 1 alignment

The pre-apply spec-and-feature alignment ran and is recorded as a modality verdict table in `design.md`, one row per requirement across the three delta specs. No row routes to a Gherkin scenario, so no `.feature` file is laid out: the repository has no BDD runner and no `.feature` file anywhere, and every observable this change asserts is either a property of the evaluated configuration (witnessed by `nix eval` / `nix build`) or an observation against a deployed host (witnessed by the group 10 integration verification). World-stratum requirements never route to a scenario in any case. No row is EST-routed, so no EST artifact is laid out either.

## Not claimed

This does not guarantee the incumbent is unaffected. The two services share the host's nginx, its PostgreSQL instance, its nix store and the disk under it, its ACME account, and its finite capacity; disjoint names bound the ways they can interfere without eliminating them.

It does not guarantee no unintended repository is ever built. The outermost boundary is the forge application's installation selection, which is set by hand on the forge and is not observable to the machine.
