### PR TITLE
fix(bootstrap): enable flakes and support hosts without systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,21 +97,49 @@ bootstrap: install-nix install-direnv
 # NixOS/nix-installer removed the 3.x tags (repo renamed from experimental-nix-installer).
 # https://github.com/NixOS/nix-installer/releases
 #
-# The nix-installer 2.34.6 defaults include settings equivalent to:
-#   --extra-conf "experimental-features = nix-command flakes"
-#   --extra-conf "auto-optimise-store = true"
-#   --extra-conf "always-allow-substitutes = true"
-#   --extra-conf "max-jobs = auto"
-#   --extra-conf "extra-nix-path = nixpkgs=flake:nixpkgs"
-#   --extra-conf "bash-prompt-prefix = (nix:\$name)\\040"
+# nix-installer 2.34.6 writes /etc/nix/nix.conf in setup_standard_config
+# (src/action/common/place_nix_configuration.rs:98-154). Its defaults are
+# extra-experimental-features = nix-command, auto-optimise-store = true (Linux
+# only), always-allow-substitutes = true, max-jobs = auto, and
+# bash-prompt-prefix. flakes is not among them: place_nix_configuration.rs:105-112
+# appends flakes, and :126-131 adds extra-nix-path, only when --enable-flakes is
+# passed (src/settings.rs:193-204, present since tag 2.34.4). The only other way
+# to get flakes is an interactive prompt that --no-confirm suppresses
+# (src/cli/subcommand/install/mod.rs:119-137), so a non-interactive install
+# without the flag lands nix-command alone. Releases through 2.33.0 wrote
+# nix-command flakes unconditionally, which is why the flag is needed at this pin
+# and was not needed at the previous one.
 #
-# We add trusted-users to allow flake-specified substituters and public keys:
-#   --extra-conf "trusted-users = root @admin @wheel"
-# This enables accepting flake nixConfig without prompts or warnings.
+# flakes is not optional here: install-direnv resolves nixpkgs#direnv and
+# 'make verify' runs 'nix flake --help'.
 #
-# If using the upstream nix installer (https://nixos.org/download/) which lacks
-# these defaults, add the --extra-conf flags above to the install command.
+# nix-command and flakes is also the set every host declares
+# (modules/system/nix-settings.nix:9-12 for NixOS, modules/darwin/base.nix:17-20
+# for darwin), so bootstrap and the fleet agree. auto-allocate-uids, which
+# modules/darwin/nix-settings.nix:55-59 merges into the darwin set, is
+# deliberately omitted. The experimental feature only makes Nix accept the
+# setting of the same name, and the setting is true nowhere in this repo except
+# magnetite (modules/machines/nixos/magnetite/default.nix:76-83), which pairs it
+# with extra-system-features = uid-range for systemd-nspawn tests. Enabling the
+# feature alone changes no build behaviour, and the daemonless mode below has no
+# daemon to allocate UIDs at all. Bootstrap's nix.conf is transient regardless:
+# the first 'just activate' regenerates it from the host's own modules.
+#
+# trusted-users lets nix accept flake-specified substituters and public keys
+# without prompts or warnings.
 NIX_INSTALLER_VERSION := 2.34.6
+
+# A usable systemd runtime is detected by the single existence test that
+# /run/systemd/system is present if and only if the machine booted under systemd
+# (sd_booted(3)). nix-installer makes the same one test in check_systemd_active
+# (src/planner/linux.rs:244-254) and names --init none in its own failure text.
+# Overridable so both branches of the check can be expanded on a host that does
+# not match.
+#
+# The resulting $$PLANNER_ARGS is expanded unquoted on purpose: it must become
+# either three words or no word at all, and quoting it would pass an empty
+# argument to the installer on every systemd host.
+SYSTEMD_RUNTIME_DIR ?= /run/systemd/system
 install-nix: ## Install Nix using the NixOS community installer
 	@echo "Installing Nix..."
 	@if command -v nix >/dev/null 2>&1; then \
@@ -123,6 +151,23 @@ install-nix: ## Install Nix using the NixOS community installer
 			Darwin-arm64)  PLATFORM="aarch64-darwin" ;; \
 			*) echo "Unsupported platform: $$(uname -s)-$$(uname -m)"; exit 1 ;; \
 		esac; \
