### PR TITLE
chore(bootstrap): pin nix-installer 2.35.1, trust @sudo, add uninstall-nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,13 @@ bootstrap: install-nix install-direnv
 # This bypasses both the Fastly CDN (HTTP 618 errors) and the shell wrapper
 # (which has template placeholders that aren't filled in for raw source files).
 # To update version, change NIX_INSTALLER_VERSION below.
-# Note: versioning jumped from 0.27.0 to 3.11.3, then back to 2.34.6 when
+# Note: versioning jumped from 0.27.0 to 3.11.3, then back to the 2.x line when
 # NixOS/nix-installer removed the 3.x tags (repo renamed from experimental-nix-installer).
+# The installer tag tracks the Nix it embeds (flake.nix: nix.url = github:NixOS/nix/<tag>),
+# so this pin is also the nix version bootstrap lands.
 # https://github.com/NixOS/nix-installer/releases
 #
-# nix-installer 2.34.6 writes /etc/nix/nix.conf in setup_standard_config
+# nix-installer 2.35.1 writes /etc/nix/nix.conf in setup_standard_config
 # (src/action/common/place_nix_configuration.rs:98-154). Its defaults are
 # extra-experimental-features = nix-command, auto-optimise-store = true (Linux
 # only), always-allow-substitutes = true, max-jobs = auto, and
@@ -107,8 +109,8 @@ bootstrap: install-nix install-direnv
 # to get flakes is an interactive prompt that --no-confirm suppresses
 # (src/cli/subcommand/install/mod.rs:119-137), so a non-interactive install
 # without the flag lands nix-command alone. Releases through 2.33.0 wrote
-# nix-command flakes unconditionally, which is why the flag is needed at this pin
-# and was not needed at the previous one.
+# nix-command flakes unconditionally, which is why the flag is needed at any
+# 2.34.4-or-later pin and was not needed before that.
 #
 # flakes is not optional here: install-direnv resolves nixpkgs#direnv and
 # 'make verify' runs 'nix flake --help'.
@@ -120,14 +122,17 @@ bootstrap: install-nix install-direnv
 # deliberately omitted. The experimental feature only makes Nix accept the
 # setting of the same name, and the setting is true nowhere in this repo except
 # magnetite (modules/machines/nixos/magnetite/default.nix:76-83), which pairs it
-# with extra-system-features = uid-range for systemd-nspawn tests. Enabling the
-# feature alone changes no build behaviour, and the daemonless mode below has no
-# daemon to allocate UIDs at all. Bootstrap's nix.conf is transient regardless:
+# with extra-system-features = uid-range for systemd-nspawn tests. That pairing is
+# belt-and-braces: nix's own getDefaultSystemFeatures
+# (nix src/libstore/globals.cc:217-239) already inserts uid-range
+# unconditionally on linux. Enabling the feature alone
+# changes no build behaviour, and the daemonless mode below has no daemon to
+# allocate UIDs at all. Bootstrap's nix.conf is transient regardless:
 # the first 'just activate' regenerates it from the host's own modules.
 #
 # trusted-users lets nix accept flake-specified substituters and public keys
 # without prompts or warnings.
-NIX_INSTALLER_VERSION := 2.34.6
+NIX_INSTALLER_VERSION := 2.35.1
 
 # A usable systemd runtime is detected by the single existence test that
 # /run/systemd/system is present if and only if the machine booted under systemd

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,14 @@ bootstrap: install-nix install-direnv
 # the first 'just activate' regenerates it from the host's own modules.
 #
 # trusted-users lets nix accept flake-specified substituters and public keys
-# without prompts or warnings.
+# without prompts or warnings. Nix's own default is `root` alone, so without
+# this the person who ran bootstrap cannot use the flake's caches and rebuilds
+# everything from source. The three admin groups are one per platform
+# convention - @admin on darwin, @wheel on nixos/fedora/arch, @sudo on
+# debian/ubuntu - because none of the three exists everywhere and nix ignores
+# the ones that do not resolve. Groups rather than $(USER) so the value is
+# static and stays right for a second admin on the same host; trusting them is
+# no escalation, since a sudoer is already root-equivalent.
 NIX_INSTALLER_VERSION := 2.35.1
 
 # A usable systemd runtime is detected by the single existence test that
