### PR TITLE
perf(nixbot): raise eval workers to 6 to shorten the serial eval chain

### DIFF
--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -1,4 +1,6 @@
-# nixbot CI service for magnetite, standing beside the buildbot-nix server.
+# nixbot CI service for magnetite, serving the fleet's GitHub repositories.
+# The buildbot-nix server is still resident on magnetite but no longer serves
+# either of them; it keeps only its Gitea repositories.
 #
 # Credential generator catalog (slots; values populated as marked):
 #   - nixbot-github-app-secret-key: manual `clan vars set` (GitHub App PEM key)
@@ -82,10 +84,30 @@
 
         buildSystems = [ "x86_64-linux" ];
 
-        # Sized beside the incumbent's 4 workers x 2 GiB (buildbot.nix:150-154)
-        # on a 16 vCPU / 32 GiB host: 2 x 2 GiB here keeps the pair inside the
-        # same headroom the incumbent's comment budgets for.
-        evalWorkerCount = 2;
+        # 6 evaluation workers on magnetite, below both nixbot's own 16-core
+        # auto-sizing heuristic of 8 and the 20 used by clan-infra, the upstream
+        # reference deployment, because the memory cap has to stay enforceable.
+        # nixbot evaluates inside a cgroup capped at evalMaxMemorySize x
+        # (workers + 1), and exceeding that cap fails the pull request
+        # permanently with no retry, unlike an attribute build. A cap above the
+        # memory magnetite can supply cannot fire before magnetite itself is
+        # exhausted, so the count is bounded by arithmetic rather than by its 16
+        # cores: at the 2048 MiB per worker chosen just below, 6 caps the
+        # evaluation tree at 14 GiB, where 8 would imply 18 GiB and 20 would
+        # imply 43 GiB. magnetite has 30.6 GiB of RAM, and 17 GiB of it were
+        # free when nixbot was deployed there in August 2026, measured with
+        # kanidm, postgres, nginx and buildbot-nix already resident. To revise
+        # the count, read MemAvailable from /proc/meminfo on magnetite under
+        # that same resident set and keep evalMaxMemorySize x (workers + 1)
+        # below it.
+        #
+        # evalWorkerCount is nix-eval-jobs' --workers, so it shortens a single
+        # evaluation instead of overlapping several. Overlapping would need
+        # nixbot's eval_concurrency setting, which nixbot's NixOS module does
+        # not expose, so evaluations stay serial across pull requests and each
+        # one's latency adds to the total. The measurements behind 6 are in
+        # cameronraysmith/vanixiets PR 2869.
+        evalWorkerCount = 6;
         evalMaxMemorySize = 2048;
 
         github = {


### PR DESCRIPTION
Raises `services.nixbot.evalWorkerCount` on magnetite from 2 to 6, leaving `evalMaxMemorySize` at 2048 MiB. The only other change in the diff is prose: the comment recording why 6, and a stale file header that claimed nixbot stands beside the buildbot-nix server when buildbot-nix's GitHub `repoAllowlist` is empty and it now serves only Gitea repositories.

## Where the three hours went

A 26-PR flake-update flood arrived on 2026-08-28 as a five-minute burst (PRs 2842-2867 created 22:19:56-22:25:00) and took until 02:03:25 to clear: 3.72 h. Measured from nixbot's own API over builds 11-36:

| quantity | value |
| --- | --- |
| builds in the flood | 26, created within a 5 min burst |
| flood span | 223.5 min (3.72 h) |
| evaluation share of each steady build's wall clock | 91.6% (4.74 min of 5.18 min) |
| evaluation share of the whole flood span | 84.0% |
| mean build-only tail after evaluation ends | 26 s |
| concurrency | 1 |

Builds did not overlap. Each build's `started_at` landed a median of 3.7 s after its predecessor's *evaluation* ended, while that predecessor went on building for a further 26 s on average. The queue therefore drained at one evaluation at a time, and the release point was evaluation end rather than build end. Queue wait grew linearly across the burst, from 0 min for the first PR to 213.6 min for the last.

Building was never the constraint. In a typical flood build, 97 of 115 attributes were already cached and the 18 that ran took 2-26 s each and overlapped freely.

## Why evaluation serialises, and which dial actually exists

nixbot guards evaluation with a global semaphore sized by `eval_concurrency` (default 1), held across an entire evaluation. Its NixOS module writes only `eval_max_memory_size`, `eval_worker_count` and `build_concurrency` into the service config, and the config model rejects unknown keys, so `eval_concurrency` cannot be raised from a NixOS deployment at all. Cross-PR evaluation is fixed at one.

That makes per-PR evaluation *latency* the only available lever, and it is a real one precisely because the chain is serial: total flood time is the sum of the individual evaluation latencies, so shortening each one shortens the whole flood proportionally.

`evalWorkerCount` is nix-eval-jobs' `--workers`. It parallelises attributes *within* one evaluation rather than overlapping several evaluations. With 2 workers that pool is small enough for one expensive attribute to block the whole stream: in 19 of 19 steady builds, attribute emission stalled for ~80 s twice, after `checks.x86_64-linux.home-configurations-exposed` (mean 83.2 s) and after `checks.x86_64-linux.nixidy-env-local-k3d` (mean 79.5 s). Those two stalls are 163 s of a 284 s evaluation, 57%. A stall means every worker was occupied and none finished, so at 2 workers a single costly attribute consumes half the pool.

## Why 6

From the measured emission timeline: a serial flake-evaluation prologue of 18.9 s, then 531 worker-seconds of evaluation work, against a critical path of at least 83 s that belongs to one attribute and cannot be split.

| workers | work / workers | projected evaluation | limited by |
| --- | --- | --- | --- |
| 2 (today) | 266 s | 285 s (matches the measured 284.5 s) | work |
| 4 | 133 s | 152 s | work |
| 6 | 89 s | ~107 s | work, just above the floor |
| 8 | 66 s | ~102 s | the single-attribute critical path |
| 16 | 33 s | ~102 s | the single-attribute critical path |
| 20 | 27 s | ~102 s | the single-attribute critical path |

Past roughly 6 workers the aggregate throughput has already caught up with the one attribute that cannot be parallelised, so additional workers buy latency this flake's shape cannot yield. 6 and 8 differ by 5-8%, inside the model's error, while 8, 16 and 20 are indistinguishable from each other.

Projected effect: steady evaluation ~4.74 min to ~1.8 min, steady build wall clock ~5.18 min to ~2.3 min, and a flood of this size from 3.72 h to roughly 2.8 h. The residual is the serial chain itself, which no setting reachable from here can remove.

## The memory tradeoff, and why the cap matters

Evaluation runs inside a kernel-enforced cgroup whose limit is `evalMaxMemorySize x (workers + 1)`, the `+1` being headroom above the per-worker limits. Two different mechanisms are in play and only one of them is recoverable:

- The per-worker `--max-memory-size` is benign. When a worker exceeds it, nix-eval-jobs recycles that worker and evaluation continues.
- The cgroup limit is not benign. Exceeding it kills the evaluation, and nixbot classifies an evaluation OOM as a *permanent* failure: unlike attribute builds, which get one automatic retry on transient errors, an evaluation OOM is never retried. The pull request just fails and stays failed until someone pushes again.

So worker count is not a free throughput dial. It is also a multiplier on the memory ceiling, and the ceiling only protects the host while it sits *below* the memory the host can actually supply. A limit above available memory is not a backstop: the host exhausts itself and the OOM killer picks a victim before the cgroup ever fires.

magnetite is a Hetzner CX53 with 16 logical cores and 30.6 GiB of RAM (per its nixos-facter report), running kanidm, a shared postgres, nginx, gitea with two podman-backed actions runners, the matrix stack including livekit and coturn, docker, omnigraph, niks3, and buildbot-nix. At nixbot's deployment the recorded baseline was 12 GiB in use with 17 GiB available. Against that:

| workers | cgroup cap | vs 17 GiB available |
| --- | --- | --- |
| 2 (today) | 6.0 GiB | 11.0 GiB spare |
| **6 (this change)** | **14.0 GiB** | **3.0 GiB spare, cap is enforceable** |
| 8 | 18.0 GiB | above available; cap cannot fire first |
| 20 (clan-infra's value) | 43.0 GiB | above physical memory; effectively uncapped |

6 is the largest worker count whose cap still sits inside the memory magnetite actually has, which is what keeps the cap meaningful rather than decorative. 8 would put the ceiling at or above available memory and reintroduce, in milder form, exactly the unbounded-evaluation risk that makes clan-infra's 20 unsuitable here.

This is also what keeps the change safe while buildbot-nix is still resident. buildbot-nix budgets 4 workers x 2 GiB for its own evaluations; 14 GiB alongside that is 22 GiB of evaluation ceilings against 30.6 GiB of physical memory, so the two pools coexist without over-committing. At 8 workers, nixbot's ceiling alone plus the 12 GiB baseline would consume the whole machine. Residual risk, stated rather than hidden: a nixbot flood evaluating concurrently with a buildbot-nix Gitea evaluation could still exceed physical memory, mitigated by buildbot-nix no longer serving either GitHub repository and by zram swap at 100% of RAM.

`evalMaxMemorySize` is deliberately untouched. The per-worker limit was not implicated: across all 26 flood builds there was no evaluation OOM.

## Verification

Verified by evaluation rather than build, because the target is x86_64-linux and the operator host is aarch64-darwin:

- `nix eval --json .#nixosConfigurations.magnetite.config.services.nixbot.evalWorkerCount` prints `6`, and `.evalMaxMemorySize` prints `2048`. This proves the values reach the machine configuration, not merely that the file parses.
- `nix eval .#checks.x86_64-linux.nixos-magnetite.drvPath` resolves to a `.drv` with exit 0, proving magnetite's whole toplevel still composes. This is the repo-sanctioned eval-only form for this machine, recorded at `openspec/changes/stand-up-nixbot-on-magnetite/tasks.md:37`.
- The prose in this diff is semantically inert, demonstrated at the service level rather than the system level: nixbot's generated configuration evaluates to the same store path, `sx8avlgx2yxy4n4cnjnbs10bylmkck09-nixbot-config.json`, both with the comment and header edits applied and with them stashed.

One trap worth recording for anyone verifying a comment-only change in this repository: the toplevel derivation path is **not** a comment-only invariant. The flake source is itself an input to the system closure, so editing any tracked file moves `checks.x86_64-linux.nixos-magnetite.drvPath` even when the edit is purely a comment. Confirmed by control, with the nixbot change stashed: appending a comment to the unrelated `modules/system/zram-swap.nix` moved the toplevel path to a third distinct value. Compare the generated service configuration instead, as above.

The full check set was deliberately not run. This change alters one service option on one machine and realises no derivation, so no other check's outcome can depend on it; `nixos-magnetite` is the only check whose evaluation covers the changed code, and its immediate caller is the machine toplevel that the second command evaluates. Deployment (`clan machines update magnetite`) is left to the operator.

## Two findings this change does not address

- **The flood's structural limit is `eval_concurrency`, not worker count.** It is consumed by nixbot but unreachable from the NixOS module, so raising cross-PR evaluation parallelism needs an upstream module change rather than a deployment setting.
- **Two check attributes dominate every evaluation.** `home-configurations-exposed` and `nixidy-env-local-k3d` account for 57% of each evaluation's wall clock. Making those cheaper to evaluate would beat any worker-count change, and would speed up every `nix flake check` in this repo, not just nixbot's.

One further datum worth recording: build 29 (PR 2860) failed with `evaluation timed out after 3600 seconds`. Its evaluation continued for 32 minutes after every one of its 82 attribute builds had finished, making no further progress, then hit nixbot's hard-coded one-hour evaluation timeout, which is also not exposed as a NixOS option. That is a second permanent, unretried failure mode driven by evaluation latency, and it is the sharpest argument that evaluation latency is worth reducing even though this change cannot remove the serial chain.
