### PR TITLE
Fix store-copied package updaters and update linear-cli to 2.5.0

### DIFF
--- a/modules/checks/hooks.nix
+++ b/modules/checks/hooks.nix
@@ -148,5 +148,51 @@
 
             touch $out
           '';
+
+      checks.updater-repository-paths =
+        pkgs.runCommand "updater-repository-paths"
+          {
+            nativeBuildInputs = [ pkgs.ripgrep ];
+            updaters = ../../pkgs/by-name;
+          }
+          ''
+            set -uo pipefail
+            failures=0
+            identity_pattern='BASH_SOURCE|[$][{]?0([^0-9]|$)'
+
+            for updater in "$updaters"/*/update.sh; do
+              [ -f "$updater" ] || continue
+              package="''${updater%/update.sh}/package.nix"
+
+              if matches=$(rg -n "$identity_pattern" "$updater"); then
+                relative_path="''${updater#"$updaters"/}"
+                echo "FAIL: $relative_path derives package paths from its copied updater identity:" >&2
+                echo "$matches" >&2
+                failures=$((failures + 1))
+              fi
+
+              if rg -q 'git rev-parse --show-toplevel' "$updater" \
+                && ! sed -n '1,2p' "$updater" | rg -q '#!nix-shell.*[[:space:]]git([[:space:]]|$)'; then
+                relative_path="''${updater#"$updaters"/}"
+                echo "FAIL: $relative_path resolves the repository with git but does not declare git in its nix-shell packages." >&2
+                failures=$((failures + 1))
+              fi
+
+              if [ -f "$package" ] \
+                && rg -q 'outputHash[[:space:]]*=' "$package" \
+                && ! rg -q 'outputHash' "$updater"; then
+                relative_path="''${updater#"$updaters"/}"
+                echo "FAIL: $relative_path does not refresh its package's fixed-output hash." >&2
+                failures=$((failures + 1))
+              fi
+            done
+
+            if [ "$failures" -ne 0 ]; then
+              echo "Updater scripts must resolve the repository root with 'git rev-parse --show-toplevel', then address pkgs/by-name/<package> under that root." >&2
+              exit 1
+            fi
+
+            touch $out
+          '';
     };
 }

--- a/pkgs/by-name/chrome-devtools-axi/update.sh
+++ b/pkgs/by-name/chrome-devtools-axi/update.sh
@@ -2,18 +2,11 @@
 #!nix-shell -i bash -p curl jq cacert git nodejs_22 nix
 # shellcheck shell=bash
 
-# Bumps an axi-family package to the current npm registry latest. The firstmate
-# bootstrap tracks these tools at latest and raises its version floors as they
-# publish, so a stale pin eventually reports MISSING rather than out-of-date.
-#
-# This script is byte-identical across the axi-family package directories; the
-# npm package name is taken from the directory it lives in.
-
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PKG="$(basename "$PKG_DIR")"
+PKG_DIR="${REPO_ROOT}/pkgs/by-name/chrome-devtools-axi"
+PKG="${PKG_DIR##*/}"
 PKG_NIX="${PKG_DIR}/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"

--- a/pkgs/by-name/dbt-fusion/update.sh
+++ b/pkgs/by-name/dbt-fusion/update.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused jq nix-prefetch
+#!nix-shell -i bash -p curl git gnused jq nix-prefetch
 
 set -euo pipefail
 
-ROOT="$(dirname "$(readlink -f "$0")")"
-NIX_DRV="$ROOT/package.nix"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NIX_DRV="${REPO_ROOT}/pkgs/by-name/dbt-fusion/package.nix"
 if [ ! -f "$NIX_DRV" ]; then
-  echo "ERROR: cannot find package.nix in $ROOT"
+  echo "ERROR: cannot find $NIX_DRV"
   exit 1
 fi
 

--- a/pkgs/by-name/gh-axi/update.sh
+++ b/pkgs/by-name/gh-axi/update.sh
@@ -2,18 +2,11 @@
 #!nix-shell -i bash -p curl jq cacert git nodejs_22 nix
 # shellcheck shell=bash
 
-# Bumps an axi-family package to the current npm registry latest. The firstmate
-# bootstrap tracks these tools at latest and raises its version floors as they
-# publish, so a stale pin eventually reports MISSING rather than out-of-date.
-#
-# This script is byte-identical across the axi-family package directories; the
-# npm package name is taken from the directory it lives in.
-
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PKG="$(basename "$PKG_DIR")"
+PKG_DIR="${REPO_ROOT}/pkgs/by-name/gh-axi"
+PKG="${PKG_DIR##*/}"
 PKG_NIX="${PKG_DIR}/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"

--- a/pkgs/by-name/hindsight/update.sh
+++ b/pkgs/by-name/hindsight/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p curl jq cacert nix
+#!nix-shell --pure -i bash -p curl jq cacert git nix
 # shellcheck shell=bash
 #
 # Bumps pkgs/by-name/hindsight to the latest upstream release: rewrites the