@@ -184,7 +191,7 @@ install-nix: ## Install Nix using the NixOS community installer
 				"$$INSTALLER_URL" -o /tmp/nix-installer && chmod +x /tmp/nix-installer; then \
 				/tmp/nix-installer install $$PLANNER_ARGS --no-confirm \
 					--enable-flakes \
-					--extra-conf "trusted-users = root @admin @wheel" && break; \
+					--extra-conf "trusted-users = root @admin @wheel @sudo" && break; \
 			fi; \
 			attempt=$$((attempt + 1)); \
 			if [ $$attempt -le $$max_attempts ]; then \

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,56 @@ install-nix: ## Install Nix using the NixOS community installer
 		fi; \
 	fi
 
+.PHONY: uninstall-nix
+# The inverse of install-nix, and the only supported one: nix-installer records
+# its plan in /nix/receipt.json and reverses exactly that plan
+# (src/cli/subcommand/uninstall.rs), so hand-removing /nix leaves the build
+# users, the daemon unit and the shell profile snippets behind.
+#
+# The uninstaller must be the copy the install left at /nix/nix-installer, not
+# NIX_INSTALLER_VERSION: the receipt is version-checked, and a binary older than
+# the plan refuses to parse it and prints that same path as the fix
+# (uninstall.rs:110-149). The pinned release is only a fallback for a host whose
+# copy is gone, where it works when the receipt is not newer than the pin.
+#
+# No sudo: ensure_root re-execs the process under sudo --set-home itself
+# (src/cli/mod.rs:133-141), matching install-nix.
+#
+# Deliberately not wired into any aggregate target - bootstrap is the composition
+# worth having - but the pair does compose to the identity map, which is how a
+# pin bump gets verified on a real host rather than only in a container:
+#
+#   make uninstall-nix CONFIRM=1 && make bootstrap && make verify
+uninstall-nix: ## Uninstall Nix by reverting /nix/receipt.json (CONFIRM=1 to skip the prompt)
+	@echo "Uninstalling Nix..."
+	@if [ ! -e /nix/receipt.json ]; then \
+		if [ -e /nix ]; then \
+			echo "No install receipt at /nix/receipt.json, but /nix exists: this Nix was not installed by nix-installer, so refusing to guess at how to remove it."; \
+			exit 1; \
+		fi; \
+		echo "Nix is not installed."; \
+	else \
+		UNINSTALLER=/nix/nix-installer; \
+		if [ ! -x "$$UNINSTALLER" ]; then \
+			case "$$(uname -s)-$$(uname -m)" in \
+				Linux-x86_64)  PLATFORM="x86_64-linux" ;; \
+				Linux-aarch64) PLATFORM="aarch64-linux" ;; \
+				Darwin-arm64)  PLATFORM="aarch64-darwin" ;; \
+				*) echo "Unsupported platform: $$(uname -s)-$$(uname -m)"; exit 1 ;; \
+			esac; \
+			echo "No installer at /nix/nix-installer; falling back to the pinned $(NIX_INSTALLER_VERSION) release."; \
+			curl --proto '=https' --tlsv1.2 -sSf -L --retry 3 --retry-delay 5 \
+				"https://github.com/NixOS/nix-installer/releases/download/$(NIX_INSTALLER_VERSION)/nix-installer-$$PLATFORM" \
+				-o /tmp/nix-installer && chmod +x /tmp/nix-installer; \
+			UNINSTALLER=/tmp/nix-installer; \
+		fi; \
+		if [ "$(CONFIRM)" = "1" ]; then \
+			"$$UNINSTALLER" uninstall --no-confirm; \
+		else \
+			"$$UNINSTALLER" uninstall; \
+		fi; \
+	fi
+
 .PHONY: install-direnv
 install-direnv: ## Install direnv (requires nix to be installed first)
 	@echo "Installing direnv..."


### PR DESCRIPTION
## Summary

`NIX_INSTALLER_VERSION := 2.34.6` → `2.35.1`, the current NixOS/nix-installer tag. The installer tag tracks the Nix it embeds (`flake.nix`: `nix.url = "github:NixOS/nix/2.35.1"`), so this is what bootstrap actually changes: nix 2.34.6 → 2.35.1 on freshly bootstrapped hosts.

Also fixes a latent bug in the installer flags that predates the pin. `trusted-users = root @admin @wheel` names darwin's admin group and nixos/fedora/arch's, and misses debian and ubuntu, where it is `sudo` and where `wheel` usually does not exist at all:

