### PR TITLE
fix(deps): pin conventional-changelog preset to the v9 line

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,13 @@
         "@cloudflare/vite-plugin"
       ],
       "groupName": "cloudflare-workers-tooling"
+    },
+    {
+      "description": "conventional-changelog-conventionalcommits@10 requires conventional-changelog-writer@9, which semantic-release@25's bundled @semantic-release/release-notes-generator@14 does not resolve; hold on 9.x until semantic-release ships a compatible generator",
+      "matchPackageNames": [
+        "conventional-changelog-conventionalcommits"
+      ],
+      "allowedVersions": "<10"
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@semantic-release/changelog": "^7.0.0",
         "@semantic-release/git": "^11.0.1",
         "@semantic-release/github": "^12.0.9",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "semantic-release": "25.0.9",
         "semantic-release-major-tag": "^0.3.2",
         "semantic-release-monorepo": "^8.0.2",
@@ -32,7 +32,7 @@
         "@semantic-release/github": "^12.0.9",
         "@types/node": "^26.4.0",
         "@vitest/coverage-v8": "^4.1.11",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "playwright": "1.61.1",
         "semantic-release": "25.0.9",
         "semantic-release-major-tag": "^0.3.2",
@@ -170,8 +170,6 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260828.1", "", { "os": "win32", "cpu": "x64" }, "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
-
-    "@conventional-changelog/template": ["@conventional-changelog/template@1.4.0", "", {}, "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -621,7 +619,7 @@
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.1.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w=="],
 
-    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@10.4.0", "", { "dependencies": { "@conventional-changelog/template": "^1.4.0" } }, "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA=="],
+    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw=="],
 
     "conventional-changelog-writer": ["conventional-changelog-writer@8.2.0", "", { "dependencies": { "conventional-commits-filter": "^5.0.0", "handlebars": "^4.7.7", "meow": "^13.0.0", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "dist/cli/index.js" } }, "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -305,10 +305,6 @@
     url = "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz";
     hash = "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==";
   };
-  "@conventional-changelog/template@1.4.0" = fetchurl {
-    url = "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz";
-    hash = "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==";
-  };
   "@cspotcode/source-map-support@0.8.1" = fetchurl {
     url = "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz";
     hash = "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==";
@@ -1562,9 +1558,9 @@
     url = "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz";
     hash = "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==";
   };
-  "conventional-changelog-conventionalcommits@10.4.0" = fetchurl {
-    url = "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz";
-    hash = "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==";
+  "conventional-changelog-conventionalcommits@9.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz";
+    hash = "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==";
   };
   "conventional-changelog-writer@8.2.0" = fetchurl {
     url = "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz";

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/git": "^11.0.1",
     "@semantic-release/github": "^12.0.9",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "semantic-release": "25.0.9",
     "semantic-release-major-tag": "^0.3.2",
     "semantic-release-monorepo": "^8.0.2"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -52,7 +52,7 @@
     "@semantic-release/github": "^12.0.9",
     "@types/node": "^26.4.0",
     "@vitest/coverage-v8": "^4.1.11",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "playwright": "1.61.1",
     "semantic-release": "25.0.9",
     "semantic-release-major-tag": "^0.3.2",


### PR DESCRIPTION
## Problem

The docs release path has failed at `generateNotes` on every main push with a release to make since Renovate raised `conventional-changelog-conventionalcommits` to `^10.4.0`. No release has been published by the `default.release-packages` effect since.

Preset major 10 requires `conventional-changelog-writer` major 9 or newer, but `semantic-release@25.0.9` resolves `@semantic-release/release-notes-generator@14.1.0`, which pins writer `^8.0.0` and therefore 8.2.0.

The mechanism is not a version check but a planted handlebars template: `@conventional-changelog/template@1.4.0` supplies a `mainTemplate` whose body is the error sentence itself. A writer-8 renderer compiles it and throws it as a `Missing helper` error; writer 9 ignores the option entirely. This bump did not create the incompatibility, it made an existing silent one loud.

## Why pin rather than upgrade

Upgrading forward is unavailable today. Every `semantic-release` channel, including `26.0.0-beta.1`, depends on release-notes-generator `^14.1.0`, and only `15.0.0-beta.2` accepts writer 9, which no `semantic-release` release references.

Two other routes were eliminated by direct test rather than by reading ranges. A top-level override forcing writer 9 fails, because the package manager nests writer 8 beneath release-notes-generator to satisfy its own range and the nested copy is the one that renders. Pinning to a lower v10 also fails, since presets 10.0.0 through 10.3.0 all resolve `@conventional-changelog/template` to 1.4.0 today.

9.3.1 is the version upstream itself tests against writer 8, and unlike 10.4.0 it does not raise the node engine requirement to 22.

## Changes

Both manifests change together because the root declares `workspaces: ["packages/*"]` and `bun.lock` keys packages by name, so one version resolves for the whole workspace.

- `package.json`, `packages/docs/package.json`: `^10.4.0` to `^9.3.1`
- `bun.lock`, `bun.nix`: regenerated via `nix run .#regenerate-bun-nix`
- `.github/renovate.json`: hold the package below 10

The Renovate rule is required rather than hygiene. `.github/workflows/regenerate-lock-files.yaml` re-runs the generator on Renovate pull requests and amends the branch, so without the hold the next Renovate run restores `^10.4.0` and re-materializes it into `bun.nix` automatically. That workflow is gated to `renovate[bot]`, so `bun.nix` is regenerated here by hand.

## Verification

**The repository's own check set does not cover this defect, and a green check set is not evidence that this is fixed.** The release path runs only as a post-build effect on main, and the `package-vanixiets-docs*` checks never invoke `generateNotes`. Pull request builds are also structurally blind to it: `modules/apps/docs/preview-version.sh` passes `--plugins`, which discards the per-plugin `preset: "conventionalcommits"` option, and wraps the invocation in `$( ... || true)`.

The primary evidence is therefore a paired reproduction. `generateNotes` from `@semantic-release/release-notes-generator@14.1.0` was invoked with the repository's real `pluginConfig` against the repository's own bun-resolved tree over the real 9 commits since `@vanixiets/docs-v0.6.0`, holding writer at CI's exact 8.2.0 and changing only the preset:

| preset | writer | result |
|---|---|---|
| 10.4.0 | 8.2.0 | fails with the CI error verbatim |
| 9.3.1 | 8.2.0 | renders the 0.6.1 notes correctly |

The rendered output under the fix is correct, not merely non-throwing:

```
## [0.6.1](https://github.com/cameronraysmith/vanixiets/compare/@vanixiets/docs-v0.6.0...@vanixiets/docs-v0.6.1) (2026-08-31)

### Bug Fixes

* **deps:** update dependency @astrojs/starlight to v0.41.10 ([9a7fd54](...))
```

### Checks run

Selected as the narrowest set that would fail if this change were wrong:

```
nix build --no-link --print-out-paths \
  .#checks.aarch64-darwin.{treefmt,package-vanixiets-docs-deps,package-vanixiets-docs,package-vanixiets-docs-test-unit}
```

All four pass. `package-vanixiets-docs-deps` is the derivation that materializes `node_modules` from `bun.nix`, so a stale or inconsistent lockfile fails there, and its log shows `bun-pkg-conventional-changelog-conventionalcommits-9.3.1.drv`. `package-vanixiets-docs` builds atop it, `treefmt` covers the changed nix and json, and `-test-unit` confirms the retuned tree still supports the test runner.

Deliberately left out: `-test-e2e` and `-test-linkcheck`, which exercise docs site content this diff does not touch, and the full check set, whose blast radius far exceeds a dependency pin.

### Not verified

The publish step after `generateNotes` was not executed, since that needs the `x86_64-linux` closure and CI credentials. Those preconditions were already passing in the failing logs, so clearing this check is expected but not directly demonstrated.

## Out of scope

The `|| true` and `--plugins` override in `preview-version.sh` mean pull request builds cannot detect a broken production release path, which is how this reached main unnoticed. Making the preview exercise the real plugin configuration, or at least propagate its exit status, would have caught it on the Renovate pull request. Not changed here.