@@ -8,11 +8,8 @@
 
 set -euo pipefail
 
-# Resolve package.nix relative to this script so the updater edits the correct
-# file regardless of the caller's working directory (e.g. nixpkgs update
-# machinery, which does not cd into the package directory).
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-PKG_NIX="${SCRIPT_DIR}/package.nix"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PKG_NIX="${REPO_ROOT}/pkgs/by-name/hindsight/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
 

--- a/pkgs/by-name/lavish-axi/update.sh
+++ b/pkgs/by-name/lavish-axi/update.sh
@@ -2,18 +2,11 @@
 #!nix-shell -i bash -p curl jq cacert git nodejs_22 nix
 # shellcheck shell=bash
 
-# Bumps an axi-family package to the current npm registry latest. The firstmate
-# bootstrap tracks these tools at latest and raises its version floors as they
-# publish, so a stale pin eventually reports MISSING rather than out-of-date.
-#
-# This script is byte-identical across the axi-family package directories; the
-# npm package name is taken from the directory it lives in.
-
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PKG="$(basename "$PKG_DIR")"
+PKG_DIR="${REPO_ROOT}/pkgs/by-name/lavish-axi"
+PKG="${PKG_DIR##*/}"
 PKG_NIX="${PKG_DIR}/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"

--- a/pkgs/by-name/linear-cli/package.nix
+++ b/pkgs/by-name/linear-cli/package.nix
@@ -87,7 +87,7 @@ let
       # regenerable artifacts: remote/ (now vendored), analysis & v8 caches, the
       # path-keyed gen/ tree, scripts-warned nonces, and npm registry metadata.
       ( cd "$DENO_DIR"
-        rm -rf remote gen
+        rm -rf remote gen node_compat_bin
         find . -name '*_analysis_cache_v2*' -delete
         find . -name 'v8_code_cache_v2*' -delete
         find . -name '.scripts-warned-*' -delete

--- a/pkgs/by-name/linear-cli/package.nix
+++ b/pkgs/by-name/linear-cli/package.nix
@@ -12,18 +12,18 @@
 }:
 
 let
-  version = "2.0.0";
+  version = "2.5.0";
 
   # Prebuilt deno-compile binaries published per tag by cargo-dist. Only the
   # Darwin artifacts are usable (see the Linux note below).
   binaries = {
     aarch64-darwin = {
       url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-aarch64-apple-darwin.tar.xz";
-      hash = "sha256-Eh/h7ubZCyLnbk6Yy7YkR07s2XCkpMYi/U1QiJtX2sw=";
+      hash = "sha256-bRHrWg7iqhDSRiXSPGBb9WmHqUdB5gu5gX+HsSOpoAs=";
     };
     x86_64-darwin = {
       url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-x86_64-apple-darwin.tar.xz";
-      hash = "sha256-cp5nFmxQlMiVFQtnLNOkRh+omYl+HyTbzQfBO7O0jBM=";
+      hash = "sha256-9Xx6zJdMG8AcCsFBZYov04DjZ3a4XxXan8vy6CTAgjw=";
     };
   };
 
@@ -35,7 +35,7 @@ let
     owner = "schpet";
     repo = "linear-cli";
     rev = "v${version}";
-    hash = "sha256-FR6WuTKws75i0T00ASxr6wTHYH8MNOdboJcDYD0aYVM=";
+    hash = "sha256-iNAJ0vaEMkPkYq0I9SLEl3GJY/B0MazOgAm3PgkIb/o=";
   };
 
   # Darwin: the upstream prebuilt deno-compile single-file executable.
@@ -112,7 +112,7 @@ let
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-r5480RsOe3Su7opj5V76nBgm3cVmlzckNAUXRayHLMg=";
+    outputHash = "sha256-eYm8+y/l4X2NFLIjny1r86Wf88gXq+m4TN53DI9fuiQ=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/linear-cli/update.sh
+++ b/pkgs/by-name/linear-cli/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p curl jq cacert nix gnused coreutils gnugrep
+#!nix-shell --pure -i bash -p curl jq cacert git nix gnused coreutils gnugrep
 # shellcheck shell=bash
 #
 # Update linear-cli (schpet/linear-cli) to the latest release.
@@ -10,14 +10,15 @@
 #      paired to each preceding `url` line)
 #   3. the `src` fetchFromGitHub `hash = "...";` line (the hash following
 #      the `rev = "v$VERSION";` line)
+#   4. the Linux source build's `denoDeps.outputHash`
 #
 # Usage: ./update.sh [VERSION]   (VERSION overrides the latest-release lookup)
 
 set -euo pipefail
 
 REPO="schpet/linear-cli"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PKG_NIX="${SCRIPT_DIR}/package.nix"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PKG_NIX="${REPO_ROOT}/pkgs/by-name/linear-cli/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
 
