### PR TITLE
feat(nixbot): admit sciexp/ironstar without effects secrets

### DIFF
--- a/modules/checks/nixbot-vanixiets.nix
+++ b/modules/checks/nixbot-vanixiets.nix
@@ -47,7 +47,7 @@
       # the topic first and then the allowlists; only the allowlist stage is
       # modelled here, because a forge topic is not visible to evaluation.
       # Both repositories below carry the topic, so the allowlist stage is
-      # what decides between them.
+      # what each service's selection reduces to.
       owner = fullName: builtins.head (lib.splitString "/" fullName);
 
       # buildbot_nix/buildbot_nix/common.py:138-148, with full_name as the
@@ -86,8 +86,9 @@
             oneSecretsFileForBothServices =
               nixbot.effects.perRepoSecretFiles.${repoKey} == buildbot.effects.perRepoSecretFiles.${repoKey};
 
-            # The cut itself: each service admits exactly one of the two
-            # repositories carrying the build topic.
+            # The cut itself. buildbot stays authoritative for ironstar while
+            # nixbot also admits it, so the two selections overlap there and
+            # differ on vanixiets.
             buildbotAdmitsVanixiets = buildbotAdmits "cameronraysmith/vanixiets";
             buildbotAdmitsIronstar = buildbotAdmits "sciexp/ironstar";
             nixbotAdmitsVanixiets = nixbotAdmits "cameronraysmith/vanixiets";
@@ -110,8 +111,9 @@
             extraNixOptions = sortedNames nixbot.effects.extraNixOptions;
           };
           expected = {
-            # ironstar stays on buildbot-nix, so its secrets file is wired
-            # only there and nixbot never loads a credential for it.
+            # ironstar's secrets file is wired only to buildbot's convention,
+            # so nixbot loads no credential for it: admitted for evaluation,
+            # building and caching, with its effects failing closed.
             effectsCredentialNames = [
               "effects-secret__github_colon_cameronraysmith_slash_vanixiets"
             ];
@@ -124,10 +126,13 @@
             buildbotAdmitsVanixiets = false;
             buildbotAdmitsIronstar = true;
             nixbotAdmitsVanixiets = true;
-            nixbotAdmitsIronstar = false;
+            nixbotAdmitsIronstar = true;
             buildbotUserAllowlist = null;
             buildbotRepoAllowlist = [ "sciexp/ironstar" ];
-            nixbotRepoAllowlist = [ "cameronraysmith/vanixiets" ];
+            nixbotRepoAllowlist = [
+              "cameronraysmith/vanixiets"
+              "sciexp/ironstar"
+            ];
             postBuildStepNames = [ "Upload to niks3" ];
             niks3ServerUrl = "https://niks3.scientistexperience.net";
             extraSandboxPaths = [ ];

--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -105,10 +105,17 @@
           # repositories carry, and it one-shot-imports against an empty DB.
           topic = null;
 
-          # nixbot serves only the repositories named here; the empty list
-          # this replaces admitted none. The entry is the forge-local name,
-          # without the "github:" prefix that perRepoSecretFiles keys carry.
-          repoAllowlist = [ "cameronraysmith/vanixiets" ];
+          # nixbot serves only the repositories named here. ironstar is
+          # admitted for evaluation, building and caching only: its effects
+          # secrets stay wired to buildbot's convention (see
+          # modules/effects/ironstar/secrets.nix), so nixbot loads no
+          # credential for it and every ironstar effect stops at its own
+          # missing-secret guard. Entries are forge-local names, without the
+          # "github:" prefix that perRepoSecretFiles keys carry.
+          repoAllowlist = [
+            "cameronraysmith/vanixiets"
+            "sciexp/ironstar"
+          ];
         };
 
         # The module creates the vhost proxying to /run/nixbot/web.sock and this


### PR DESCRIPTION
Admits `sciexp/ironstar` to nixbot for evaluation, building and caching, while its release effects stay non-functional by design.

## What changes

`modules/nixos/nixbot.nix` adds `"sciexp/ironstar"` to `github.repoAllowlist`, which controls what nixbot imports and can see. An imported repository arrives disabled and needs an operator toggle in the web interface before it builds, so merging this starts no build.

`modules/checks/nixbot-vanixiets.nix` pins the new selection. `nixbotAdmitsIronstar` becomes `true` and `nixbotRepoAllowlist` carries both entries; every pre-existing assertion is kept. The check name is unchanged, because it still guards nixbot's vanixiets wiring together with both services' repository selections, and renaming it would churn references without removing a misreading.

## The omission is deliberate

`modules/effects/ironstar/secrets.nix` is left in buildbot's secrets convention and is not wired to nixbot's. That is the point of this stage rather than an oversight. nixbot loads no `effects-secret__` credential for ironstar, so every ironstar effect stops at its own missing-secret guard: nixbot's effects for the repository fail closed. ironstar's `deploy-sites` effect publishes production sites, so without that property admitting ironstar would fire a real production deploy on first contact.

The check enforces it: `effectsCredentialNames` remains vanixiets-only, so a future edit cannot wire ironstar's secrets into nixbot silently.

buildbot keeps `"sciexp/ironstar"` in its own `repoAllowlist` and remains authoritative for the repository throughout this stage. Wiring the effects secrets to nixbot and removing ironstar from buildbot are a deliberate second stage, not follow-up cleanup.

## Verification

Evaluated against magnetite's host configuration, so the allowlists below are resolved output rather than source text:

```
$ nix eval .#nixosConfigurations.magnetite.config.services.nixbot.github.repoAllowlist
[ "cameronraysmith/vanixiets" "sciexp/ironstar" ]

$ nix eval --json .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.github.repoAllowlist
["sciexp/ironstar"]

$ nix eval --json .#nixosConfigurations.magnetite.config.services.buildbot-nix.master.github.userAllowlist
null

$ nix eval --json .#nixosConfigurations.magnetite.config.systemd.services.nixbot.serviceConfig.LoadCredential \
    --apply 'l: builtins.filter (s: builtins.match "effects-secret__.*" s != null) l'
["effects-secret__github_colon_cameronraysmith_slash_vanixiets:/run/secrets/vars/per-machine/magnetite/vanixiets-effects-secrets/secrets"]
```

buildbot's `userAllowlist` stays `null`: its two allowlists are OR'd rather than intersected, so an owner list would readmit vanixiets regardless of the repository list.

`nix build .#checks.x86_64-linux.nixbot-vanixiets-wiring` passes. That is the only check reading either service's allowlist or nixbot's effects credentials, so it is the narrowest selection that would still fail if this change were wrong; a wider run would not exercise this diff and was deliberately left out.