+		PLANNER_ARGS=""; \
+		case "$$PLATFORM" in \
+			*-linux) \
+				if [ ! -d "$(SYSTEMD_RUNTIME_DIR)" ]; then \
+					if [ "$$(id -u)" -ne 0 ]; then \
+						echo "Cannot install Nix: no systemd runtime at $(SYSTEMD_RUNTIME_DIR), and this process is uid $$(id -u) rather than root."; \
+						echo ""; \
+						echo "Without systemd the only mode this installer supports is 'install linux --init none', which creates a system-wide /nix and the build users but no daemon, leaving the store writable only by root. Running it as a non-root user does not fail early: nix-installer re-executes itself under sudo, and the Nix it leaves behind is unusable by uid $$(id -u)."; \
+						echo ""; \
+						echo "A true single-user installation - /nix owned by the invoking user, no build users, no daemon - is not implemented by this Makefile. Re-run as root, or install Nix manually:"; \
+						echo "  https://nix.dev/manual/nix/stable/installation/installing-binary"; \
+						exit 1; \
+					fi; \
+					echo "No systemd runtime at $(SYSTEMD_RUNTIME_DIR); installing root-only Nix with no daemon."; \
+					PLANNER_ARGS="linux --init none"; \
+				fi ;; \
+		esac; \
 		INSTALLER_URL="https://github.com/NixOS/nix-installer/releases/download/$(NIX_INSTALLER_VERSION)/nix-installer-$$PLATFORM"; \
 		echo "Platform: $$PLATFORM"; \
 		echo "Downloading from: $$INSTALLER_URL"; \
@@ -132,7 +177,8 @@ install-nix: ## Install Nix using the NixOS community installer
 			echo "Attempt $$attempt of $$max_attempts..."; \
 			if curl --proto '=https' --tlsv1.2 -sSf -L --retry 3 --retry-delay 5 \
 				"$$INSTALLER_URL" -o /tmp/nix-installer && chmod +x /tmp/nix-installer; then \
-				/tmp/nix-installer install --no-confirm \
+				/tmp/nix-installer install $$PLANNER_ARGS --no-confirm \
+					--enable-flakes \
 					--extra-conf "trusted-users = root @admin @wheel" && break; \
 			fi; \
 			attempt=$$((attempt + 1)); \


### PR DESCRIPTION
## Summary

`make bootstrap` is the first command a new contributor runs, and it currently
produces a Nix that the rest of the repository cannot use. This fixes that and
adds support for Linux hosts that have no systemd runtime.

Two separate defects, both in `install-nix`.

### Flakes are not enabled

`nix-installer` releases through 2.33.0 wrote `experimental-features =
nix-command flakes` into `/etc/nix/nix.conf` unconditionally. 2.34.4 changed
that: `flakes` now requires an explicit `--enable-flakes`, which defaults to
false (`src/settings.rs:193-204`), and the only other route is an interactive
prompt that `--no-confirm` suppresses
(`src/cli/subcommand/install/mod.rs:119-137`). The recipe passes `--no-confirm`
and no flag, so since the pin moved to 2.34.6 a fresh install has landed
`nix-command` alone.

Everything downstream of bootstrap needs flakes. `install-direnv` resolves
`nixpkgs#direnv` (`Makefile:156`), and `make verify` probes `nix flake --help`
(`Makefile:184-187`). Both fail on a genuinely fresh host. This has gone
unnoticed because the CD job that runs `make bootstrap` end to end is
dispatch-only and last ran against the 2.33.0 pin.

The comment block that asserted those defaults was accurate when written: it
described `experimental-nix-installer` 3.11.3. The commit that moved the pin to
2.34.6 rewrote the version in the block's first line and left the six-line body
describing a different installer's behaviour. It is replaced with what 2.34.6
actually does, cited to `place_nix_configuration.rs`, so the next reader is not
misled the same way.

### No usable install on Linux without systemd

In an ephemeral or containerized environment where PID 1 is not systemd, the
current recipe cannot produce a working install. It names no planner, so the
Linux planner runs with `init = Systemd`, and that arm requires `systemctl`
unconditionally at plan time (`configure_init_service.rs:127-139`) and shells
out to `systemctl is-active` during execute. There is no daemon to talk to
afterwards either.

`nix-installer` supports a daemonless mode for exactly this case, and its own
failure text for a missing systemd runtime recommends it. `install linux --init
none` leaves `InitSystem::None` arms that are empty in both plan and execute
(`configure_init_service.rs:141-143`, `:454-456`), while still creating the
store, the build group and the build users (`planner/linux.rs:75-81`). The
result is therefore a multi-user store layout with no daemon — writable only by
root, not a single-user install.

Because it is root-only, a non-root caller is refused. This matters: the
installer would not fail early on its own. `ensure_root()` re-executes it under
`sudo` (`src/cli/mod.rs:133-192`), so a non-root invocation would appear to
succeed and leave behind a Nix that the invoking user cannot use. A refusal
naming the missing piece is better than that. The message says plainly that a
true single-user installation is not implemented here and points at the upstream
manual, rather than implying a path that works.