@@ -85,5 +86,35 @@ fi
 
 sed -i'' -e "/rev = \"v\${version}\"/{ n; s|hash = \"sha256-[^\"]*\"|hash = \"${src_sri}\"|; }" "$PKG_NIX"
 echo "  src: ${src_sri}"
+
+echo "Prefetching x86_64-linux Deno dependencies..."
+fake_hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+sed -i'' -e "s|outputHash = \"sha256-[^\"]*\";|outputHash = \"${fake_hash}\";|" "$PKG_NIX"
+
+if ! grep -qF "outputHash = \"${fake_hash}\";" "$PKG_NIX"; then
+  echo "error: failed to replace denoDeps.outputHash with the probe hash" >&2
+  exit 1
+fi
+
+deno_deps_log="$(mktemp)"
+trap 'rm -f "$deno_deps_log"' EXIT
+
+if nix build "${REPO_ROOT}#packages.x86_64-linux.linear-cli.denoDeps" \
+  --system x86_64-linux \
+  --no-link \
+  -L 2>&1 | tee "$deno_deps_log"; then
+  echo "error: denoDeps unexpectedly matched the probe hash" >&2
+  exit 1
+fi
+
+deno_deps_hash="$(sed -n 's/^[[:space:]]*got:[[:space:]]*\(sha256-[^[:space:]]*\)$/\1/p' "$deno_deps_log" | tail -1)"
+
+if [[ -z "$deno_deps_hash" ]]; then
+  echo "error: x86_64-linux denoDeps build failed without producing a fixed-output hash" >&2
+  exit 1
+fi
+
+sed -i'' -e "s|outputHash = \"${fake_hash}\";|outputHash = \"${deno_deps_hash}\";|" "$PKG_NIX"
+echo "  denoDeps (x86_64-linux): ${deno_deps_hash}"
 
 echo "Updated linear-cli to ${latest_version}"

--- a/pkgs/by-name/quota-axi/update.sh
+++ b/pkgs/by-name/quota-axi/update.sh
@@ -2,18 +2,11 @@
 #!nix-shell -i bash -p curl jq cacert git nodejs_22 nix
 # shellcheck shell=bash
 
-# Bumps an axi-family package to the current npm registry latest. The firstmate
-# bootstrap tracks these tools at latest and raises its version floors as they
-# publish, so a stale pin eventually reports MISSING rather than out-of-date.
-#
-# This script is byte-identical across the axi-family package directories; the
-# npm package name is taken from the directory it lives in.
-
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PKG="$(basename "$PKG_DIR")"
+PKG_DIR="${REPO_ROOT}/pkgs/by-name/quota-axi"
+PKG="${PKG_DIR##*/}"
 PKG_NIX="${PKG_DIR}/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"

--- a/pkgs/by-name/tasks-axi/update.sh
+++ b/pkgs/by-name/tasks-axi/update.sh
@@ -2,18 +2,11 @@
 #!nix-shell -i bash -p curl jq cacert git nodejs_22 nix
 # shellcheck shell=bash
 
-# Bumps an axi-family package to the current npm registry latest. The firstmate
-# bootstrap tracks these tools at latest and raises its version floors as they
-# publish, so a stale pin eventually reports MISSING rather than out-of-date.
-#
-# This script is byte-identical across the axi-family package directories; the
-# npm package name is taken from the directory it lives in.
-
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PKG="$(basename "$PKG_DIR")"
+PKG_DIR="${REPO_ROOT}/pkgs/by-name/tasks-axi"
+PKG="${PKG_DIR##*/}"
 PKG_NIX="${PKG_DIR}/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"

--- a/pkgs/by-name/uncomment-bin/update.sh
+++ b/pkgs/by-name/uncomment-bin/update.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p curl jq cacert nix
+#!nix-shell --pure -i bash -p curl jq cacert git nix
 # shellcheck shell=bash
 
 set -euo pipefail
 
-# Resolve package.nix relative to this script so the updater edits the correct
-# file regardless of the caller's working directory (e.g. nixpkgs update
-# machinery, which does not cd into the package directory).
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-PKG_NIX="${SCRIPT_DIR}/package.nix"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PKG_NIX="${REPO_ROOT}/pkgs/by-name/uncomment-bin/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
 

--- a/pkgs/by-name/worktrunk-bin/update.sh
+++ b/pkgs/by-name/worktrunk-bin/update.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p curl jq cacert nix
+#!nix-shell --pure -i bash -p curl jq cacert git nix
 # shellcheck shell=bash
 
 set -euo pipefail
 
