### PR TITLE
feat(kanidm): enable online backups, align the branding cli, and bump to 1.11

### DIFF
--- a/modules/nixos/kanidm.nix
+++ b/modules/nixos/kanidm.nix
@@ -11,7 +11,7 @@
 # that LoadCredential alone failed at deploy time, and provides no rotation
 # downside since kanidm holds the TLS chain in process memory and requires restart
 # for rotation either way. Hostname is a literal FQDN; package is pinned to
-# kanidmWithSecretProvisioning_1_10.
+# kanidmWithSecretProvisioning_1_11.
 #
 # Clan-vars secret generators (admin-password, idm-admin-password, oauth2-synapse)
 # declared inline below; admin passwords are wired into
@@ -121,7 +121,7 @@ in
       };
 
       services.kanidm = {
-        package = pkgs.kanidmWithSecretProvisioning_1_10;
+        package = pkgs.kanidmWithSecretProvisioning_1_11;
 
         server.enable = true;
 
@@ -146,12 +146,10 @@ in
           tls_chain = "${certs.directory}/fullchain.pem";
           tls_key = "${certs.directory}/key.pem";
 
-          # nixpkgs already emits path and schedule, but defaults versions to 0,
-          # which the module treats as "backups disabled".
+          # nixpkgs emits path and schedule, but defaults versions to 0, which the
+          # module treats as "backups disabled" (nixos/modules/services/security/
+          # kanidm.nix: enableServerBackup gates on versions != 0).
           online_backup.versions = 7;
-
-          # Temporary until the first backup lands; reverted by the 1.11 bump.
-          online_backup.schedule = "00 * * * *";
         };
 
         provision = {

--- a/modules/nixos/kanidm.nix
+++ b/modules/nixos/kanidm.nix
@@ -145,6 +145,13 @@ in
           # matches clan-infra/web02 and jfly-clan-snow/fflewddur.
           tls_chain = "${certs.directory}/fullchain.pem";
           tls_key = "${certs.directory}/key.pem";
+
+          # nixpkgs already emits path and schedule, but defaults versions to 0,
+          # which the module treats as "backups disabled".
+          online_backup.versions = 7;
+
+          # Temporary until the first backup lands; reverted by the 1.11 bump.
+          online_backup.schedule = "00 * * * *";
         };
 
         provision = {
@@ -234,7 +241,9 @@ in
         wants = [ "kanidm.service" ];
         wantedBy = [ "multi-user.target" ];
         path = [
-          pkgs.kanidmWithSecretProvisioning_1_10
+          # Upstream requires the CLI to match the server minor exactly, so this
+          # derives from the server package rather than pinning independently.
+          config.services.kanidm.package
           pkgs.curl
         ];
         environment = {


### PR DESCRIPTION
Enables kanidm's online backups on magnetite, ties the branding unit's CLI to the server package it talks to, and bumps the server from 1.10 to 1.11.

The first two changes are already running on the host; the third is not yet deployed.
Backups are live and producing files, so the upgrade lands on top of a working backup rather than ahead of one.

## Why `versions` has to be set explicitly

nixpkgs emits `online_backup.path` and `online_backup.schedule` on its own, which makes the feature look configured from the NixOS side.
It leaves `versions` at `0`, and the module gates the whole feature on that being nonzero — `enableServerBackup = cfg.server.enable && (cfg.server.settings.online_backup.versions != 0)` at `nixos/modules/services/security/kanidm.nix:65`.
With `versions` at its default, the emitted path and schedule were inert and no backup directory was even created.
Setting `versions = 7` is what turns the feature on; there is no separate enable flag.

Backups are now landing: seven files in `/var/lib/kanidm/backups`, roughly 45 KB each, retention holding at seven as declared.

## The hourly schedule, and why reverting it belongs here

Reaching a retained backup on the nixpkgs default schedule — once daily at 22:00 UTC — would have meant waiting until the next 22:00 boundary before the assertion "backups work" was backed by anything.
An hourly override collapsed that to under an hour, so the first retained backup was evidence rather than expectation.

Retention is a count of files, not a duration, so that override had a real cost: hourly writes against `versions = 7` give a seven-*hour* window.
Reverting it now, with `versions` unchanged, **lengthens** on-host retention from roughly seven hours to roughly a week.
That is the operationally important part, and it is why the revert belongs in the same change as the upgrade rather than after it: the pre-upgrade backups already on disk survive for days instead of being pruned within hours of the migration.

The override is deleted rather than replaced with an explicit `"00 22 * * *"`.
The nixpkgs module declares `schedule` with an `mkOption` default (`kanidm.nix:375`), so deleting the override leaves nixpkgs authoritative; restating the value locally would freeze a copy of today's default and silently diverge if upstream ever changed it.

## Why the branding CLI derives from the server package

`systemd.services.kanidm-site-branding` named `pkgs.kanidmWithSecretProvisioning_1_10` directly, duplicating the pin in `services.kanidm.package`.
Upstream requires the `kanidm` CLI to match the server's minor version exactly, so two independent references to one version are a latent skew — bumping the server alone would leave the branding unit driving a 1.10 client against a 1.11 server.
Deriving from `config.services.kanidm.package` makes that skew unrepresentable, and it is what let the bump in this same pull request be a one-line edit that carries the client along with it.

## The 1.11 bump

kanidm 1.10 reaches end-of-life on 2026-08-31, and the pinned nixpkgs already carries `kanidmWithSecretProvisioning_1_11` at 1.11.0.

The documented pre-upgrade check passes on the live instance:

```
$ kanidmd domain upgrade-check
domain_current_level: 14
domain_upgrade_level: 15
status: PASS
```

Upstream documents the migration as running in a single transaction that makes no data changes unless it succeeds ([`server_updates.md:117-118`](https://github.com/kanidm/kanidm/blob/master/book/src/server_updates.md)).
Downgrades are not possible (`:87`), so the recovery path is restore-from-backup, not reverting this commit — which is the reason the backup work is a prerequisite and not a nicety.
A pre-upgrade backup has been copied off the host and validated: 322 entries, self-identifying as version 1.10, keyhandles present.

## Verification

Evaluated magnetite's host configuration, the narrowest check that could falsify a one-file module change; the repository exposes no kanidm- or magnetite-specific check that resolves on a non-NixOS builder.

```
{"brandingCliStore":"/nix/store/jdmskyjasykgq6zz2j500dhq6rd81c2z-kanidm-with-secret-provisioning-1.11.0",
 "serverStore":    "/nix/store/jdmskyjasykgq6zz2j500dhq6rd81c2z-kanidm-with-secret-provisioning-1.11.0",
 "resolvedSchedule":"00 22 * * *",
 "resolvedVersions":7,
 "toplevel":"/nix/store/fqn7dbzrmlczry6f31gg8czppckyjm1y-nixos-system-magnetite-...drv"}
```

`brandingCliStore` and `serverStore` are byte-identical store paths at 1.11.0.
That is demonstrated rather than assumed, because the exact-minor-match requirement is the entire reason the branding change exists.
The 1.10 end-of-life warning that nixpkgs emitted during evaluation before the bump is now absent.

The resolved schedule is confirmed from the generated artifact rather than the module source — building `environment.etc."kanidm/server.toml"` yields:

```toml
[online_backup]
path = "/var/lib/kanidm/backups"
schedule = "00 22 * * *"
versions = 7
```

Also built the two structural checks covering the host set, `structure-nixos-configurations` and `machine-registry-completeness`; both pass. `nix fmt --ci` reports the edited file unchanged.

Deliberately not run: the full check set, and any realizing build of the magnetite system closure.
The diff touches one NixOS module consumed by one host, so a repository-wide run would take far longer while testing nothing the evaluation above does not already settle.
The migration itself cannot be verified before deployment by construction; that is what the validated off-host backup covers.
