### PR TITLE
Update agent-tooling packages: five *-axi packages and no-mistakes

### DIFF
--- a/pkgs/by-name/chrome-devtools-axi/package-lock.json
+++ b/pkgs/by-name/chrome-devtools-axi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chrome-devtools-axi",
-  "version": "0.1.29",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chrome-devtools-axi",
-      "version": "0.1.29",
+      "version": "0.1.33",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.10.tgz",
-      "integrity": "sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.11.tgz",
+      "integrity": "sha512-ksACrhe4GdsIK/TfPz8P0iA8NmiRFQ43zu3/HM7NGPv7s1+xKUsupufXntedR4YxM23S2zMPJyLvn/jS/wZyBg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -472,9 +472,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -609,9 +609,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -660,9 +660,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -690,9 +690,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -776,12 +776,32 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/object-assign": {
@@ -877,9 +897,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -1132,9 +1152,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1184,9 +1204,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/pkgs/by-name/chrome-devtools-axi/package.nix
+++ b/pkgs/by-name/chrome-devtools-axi/package.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "0.1.29";
+  version = "0.1.33";
 
   # The npm registry tarball carries the built dist/ tree but no lockfile, and
   # the GitHub repo carries a pnpm-lock.yaml that buildNpmPackage cannot read.
@@ -23,7 +23,7 @@ let
     tar -xzf ${
       fetchurl {
         url = "https://registry.npmjs.org/chrome-devtools-axi/-/chrome-devtools-axi-${version}.tgz";
-        hash = "sha256-fWcBisj6b3RMkjqjRI7FAOW6xhsl6kAyz802Ts4G7xQ=";
+        hash = "sha256-q1C8ZAOI9pkhnwmxczYegbEfJx/38cV9M9cEN9jfzgU=";
       }
     } -C $out --strip-components=1
     jq 'del(.devDependencies, .scripts)' $out/package.json > $out/package.json.stripped
@@ -38,7 +38,7 @@ buildNpmPackage {
   nodejs = nodejs_22;
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-2qRZierRVAc2zC+z7CBjOldBr/YGvwGdfNZiFa3yxpo=";
+  npmDepsHash = "sha256-8TCkg9Fm5t/9hb17ormm552YaFrlOSJyOSoliAqxcLA=";
 
   makeCacheWritable = true;
 

--- a/pkgs/by-name/gh-axi/package-lock.json
+++ b/pkgs/by-name/gh-axi/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "gh-axi",
-  "version": "0.1.29",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-axi",
-      "version": "0.1.29",
+      "version": "0.1.35",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
-        "axi-sdk-js": "^0.1.8"
+        "axi-sdk-js": "^0.1.10"
       },
       "bin": {
         "gh-axi": "dist/bin/gh-axi.js"
@@ -26,9 +26,9 @@
       "license": "MIT"
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.10.tgz",
-      "integrity": "sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.11.tgz",
+      "integrity": "sha512-ksACrhe4GdsIK/TfPz8P0iA8NmiRFQ43zu3/HM7NGPv7s1+xKUsupufXntedR4YxM23S2zMPJyLvn/jS/wZyBg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"

--- a/pkgs/by-name/gh-axi/package.nix
+++ b/pkgs/by-name/gh-axi/package.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "0.1.29";
+  version = "0.1.35";
 
   # The npm registry tarball carries the built dist/ tree but no lockfile, and
   # the GitHub repo carries a pnpm-lock.yaml that buildNpmPackage cannot read.
@@ -25,7 +25,7 @@ let
     tar -xzf ${
       fetchurl {
         url = "https://registry.npmjs.org/gh-axi/-/gh-axi-${version}.tgz";
-        hash = "sha256-2GMZ59vDc4LCdWBHkRT3hKgqnJtHl4af/wGUhQikw20=";
+        hash = "sha256-9yWr5EfJkqPWzA2aYyWGcj7RzxbHlRpAvODHPgkD5q4=";
       }
     } -C $out --strip-components=1
     jq 'del(.devDependencies, .scripts)' $out/package.json > $out/package.json.stripped
@@ -40,7 +40,7 @@ buildNpmPackage {
   nodejs = nodejs_22;
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-RwgGz7V6F5+f35XqHBP6qcjGEYd4pgwA4jDTgDtL9R0=";
+  npmDepsHash = "sha256-jGlXEgdJqn80dRy89gzIi5uEygKPCEiaOkoyqVhlUQY=";
 
   makeCacheWritable = true;
 

--- a/pkgs/by-name/lavish-axi/package-lock.json
+++ b/pkgs/by-name/lavish-axi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lavish-axi",
-  "version": "0.1.46",
+  "version": "0.1.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lavish-axi",
-      "version": "0.1.46",
+      "version": "0.1.63",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/browser": "4.2.4",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.10.tgz",
-      "integrity": "sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.11.tgz",
+      "integrity": "sha512-ksACrhe4GdsIK/TfPz8P0iA8NmiRFQ43zu3/HM7NGPv7s1+xKUsupufXntedR4YxM23S2zMPJyLvn/jS/wZyBg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "5.7.16",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.7.16.tgz",
-      "integrity": "sha512-V9CJxvrWIXTDuP/0tpijjWaKaKJNYo2IrULJfTWs3/DjW9rPqswk1n8NCLQRLrTutmlG2Ech7nkJDpCnF+6Dzw==",
+      "version": "5.7.23",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.7.23.tgz",
+      "integrity": "sha512-Jp5VuhfpLz9zLGEB1VTZFTSAcUn02qMazb55RSciY7V4xQgmzYm3Af160gkQc3OnMVfDUwnQXvwu4O4MwoK1NQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/saadeghi/daisyui?sponsor=1"
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -723,12 +723,32 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/object-inspect": {
@@ -836,9 +856,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -1107,9 +1127,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/pkgs/by-name/lavish-axi/package.nix
+++ b/pkgs/by-name/lavish-axi/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.1.46";
+  version = "0.1.63";
 
   # The npm registry tarball carries the built dist/ tree but no lockfile, and
   # the GitHub repo carries a pnpm-lock.yaml that buildNpmPackage cannot read.
@@ -22,7 +22,7 @@ let
     tar -xzf ${
       fetchurl {
         url = "https://registry.npmjs.org/lavish-axi/-/lavish-axi-${version}.tgz";
-        hash = "sha256-fiklREn9XrXl+ZmzTQyHB9cYAyc3UPLI9AjdetkaP3E=";
+        hash = "sha256-5mUCYaNYxACIkH66JbAnM2eBfNLz2idJs7OdthrLeNg=";
       }
     } -C $out --strip-components=1
     jq 'del(.devDependencies, .scripts)' $out/package.json > $out/package.json.stripped
@@ -37,7 +37,7 @@ buildNpmPackage {
   nodejs = nodejs_22;
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-JU3bvfIfLcukeKwd4E7ruNpkARLDP2o5iLXditd0aOg=";
+  npmDepsHash = "sha256-upokKvtPToJjEjQb8lyxmqk0FRiq5/dhRL9c8mv2XVY=";
 
   makeCacheWritable = true;
 

--- a/pkgs/by-name/no-mistakes/package.nix
+++ b/pkgs/by-name/no-mistakes/package.nix
@@ -9,13 +9,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "no-mistakes";
-  version = "1.45.4";
+  version = "1.60.2";
 
   src = fetchFromGitHub {
     owner = "kunchenguid";
     repo = "no-mistakes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pfR60vack5oLItPfu4zDYYk76S8qhDOJP/uiudo7kVI=";
+    hash = "sha256-+aJKgoykK443BLiQQgvMgL0rbsipUrs2LHERz9KdTMY=";
   };
 
   vendorHash = "sha256-NZOYxNYvt4192uqKBdKRxdgrKFvWx3585psdCnRdPSM=";

--- a/pkgs/by-name/quota-axi/package-lock.json
+++ b/pkgs/by-name/quota-axi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quota-axi",
-  "version": "0.1.28",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quota-axi",
-      "version": "0.1.28",
+      "version": "0.1.34",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "2.1.0",
@@ -26,9 +26,9 @@
       "license": "MIT"
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.10.tgz",
-      "integrity": "sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.11.tgz",
+      "integrity": "sha512-ksACrhe4GdsIK/TfPz8P0iA8NmiRFQ43zu3/HM7NGPv7s1+xKUsupufXntedR4YxM23S2zMPJyLvn/jS/wZyBg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"

--- a/pkgs/by-name/quota-axi/package.nix
+++ b/pkgs/by-name/quota-axi/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.1.28";
+  version = "0.1.34";
 
   # The npm registry tarball carries the built dist/ tree but no lockfile, and
   # the GitHub repo carries a pnpm-lock.yaml that buildNpmPackage cannot read.
@@ -22,7 +22,7 @@ let
     tar -xzf ${
       fetchurl {
         url = "https://registry.npmjs.org/quota-axi/-/quota-axi-${version}.tgz";
-        hash = "sha256-tuSk9UW/aqCKx4nTIxO+cJCUxRcn1eDZfSyS7XeSefU=";
+        hash = "sha256-yoc4jHx1FAA3asoKQ4Lz+QK4qpnN8feXyzaz8PLAPnQ=";
       }
     } -C $out --strip-components=1
     jq 'del(.devDependencies, .scripts)' $out/package.json > $out/package.json.stripped
@@ -37,7 +37,7 @@ buildNpmPackage {
   nodejs = nodejs_22;
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-DSKvsCFr4H1ztgne1zkjh06EU2ALbclc2fR6rI55ffM=";
+  npmDepsHash = "sha256-DZMYfy3jdLGD40Cvl+o4DAtj/lDe7iU043ppJL1SUtk=";
 
   makeCacheWritable = true;
 

--- a/pkgs/by-name/tasks-axi/package-lock.json
+++ b/pkgs/by-name/tasks-axi/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "tasks-axi",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tasks-axi",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
-        "axi-sdk-js": "^0.1.7"
+        "axi-sdk-js": "^0.1.10"
       },
       "bin": {
         "tasks-axi": "dist/bin/tasks-axi.js"
@@ -26,9 +26,9 @@
       "license": "MIT"
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.10.tgz",
-      "integrity": "sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.11.tgz",
+      "integrity": "sha512-ksACrhe4GdsIK/TfPz8P0iA8NmiRFQ43zu3/HM7NGPv7s1+xKUsupufXntedR4YxM23S2zMPJyLvn/jS/wZyBg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"

--- a/pkgs/by-name/tasks-axi/package.nix
+++ b/pkgs/by-name/tasks-axi/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.2.4";
+  version = "0.2.5";
 
   # The npm registry tarball carries the built dist/ tree but no lockfile, and
   # the GitHub repo carries a pnpm-lock.yaml that buildNpmPackage cannot read.
@@ -22,7 +22,7 @@ let
     tar -xzf ${
       fetchurl {
         url = "https://registry.npmjs.org/tasks-axi/-/tasks-axi-${version}.tgz";
-        hash = "sha256-hujgVLbREGAe42U6l+P3zGxJ6tLD6V5BGie8YokRpcw=";
+        hash = "sha256-Vv2AUAYDdK5eD4CLRoiLq3TZasO5Tn/8C6FKSt7QozA=";
       }
     } -C $out --strip-components=1
     jq 'del(.devDependencies, .scripts)' $out/package.json > $out/package.json.stripped
@@ -37,7 +37,7 @@ buildNpmPackage {
   nodejs = nodejs_22;
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-Gh5u9Vcxm5ymWye2SrCrX/F8AjN0dc7CQ3GnqBKJBNw=";
+  npmDepsHash = "sha256-xwgNl86LbrDOjAgqvui1RBu09hj0KsQTk5uUvoGJrpo=";
 
   makeCacheWritable = true;
 


### PR DESCRIPTION
## Summary

Updates the six agent-tooling packages in `pkgs/by-name` that `modules/home/ai/firstmate/default.nix` installs, using each package's own update mechanism rather than hand-edited version strings.

| Package | From | To | Mechanism |
| --- | --- | --- | --- |
| `gh-axi` | 0.1.29 | 0.1.35 | `pkgs/by-name/gh-axi/update.sh` |
| `quota-axi` | 0.1.28 | 0.1.34 | `pkgs/by-name/quota-axi/update.sh` |
| `tasks-axi` | 0.2.4 | 0.2.5 | `pkgs/by-name/tasks-axi/update.sh` |
| `lavish-axi` | 0.1.46 | 0.1.63 | `pkgs/by-name/lavish-axi/update.sh` |
| `chrome-devtools-axi` | 0.1.29 | 0.1.33 | `pkgs/by-name/chrome-devtools-axi/update.sh` |
| `no-mistakes` | 1.45.4 | 1.60.2 | `nix-update --flake --use-github-releases --build no-mistakes` |

No package in the set was already current, so nothing is reported as unchanged.

## Mechanism

The five `*-axi` packages carry a byte-identical `update.sh` (verified: all five hash to `05504a55d269635261ac323b0047c2be`). It resolves the npm registry `latest` dist-tag, rehashes the tarball, regenerates `package-lock.json` against the dev-stripped `package.json` the derivation splices in, and re-derives `npmDepsHash`. Because the script takes the npm package name from the directory it lives in, it must be invoked in place from the source tree. The generic `just update-package <pkg>` recipe and the `apps.update-*` entries in `modules/apps/updates.nix` both route the script through the nix store first, where that derivation collapses:

```
store path:        /nix/store/5cwpr83v963pbhq3qi1v915za6px40cc-source
PKG_DIR would be:  /nix/store
PKG would be:      store
```

That is consistent with `modules/apps/updates.nix` defining no `update-*` app for any of these five packages. Each was therefore run as `./pkgs/by-name/<pkg>/update.sh`. Because the script resolves whatever the registry currently serves and takes no version argument, the resolved versions are reported above as measured rather than assumed; none of the five publishes a `next` dist-tag, so no prerelease was in play.

`no-mistakes` instead declares `passthru.updateScript = nix-update-script { }`, so `nix-update` is authoritative. The `--use-github-releases` flag is load-bearing rather than incidental. Without it `nix-update` reads the `releases.atom` feed and infers prerelease status from the version string alone, which would have selected `v1.61.0`; upstream flags that tag as a prerelease, and the string carries no `rc`/`beta`/`pre` marker to catch it. The releases API carries the real flag, so the default `--version=stable` filter skips it and selects `v1.60.2`, the newest upstream release not marked prerelease. This matches the character of the pin being replaced: `v1.45.4` was also a non-prerelease. `vendorHash` is unchanged.

No aggregate updater exists in this repository, so the packages were driven individually.

## Verification

Each derivation was built on `aarch64-darwin` and the resulting binary was run:

```
gh-axi                 -> 0.1.35
quota-axi              -> 0.1.34
tasks-axi              -> 0.2.5
lavish-axi             -> 0.1.63
chrome-devtools-axi    -> 0.1.33
no-mistakes            -> no-mistakes version v1.60.2
```

The `no-mistakes` build additionally exercises `versionCheckHook`, which independently confirmed `1.60.2` in the binary's output.

The covering check selection was the six `package-*` checks plus `treefmt`, all green:

```
nix build .#checks.aarch64-darwin.package-{gh,quota,tasks,lavish,chrome-devtools}-axi \
          .#checks.aarch64-darwin.package-no-mistakes \
          .#checks.aarch64-darwin.treefmt
```

`treefmt` reported 438 files processed, 0 changed. `treefmt` is in the selection because the diff touches both `.nix` and `.json` files; the `package-*` checks are the only checks that evaluate these six derivations.

Deliberately excluded: the remaining 103 flake checks, and the `home-manager-*` and `darwin-*` configuration checks. The diff changes only version strings, source hashes, `npmDepsHash`, and lockfile contents inside six package directories. `modules/home/ai/firstmate/default.nix` is the sole consumer and refers to all six by attribute name with no version constraint, so no consumer eval could observe the change and no floor elsewhere in the tree needed syncing. A full-repository run would not have been more severe here.

## Notes for maintainers

Two observations surfaced while establishing the mechanism; neither is changed by this PR, to keep the diff to the version bumps:

- `just update-package` and the `apps.update-*` pattern are unusable for the `*-axi` family for the store-path reason shown above. Wiring `update-*` apps for them would require the script to stop deriving its package name from `dirname "$BASH_SOURCE"`.
- `nix-update` on `no-mistakes` needs `--use-github-releases` to avoid selecting prerelease tags, since upstream's prerelease tags are plain `vX.Y.Z` strings. The header comment in `modules/apps/updates.nix` currently suggests the bare `nix-update --flake <package>` form.

No configuration was activated and nothing was installed imperatively; provisioning stays declarative.