Detection is one capability probe, not a list of container or platform
heuristics: `/run/systemd/system` exists if and only if the machine booted under
systemd, which is the `sd_booted(3)` convention and the same single test
`nix-installer` makes in `check_systemd_active` (`planner/linux.rs:244-254`).
It is exposed as `SYSTEMD_RUNTIME_DIR` so both branches can be exercised on a
host that does not match.

macOS and ordinary systemd Linux hosts take exactly the path they took before,
plus `--enable-flakes`. No init system is introduced. `install-direnv` is
unchanged and still runs after Nix, including in daemonless mode: the profile
script it sources is placed by `ConfigureNix`, which the Linux planner emits
unconditionally regardless of `init` (`planner/linux.rs:78-85`,
`configure_shell_profile.rs:11`), and as root the store is directly writable, so
`nix profile install` needs no daemon.

### experimental-features

Bootstrap previously inherited whatever the installer defaulted to, while every
configured host declares a deliberate set. Bootstrap now sets `nix-command
flakes`, which is the set every host in the fleet declares
(`modules/system/nix-settings.nix:9-12` for NixOS,
`modules/darwin/base.nix:17-20` for darwin) and the only set common to all of
them.

`auto-allocate-uids`, which `modules/darwin/nix-settings.nix:55-59` merges into
the darwin set, is deliberately omitted, and the reasoning is worth recording
because copying it would look like consistency. The experimental feature only
makes Nix *accept* the setting of the same name; it changes no build behaviour
by itself. The setting is true nowhere in this repository except magnetite
(`modules/machines/nixos/magnetite/default.nix:76-83`), where it is paired with
`extra-system-features = uid-range` for systemd-nspawn tests. On all four darwin
hosts the feature is enabled without the setting and is therefore already inert.
In a daemonless install there is no daemon to allocate UIDs at all, so setting
it there would advertise a capability the runtime cannot honour. It is omitted
with a comment saying why.

This divergence is bounded in time regardless: whatever bootstrap writes into
`/etc/nix/nix.conf` is transient, because the first `just activate` regenerates
that file from the host's own modules.

## Verification, and what it does not cover

Proven by execution:

- The `PLANNER_ARGS` decision fragment was extracted verbatim from the recipe
  and executed across four conditions — darwin, Linux with a systemd runtime,
  Linux without one as root, and Linux without one as non-root. Both branches
  are reachable, the two unchanged paths emit the same command line as before
  (plus `--enable-flakes`), the daemonless path emits `install linux --init none
  --no-confirm --enable-flakes --extra-conf "trusted-users = ..."`, and the
  non-root refusal prints its message and exits 1.
- `make -n install-nix` expands the recipe and shows the emitted command lines;
  `make -n bootstrap` confirms the Makefile still parses.
- `shellcheck` on the fully expanded recipe reports nothing at warning severity.
  At style severity it reports one finding, `SC2086` on `$PLANNER_ARGS`, where
  word splitting is the mechanism — quoting it would pass an empty argument to
  the installer on every systemd host. A comment records that so it is not
  "fixed" into a break.
- `prek` passes. Its only hooks are gitleaks and treefmt.

Established by reading the installer source at tag `2.34.6`, not by execution:
every claim above about flag existence, flag semantics, default `nix.conf`
contents, and which actions each `init` value emits. This work was done on
`aarch64-darwin`, so the Linux daemonless path cannot be executed here and no
installer was run.

Test selection: nothing in the flake reads the `Makefile`. `treefmt` runs
`nixfmt` only (`modules/formatting.nix:13`), no check references the file, and
there is no `shellcheck`, `checkmake`, or `.editorconfig` coverage of it. The
flake check suite was therefore not run, since it could not fail on this change;
the recipe's own behaviour is the subject, and the checks above are what could
falsify it. The one gate that does execute this code end to end is the
dispatch-only CD `bootstrap-verification` job, which requires a Linux runner.

## Findings not addressed here

- There is no automated coverage of the `Makefile` at all, so a syntactically
  broken or semantically wrong bootstrap recipe ships silently until someone
  dispatches the CD job by hand. That is how the flakes regression survived a
  pin bump.
- A true single-user installation path — `/nix` owned by the invoking user, no
  build users, no daemon — does not exist. The new error message points at the
  upstream manual instead.
- `packages/docs/src/content/docs/guides/getting-started.md:52` says bootstrap
  disables `auto-optimise-store` to prevent Darwin corruption. The installer
  does not write that setting on macOS at all and sets it true on Linux
  (`place_nix_configuration.rs:115-116`), so the description is inaccurate
  independently of this change. Line 51 of the same list claims flakes are
  enabled, which this change makes true again.
- The fleet's two base feature sets disagree: darwin base carries
  `auto-allocate-uids`, NixOS base does not, and `modules/darwin/base.nix:17-20`
  is a redundant subset of `modules/darwin/nix-settings.nix:55-59`.
