### PR TITLE
feat: add git-backed devin environment blueprint

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,0 +1,90 @@
+# https://docs.devin.ai/onboard-devin/environment/git-backed-blueprints
+# Nix is the only host-level dependency: it is installed through the repo's own
+# pinned bootstrap, and every other tool (just, prek, treefmt, bun, jq) comes
+# from the flake devshell, entered via direnv.
+initialize: |
+  # Pinned NixOS/nix-installer, systemd daemon planner (/run/systemd/system exists here).
+  # bootstrap rather than install-nix: the sandbox image ships /usr/bin/direnv, so
+  # install-direnv is a no-op today, but it self-heals if that ever goes away.
+  make bootstrap
+
+  # Nothing here grants trust: install-nix's `--extra-conf trusted-users` covers @sudo,
+  # which is the group the sandbox user is in, and the installer writes that into
+  # nix.conf itself. `nix store info --json` reports trusted: true after bootstrap.
+  # What is left is settings the repo has no reason to carry, written to the
+  # installer's own `!include` target, which is also the pre-activation seam the darwin
+  # hosts migrate trusted-users out of. It is rewritten whole rather than appended to,
+  # so the step is idempotent if it ever re-runs over an existing /nix, where install-nix
+  # short-circuits on `command -v nix`; the only content thereby dropped is the
+  # installer's copy of trusted-users, still in force from nix.conf.
+  # auto-allocate-uids + cgroups are what systemd-nspawn-flavor NixOS tests need,
+  # matching magnetite's and the rosetta builder's nix.settings. Their uid-range is
+  # not repeated here: nix inserts it into the default system-features on every
+  # linux (nix src/libstore/globals.cc:217-239, `nix config show system-features`).
+  printf 'accept-flake-config = true\nauto-allocate-uids = true\nextra-experimental-features = auto-allocate-uids cgroups\n' | sudo tee /etc/nix/nix.custom.conf
+  sudo systemctl restart nix-daemon.service
+
+  # Agent commands run in non-interactive shells, which read neither
+  # /etc/bash.bashrc nor /etc/profile.d/nix.sh.
+  echo "BASH_ENV=/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" >> $ENVRC
+
+  # QEMU-flavor NixOS tests run as a nix build user inside the sandbox, and
+  # nix-daemon drops supplementary groups for those users, so adding anyone to the
+  # kvm group does not reach them: qemu then reports "Could not access KVM kernel
+  # module: Permission denied" and accel=kvm:tcg falls back to TCG silently, at
+  # roughly an eighth of the speed. Widening the mode is what upstream systemd's
+  # udev defaults do. Nix bind-mounts /dev/kvm into the sandbox on its own, so no
+  # extra-sandbox-paths entry is needed.
+  printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/99-kvm.rules
+  # --settle: trigger only queues the event, so without it the mode is still 0660
+  # for a moment afterwards and anything checking it here races udevd.
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --name-match=kvm --settle
+maintenance: |
+  # Realize the devshell; its shellHook writes .pre-commit-config.yaml and installs the prek hooks.
+  nix develop --accept-flake-config --command true
+  # Warm the nix-direnv cache so later `direnv exec .` invocations skip flake evaluation.
+  direnv allow
+  # `bun install` over the root workspace (packages/*), so packages/docs is covered;
+  # incremental outside CI, unlike `bun run reinstall`, which maintenance forbids.
+  # Playwright browsers come from the devshell's PLAYWRIGHT_BROWSERS_PATH, not a download.
+  direnv exec . just install
+
+  # .agents/ is gitignored, so a fresh clone carries none of the repo's skills, and
+  # the devshell shellHook only composes AGENTS.md/CLAUDE.md - apm-skills-install is
+  # what materializes .agents/skills/, which is the only place a harness discovers
+  # them. apm rewrites apm.lock.yaml's generated_at on every run, so the tracked file
+  # is put back afterwards; the snapshot is expected to start on a clean tree.
+  cp apm.lock.yaml /tmp/apm.lock.yaml.pre-install
+  direnv exec . just agents-install
+  cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml
+knowledge:
+  - name: lint
+    contents: |
+      direnv exec . just lint  # prek run --all-files: gitleaks + treefmt
+  - name: test
+    contents: |
+      direnv exec . nix build .#checks.x86_64-linux.<name> # single check; cheapest feedback loop
+      direnv exec . just check-fast        # nix-fast-build over checks.x86_64-linux; cold runs build whole machine toplevels
+      direnv exec . just check             # full nix flake check
+      # checks.x86_64-linux currently contains no NixOS-test-framework checks, so
+      # nothing here exercises kvm or nspawn yet; `just test-integration` targets
+      # vm-test-framework and vm-boot-all-machines, neither of which the flake defines.
+      direnv exec . just test-package docs # bun unit + coverage + build + e2e
+      # just test-quick is darwin-pinned (checks.aarch64-darwin.*) and cannot run here
+  - name: build
+    contents: |
+      direnv exec . just docs-build             # typst diagrams + astro site
+      direnv exec . just build-machine cinnabar # nixos hosts: cinnabar, electrum
+  - name: startup
+    contents: |
+      direnv exec . just docs-dev  # astro dev server for packages/docs
+  - name: notes
+    contents: |
+      Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.
+      x86_64-linux only: darwinConfigurations, checks.aarch64-*, and `just activate*` cannot run here.
+      No age/sops keys are provisioned, so sops, clan vars, and secret-decrypting recipes fail by design.
+      The nix store grows quickly on the sandbox disk; reclaim with `direnv exec . just gc`.
+      AGENTS.md, CLAUDE.md and .agents/skills/ are generated and gitignored: entering the
+      devshell composes the first two, `just agents-install` deploys the skills. Never edit
+      them; edit the .apm/ fragments under modules/home/ai/plugins/ and regenerate.