```diff
-    --extra-conf "trusted-users = root @admin @wheel"
+    --extra-conf "trusted-users = root @admin @wheel @sudo"
```

With no group resolving, nix's own default is the effective value — `root` alone — so the user who just ran `make bootstrap` is untrusted, and the daemon *silently* ignores the `substituters` and `trusted-public-keys` this flake declares in `nixConfig`: it warns rather than errors and rebuilds from source what the caches already have. Groups rather than `$(USER)` keeps the value static and still correct for a second admin on the host, and nix ignores names that do not resolve, so all three can be listed unconditionally. No escalation is implied: a member of a sudo group can already become root, which is the bound on what `trusted-users` grants.

Verified on a debian-family host, holding everything else fixed:

| `trusted-users` in nix.conf | `nix store info --json` → `trusted` |
| --- | --- |
| `root @admin @wheel` | `false` |
| `root @admin @wheel @sudo` | `true` |

Adds `uninstall-nix`, without which a pin bump is unverifiable on any machine that has already been bootstrapped — `install-nix` short-circuits on `command -v nix`, so `make bootstrap` on such a host is a 9ms no-op that proves only idempotence. The target delegates to the installer's own receipt-reverting `uninstall`, since hand-removing `/nix` would leave the 32 build users, the daemon unit and the profile snippets behind:

```make
uninstall-nix:
	# /nix/nix-installer, not the pinned release: the receipt is version-checked and an
	# older binary refuses to parse a newer plan (uninstall.rs:110-149). Pinned download
	# is a fallback for a host whose copy is gone. No sudo — ensure_root re-execs itself.
	$$UNINSTALLER uninstall $(if CONFIRM=1: --no-confirm)
```

`make uninstall-nix CONFIRM=1 && make bootstrap && make verify` then composes to the identity map, which is how the new pin was verified here — on this Devin sandbox, i.e. through the systemd planner rather than only the container's `--init none`:

| step | result |
| --- | --- |
| `uninstall-nix` | `/nix`, `/etc/nix`, `nix-daemon.service`, all 32 `nixbld*`, `/etc/profile.d/nix.sh` all gone |
| `uninstall-nix` again | `Nix is not installed.`, exit 0 |
| `bootstrap` | 2.1s, `nix (Nix) 2.35.1`, receipt `2.35.1`, daemon active, 32 build users |
| `verify` | all checks pass |
| `nix develop` cold | 1m22s, fully substituted |

Everything the pin's comment block asserts was re-verified against the 2.35.1 source rather than assumed, and it all still holds line-for-line — `setup_standard_config` is still `place_nix_configuration.rs:98-154`, `flakes`/`extra-nix-path` are still gated on `--enable-flakes` at `:105-112`/`:126-131`, `settings.rs:193-204` still defaults `enable_flakes = false`, the suppressed prompt is still `install/mod.rs:119-137`, and `check_systemd_active` is still `linux.rs:244-254`.

Worth recording about that file, since it is why the flag rather than post-hoc configuration is the right place for this: `trusted-users` is the one setting the installer special-cases, promoting it out of `nix.custom.conf` into `nix.conf` proper — a documented workaround for Cachix not following `!include` — so it lands in *both* files (`place_nix_configuration.rs:98-154`, and `/nix/receipt.json` shows it in both actions).

One comment claim was wrong and is corrected here: `uid-range` is not new in 2.35 defaults. `getDefaultSystemFeatures` inserts it unconditionally on linux in 2.34.6 and 2.35.1 alike (`nix src/libstore/globals.cc:217-239`), which `nix config show system-features` confirms on a 2.34.6 host. So magnetite's `extra-system-features = [ "uid-range" ]` is belt-and-braces rather than required, and the comment now says that instead of implying the pin lags a default.

Two clarifications, no behavior attached: the version history note no longer names the superseded pin, and "the flag is needed at this pin and was not needed at the previous one" becomes "needed at any 2.34.4-or-later pin" — otherwise "the previous one" would now read as 2.34.6, which needed it too.


Link to Devin session: https://app.devin.ai/sessions/d8f060379a874a37ba13571d8f1f48a3
Open in Devin Desktop: https://app.devin.ai/desktop/session/d8f060379a874a37ba13571d8f1f48a3?variant=devin
Requested by: @cameronraysmith