-# Resolve package.nix relative to this script so the updater edits the correct
-# file regardless of the caller's working directory (e.g. nixpkgs update
-# machinery, which does not cd into the package directory).
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-PKG_NIX="${SCRIPT_DIR}/package.nix"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PKG_NIX="${REPO_ROOT}/pkgs/by-name/worktrunk-bin/package.nix"
 
 current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
 


### PR DESCRIPTION
## Summary

Update scripts exposed as flake apps are copied into the Nix store before execution. Scripts that derive their package directory from `$0` or `BASH_SOURCE` consequently resolve `/nix/store/...-update.sh` rather than the repository package directory, so `package.nix` cannot be read. The correct convention is to resolve the repository root with `git rev-parse --show-toplevel`, then address `pkgs/by-name/<package>` beneath that root.

The affected scripts were:

- `pkgs/by-name/chrome-devtools-axi/update.sh`
- `pkgs/by-name/dbt-fusion/update.sh`
- `pkgs/by-name/gh-axi/update.sh`
- `pkgs/by-name/hindsight/update.sh`
- `pkgs/by-name/lavish-axi/update.sh`
- `pkgs/by-name/linear-cli/update.sh`
- `pkgs/by-name/quota-axi/update.sh`
- `pkgs/by-name/tasks-axi/update.sh`
- `pkgs/by-name/uncomment-bin/update.sh`
- `pkgs/by-name/worktrunk-bin/update.sh`

All ten scripts now use repository-root-relative package paths. Updaters that newly invoke Git in the pure flake-app environment also declare Git as a runtime dependency.

`nix run .#update-linear-cli` now completes through the supported entry point and updates linear-cli from 2.0.0 to 2.5.0, including its source hash, two Darwin artifact hashes, and Linux source-build dependency hash.

## Linux dependency output

Nixbot build 118 exposed that the original updater refreshed three of the four fixed-output hashes and silently retained the 2.0.0 `denoDeps.outputHash`. Darwin did not detect the stale value because linear-cli installs upstream binaries on aarch64-darwin and x86_64-darwin; x86_64-linux is the only supported system that consumes the source-build dependency derivation.

The vendored dependency output is platform-dependent in both 2.0.0 and 2.5.0. Deno retains the host-selected optional lefthook package: `lefthook-darwin-arm64` on aarch64-darwin and `lefthook-linux-x64` on x86_64-linux. A forced 2.0.0 Linux build also produced a different hash from the retained Darwin-generated 2.0.0 value. Because only Linux consumes `denoDeps`, the package needs one Linux-generated dependency hash rather than a per-system map.

After the Linux hash matched, the remote builder exposed an absolute `deno_dir/node_compat_bin/node` shim referencing the Deno store path. Nix rejects such a reference in fixed-output content. The dependency derivation now removes that regenerable, non-npm cache artifact before hashing; the cleaned output has no store references.

The updater now replaces the dependency pin with a probe hash, builds the derivation explicitly as x86_64-linux through the configured magnetite fleet builder, extracts the produced digest, and fails if no digest is available. The cleaned 2.5.0 Linux hash was generated by rerunning `nix run .#update-linear-cli -- 2.5.0`; a second run was idempotent. A pinned magnetite build completed the Linux package and its install check reported `linear 2.5.0`.

## Recurrence checks

The flake check in `modules/checks/hooks.nix` scans every `pkgs/by-name/*/update.sh`, rejects package-path resolution from script identity, explains the repository-root convention, and verifies that scripts using Git declare it in the updater runtime. The check accepts the existing atomic updater as the working pattern. It also rejects packaged updaters that own an `outputHash` without updating that hash, preventing another partial update from silently retaining a stale fixed-output pin.

## Related updater results

- `nix run .#update-hindsight` completes and would update 0.9.1 to 0.9.2. Its generated package change was restored and is not part of this pull request.
- `nix run .#update-worktrunk-bin` completes and would update 0.65.0 to 0.75.0. Its generated package change was restored and is not part of this pull request.

## Verification

- `nix eval --raw .#checks.aarch64-darwin.updater-repository-paths.drvPath`
- `nix build .#checks.aarch64-darwin.updater-repository-paths`
- `shellcheck pkgs/by-name/linear-cli/update.sh`
- `nix build --no-link --print-out-paths .#linear-cli`
- Built Darwin binary: `linear 2.5.0`
- Pinned magnetite x86_64-linux build and install check: `linear 2.5.0`
- Supported updater repeated with no worktree change
- `bash -n` for all ten affected updater scripts
- `git diff --check 4ff7508dff8d7d3959fc1eee4ee8afdfe78bbb06..HEAD`
- Nixbot build 121 succeeded for commit `15efb95c5`; `checks.x86_64-linux.package-linear-cli` was `skipped_local` because the pinned magnetite build had already populated the CI store, and all six home-manager plus five NixOS consumers succeeded.

The full parallel check set was not run locally. Nixbot build 121 supplied the x86_64-linux integration result.