### PR DESCRIPTION
## Summary

Declares the Devin sandbox in `.devin/blueprint.yaml`, so it is reviewed and versioned here rather than held in Devin's settings UI. Nix stays the only host-level dependency: `initialize` runs the repo's own `make bootstrap`, and every other tool reaches the agent from the flake devshell through direnv, exactly as a human contributor gets them.

```yaml
initialize: make bootstrap; nix.custom.conf; BASH_ENV; kvm udev rule
maintenance: nix develop -c true; direnv allow; direnv exec . just install
knowledge:   lint/test/build/startup, all via `direnv exec .`
```

Three properties of the sandbox drive the steps that are not just bootstrap.

**Trust is not configured here** — it is configured in `install-nix`'s installer flags, in the stacked #2893, because "the bootstrapping user must be trusted or nix ignores the flake's substituters" is true of every debian/ubuntu host and not of this sandbox. After that fix, `nix store info --json` reports `trusted: true` here with nothing added. What remains for `/etc/nix/nix.custom.conf` is only the settings the repo itself has no reason to carry:

```
accept-flake-config = true
auto-allocate-uids = true
extra-experimental-features = auto-allocate-uids cgroups
```

That file is not a new one: it is the installer's own `!include` target, where `--extra-conf` already lands, and the pre-activation seam the darwin hosts migrate `trusted-users` out of. So this write *replaces* the installer's copy — deliberately, because a fixed body is what keeps the step idempotent when `initialize` re-runs over an existing `/nix`, where `install-nix` short-circuits on `command -v nix` and this is the only step that re-applies. The one setting so dropped is the installer's duplicate of `trusted-users`, which remains in force from `nix.conf`. `uid-range` is deliberately absent: nix inserts it into the default `system-features` on every linux (`src/libstore/globals.cc:217-239`).

**Agent commands run in non-interactive, non-login shells**, which read neither `/etc/bash.bashrc` nor `/etc/profile.d/nix.sh`, so nix is simply absent from `PATH`. `BASH_ENV` via `$ENVRC` covers every such shell without shell-init hacks.

**`/dev/kvm` cannot be reached by group membership.** It is `root:kvm`, and nix-daemon drops supplementary groups for the `nixbld*` users it builds as, so no `usermod -aG kvm` reaches a QEMU inside a build sandbox: `accel=kvm:tcg` falls back to TCG silently, at roughly an eighth of the speed. A udev rule widening the node to 0666, as upstream systemd's own defaults do, covers the session user and the build users alike. `udevadm trigger --settle`, because the bare form only queues the event — without it the node is still 0660 when `initialize` returns.

`maintenance` is incremental by construction: `nix develop -c true` realizes the devshell (whose shellHook writes `.pre-commit-config.yaml` and installs the prek hooks), `direnv allow` warms the nix-direnv cache so later `direnv exec .` skips flake evaluation, and `just install` is `bun install` over the root workspace rather than `bun run reinstall`.

`knowledge` records the verified command surface and, as importantly, what is structurally impossible here, so an agent does not spend a session discovering it: darwin and aarch64 outputs, `just activate*`, `just test-quick` (darwin-pinned), and anything needing age/sops keys. It also notes that `checks.x86_64-linux` currently contains no NixOS-test-framework checks, so nothing in it exercises kvm or nspawn yet.

Every command was run on this sandbox, and the whole file was replayed after tearing nix down with `make uninstall-nix` — i.e. verified against a clean host, not only the one it was written against.

Note on how this takes effect: the repo was added to Devin's environment before this file existed, so its blueprint is settings-managed; committing this does nothing until it is on `main` **and** synced once (Settings → Environment → Blueprints, or `POST /v3beta1/organizations/{org_id}/snapshot-setup/sync`). After that first sync the repo flips to git-backed and this file becomes the source of truth.


Link to Devin session: https://app.devin.ai/sessions/d8f060379a874a37ba13571d8f1f48a3
Open in Devin Desktop: https://app.devin.ai/desktop/session/d8f060379a874a37ba13571d8f1f48a3?variant=devin
Requested by: @cameronraysmith