### PR TITLE
fix(devin): make /dev/kvm reachable from the nix build sandbox

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -8,15 +8,27 @@ initialize: |
 
   # /etc/nix/nix.conf ends in `!include nix.custom.conf`; without a trusted session
   # user, nix silently ignores the flake's substituters and --accept-flake-config.
-  printf 'trusted-users = root %s\naccept-flake-config = true\n' "$(id -un)" | sudo tee /etc/nix/nix.custom.conf
+  # auto-allocate-uids + cgroups + uid-range are what systemd-nspawn-flavor NixOS
+  # tests need, matching magnetite's and the rosetta builder's nix.settings.
+  # uid-range is already in nix 2.35's default system-features, but nix-installer
+  # 2.34.6 predates that, so it is requested explicitly.
+  printf 'trusted-users = root %s\naccept-flake-config = true\nauto-allocate-uids = true\nextra-experimental-features = auto-allocate-uids cgroups\nextra-system-features = uid-range\n' "$(id -un)" | sudo tee /etc/nix/nix.custom.conf
   sudo systemctl restart nix-daemon.service
 
   # Agent commands run in non-interactive shells, which read neither
   # /etc/bash.bashrc nor /etc/profile.d/nix.sh.
   echo "BASH_ENV=/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" >> $ENVRC
 
-  # checks.x86_64-linux.vm-* need write access to /dev/kvm.
-  sudo usermod -aG kvm "$(id -un)"
+  # QEMU-flavor NixOS tests run as a nix build user inside the sandbox, and
+  # nix-daemon drops supplementary groups for those users, so adding anyone to the
+  # kvm group does not reach them: qemu then reports "Could not access KVM kernel
+  # module: Permission denied" and accel=kvm:tcg falls back to TCG silently, at
+  # roughly an eighth of the speed. Widening the mode is what upstream systemd's
+  # udev defaults do. Nix bind-mounts /dev/kvm into the sandbox on its own, so no
+  # extra-sandbox-paths entry is needed.
+  printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/99-kvm.rules
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --name-match=kvm
 maintenance: |
   # Realize the devshell; its shellHook writes .pre-commit-config.yaml and installs the prek hooks.
   nix develop --accept-flake-config --command true
@@ -30,8 +42,11 @@ knowledge:
   - name: test
     contents: |
       direnv exec . nix build .#checks.x86_64-linux.<name> # single check; cheapest feedback loop
-      direnv exec . just check-fast        # nix-fast-build over checks.x86_64-linux; cold runs build VM closures
-      direnv exec . just check             # full nix flake check, includes linux VM tests
+      direnv exec . just check-fast        # nix-fast-build over checks.x86_64-linux; cold runs build whole machine toplevels
+      direnv exec . just check             # full nix flake check
+      # checks.x86_64-linux currently contains no NixOS-test-framework checks, so
+      # nothing here exercises kvm or nspawn yet; `just test-integration` targets
+      # vm-test-framework and vm-boot-all-machines, neither of which the flake defines.
       direnv exec . just test-package docs # bun unit + coverage + build + e2e
       # just test-quick is darwin-pinned (checks.aarch64-darwin.*) and cannot run here
   - name: build


### PR DESCRIPTION
## Summary

Two corrections to `.devin/blueprint.yaml`, both verified on a live Devin box (Nix 2.35.2, cloud-hypervisor guest with nested `vmx`).

**`usermod -aG kvm` does not do what the comment claims.** A QEMU-flavor NixOS test runs as a nix build user inside the sandbox, and `nix-daemon` drops supplementary groups for build users — so no group membership, of the session user or of `nixbld*`, ever reaches the process that opens the device. With `/dev/kvm` at the default `0660 root:kvm`, qemu logs `Could not access KVM kernel module: Permission denied` and `accel=kvm:tcg` **falls back to TCG silently**; the same one-node test took 142.3s emulated vs 18.2s accelerated. Fixed by widening the mode via udev, which is what upstream systemd's udev defaults do:

```diff
-sudo usermod -aG kvm "$(id -un)"
+printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/99-kvm.rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger --name-match=kvm
```

The rule is re-applied by `systemd-udevd` on boot, so it survives snapshot restore (checked by `chmod 0600` + `udevadm trigger`). No `extra-sandbox-paths` entry is needed — nix bind-mounts `/dev/kvm` into the sandbox on its own; I confirmed the accelerated run still succeeds with `extra-sandbox-paths` removed and `sandbox = true`.

**nspawn-flavor tests need daemon settings the blueprint never sets**, mirroring what `magnetite` and the rosetta builder already configure in `nix.settings`:

```
auto-allocate-uids = true
extra-experimental-features = auto-allocate-uids cgroups
extra-system-features = uid-range
```

`uid-range`, `kvm` and `nixos-test` are all in Nix 2.35's *default* `system-features` (`nix config show --json`), but `NIX_INSTALLER_VERSION := 2.34.6` predates that, so `uid-range` is requested explicitly rather than assumed.

Both flavours were exercised end to end here: a `testers.runNixOSTest` node booted with `Hypervisor detected: KVM` / `Detected virtualization kvm`, and clan-core's `checks.x86_64-linux.nixos-test-container` (two `systemd-nspawn` machines, sshd + inter-container ping) passed in 1.2s.

Also corrects the `test` knowledge note, which advertised VM coverage this flake does not have: `builtins.attrNames checks.x86_64-linux` contains no NixOS-test-framework check at all, and `just test-integration` builds `vm-test-framework` and `vm-boot-all-machines`, neither of which the flake defines. So the KVM plumbing above is currently latent — it makes the box ready for such checks rather than fixing a failure you would hit today. The dead `just test-integration` recipe is left alone as out of scope for the blueprint.


Link to Devin session: https://app.devin.ai/sessions/8f79429ca8504a05a4279dd9d8ddfea6
Open in Devin Desktop: https://app.devin.ai/desktop/session/8f79429ca8504a05a4279dd9d8ddfea6?variant=devin
Requested by: @cameronraysmith