### PR TITLE
perf(magnetite): raise nix daemon cache-fetch concurrency after locating the eval bottleneck

### DIFF
--- a/docs/notes/development/incidents/2026-09-02-nixbot-eval-throughput-magnetite-storage-audit.md
+++ b/docs/notes/development/incidents/2026-09-02-nixbot-eval-throughput-magnetite-storage-audit.md
@@ -1,0 +1,110 @@
+---
+title: nixbot evaluation throughput and magnetite storage audit, 2026-09-02
+---
+
+Two questions were asked together: why nixbot evaluations on magnetite collapsed from a 9m41s baseline to 44-55 minutes, and whether magnetite's store, ZFS datasets and garbage collection have behaved since the storage tuning of roughly two months ago.
+They turn out to be independent.
+The storage stack is healthy and is not implicated; the evaluation slowdown lives in substituter round trips reaching the evaluator through the nix daemon.
+Everything below separates what was measured from what was inferred, and every host command was read-only: no service was started, stopped or reloaded, no check was cancelled, no garbage collection was run, no store path was deleted, and no ZFS property or snapshot was touched.
+
+## The reported hypothesis is refuted
+
+The reading under test was that buildbot-nix had been configured far more permissively about concurrent evaluators than the nixbot configuration that replaced it, and that the right knobs had neither been found nor dialled in.
+Read against both upstream sources, that is not what happened.
+buildbot-nix serializes evaluation globally with `util.MasterLock("nix-eval")` in `buildbot_nix/__init__.py`, consumed at `nix_eval.py`, and nixbot serializes it with `eval_concurrency: int = 1` in `nixbot/config.py`, enforced as an `asyncio.Semaphore` in `orchestrator.py`.
+Both permit exactly one evaluation at a time, and they always did.
+On the one dial where the two differ, the migration went the more permissive way rather than the less: buildbot-nix ran `evalWorkerCount = 4` and nixbot now runs 6, raised in PR 2869 (merged 2026-08-29T03:16Z) precisely to shorten the serial chain.
+
+There is also no knob left to turn, which matters more than the refutation.
+At the pinned rev `660d7182`, nixbot's NixOS module builds its config JSON from a closed attrset that `ExecStart` consumes directly, with no freeform settings escape and no `evalConcurrency` or `evalTimeout` option; `eval_concurrency` and the 3600 second `eval_timeout` are therefore unreachable from this repository at any value.
+`buildConcurrency` is unset and resolves to the CPU count, 16, so build concurrency is already saturating.
+`evalWorkerCount` is already at the largest value whose memory cap stays enforceable: nixbot evaluates inside a cgroup capped at `evalMaxMemorySize x (evalWorkerCount + 1)`, so 6 workers at 2048 MiB cap the tree at 14 GiB against 17-20 GiB available, where 8 would imply 18 GiB.
+A cap that cannot fire before the host itself exhausts is not a cap, and exceeding the cgroup is an `EvalOOMError`, which fails the pull request permanently with no retry.
+
+The claim that two evaluations were in flight simultaneously is also refuted, by the service's own database.
+Exactly one build row exists for head `e8b2ceb20` (build 184, created 00:11:39.816696+00), its status is `pending` and its `started_at` is `NULL`: it was queued behind the evaluation semaphore and never started.
+Head `61b997f60` matches no build row at all.
+A queued build's GitHub check run already reports `in_progress`, so queue time is indistinguishable from evaluation time from the outside, which is what made one waiting build look like a second running one.
+The 50-minute run attributed to `9769a88d5` was queue wait behind the preceding evaluation, then supersession while still pending.
+
+## What the evaluation is actually doing
+
+Measured, on build 172 (PR 2908, 117 attributes, 490 seconds end to end).
+The evaluation opens with a burst of roughly 75-90 seconds in which six `nix-eval-jobs` workers each hold 75-85% of a core, churning at about one worker lifetime per attribute.
+Then the workers disappear entirely.
+For the remaining 6.5-7 minutes the master process has zero children, sits in `unix_stream_read_generic` on the nix-daemon UNIX socket, takes about 48 reads per second, and its `voluntary_ctxt_switches` count is flat across samples 30 seconds apart, meaning the main thread is fully parked.
+Child CPU accounting confirms the shape: 469.5 seconds of reaped child CPU all landed inside the first 75-90 seconds, after which CPU is near zero.
+Roughly 85% of that healthy evaluation's wall clock is that single wait.
+
+The daemon on the other end of the socket is not working either.
+It idles at a few percent CPU while holding established TLS connections to the caches, and its journal over four hours contains zero `unable to download` lines, zero TLS errors, and no retry storms.
+Host-wide during the slow window: load 1.11 across 16 CPUs, `vmstat wa=0` in every sample, 88-97% idle, ARC hit ratio 99% over 18 days, and no swap activity against a 30 GiB zram device.
+The eval cgroup sat at 272 MiB of its 14336 MiB cap with `oom_kill=0`.
+
+Attribute count is not the variable.
+The `build_attributes` table records 117 attributes for builds 161 through 172 and 176 alike, and those same 117 attributes produced evaluations of roughly 200 seconds and of 3312 seconds.
+Build 168 (PR 2904) is the worst case and it did not merely run slowly: it was killed at nixbot's hard 3600 second `eval_timeout`, recorded verbatim as `"msg": "evaluation failed", "build_id": 168, "error": "evaluation timed out after 3600 seconds"`, which is a permanent failure with no retry.
+
+The mechanism connecting these is `--check-cache-status`, which nixbot hard-codes in its `nix-eval-jobs` invocation alongside `--option eval-cache false` and `--force-recurse`.
+Every evaluated attribute's closure must be resolved against the configured substituters before the evaluation can finish, and there are nine of them.
+The evaluator cannot reach the network itself: `nixbot.service` sets `RestrictAddressFamilies=AF_UNIX` and runs `nix-eval-jobs` under bwrap, so every substituter byte flows through the daemon over the socket the master is parked on.
+
+Latency was measured with curl from magnetite against all nine endpoints, medians of three, for a hash that exists and a hash that cannot.
+Miss totals: cache.nixos.org 145 ms, nix-community.cachix.org 169, cache.numtide.com 128, cache.clan.lol 92, pyproject-nix.cachix.org 158, catppuccin.cachix.org 155, cuda-maintainers.cachix.org 173, cache.scientistexperience.net 74, cameronraysmith.cachix.org 181.
+Those sum to roughly 1.27 seconds of serial-equivalent latency for a single path absent from every cache.
+The cost is round trips rather than connection setup: connect is uniformly 7-9 ms and the TLS handshake 22-57 ms, and keep-alive reuse demonstrably works, with a warm hit on a reused connection costing 5.6-6.3 ms against 33.7 ms cold.
+The specific network hypothesis of broken connection reuse is therefore refuted too: the CLOSE-WAIT count at measurement was 1, not a pileup, and the cachix-family 404s carry 100-150 ms of server think time behind Cloudflare rather than any handshake cost.
+
+## The change that shipped, and what it does not fix
+
+Since no nixbot-level concurrency dial is both available and safe, the change raises the daemon's ceiling on concurrent cache round trips, in `modules/machines/nixos/magnetite/default.nix` beside the existing host-level nix tuning.
+`http-connections` goes from its default 25 to 100, bounded by file descriptors and outbound sockets.
+`max-substitution-jobs` goes from its default 16 to 32, bounded by CPU for decompression and by network for the transfers.
+Both oversubscribe the 16 cores on purpose, because the work they bound is latency-bound rather than CPU-bound, which is what an idle host blocked on cache round trips demonstrates.
+Neither is bounded by RAM: they apply to `nix-daemon.service`, outside the eval cgroup whose 14 GiB cap is the one ceiling that must stay enforceable, and 100 curl handles cost single-digit MiB against 20 GiB available.
+`http-connections` is the dial the measurement shows binding; `max-substitution-jobs` is build-side and is not measured as binding, and is raised only because it was an untuned default on the same latency-bound path.
+
+Whether this alone restores the 9m41s baseline cannot be determined from what was measured, and the honest answer is that it is unlikely to do so by itself.
+The measured park phase accounts for 85% of a healthy 8-minute evaluation, and raising the round-trip ceiling should compress that phase directly.
+It does not explain the multiplier that turns a 200 second evaluation into a 3312 second one at identical attribute count.
+No slow evaluation was live during measurement, so the split of a 3312 second run into burst and park was never observed, and the per-evaluation query count could not be counted because the `eval-gcroots` directories for builds 168, 171, 172 and 173 are cleaned after each build.
+Two candidate multipliers remain untested: closure-scale path fan-out of order 10^4 to 10^5 lookups, and evaluation-CPU variance on those particular branches, where a longer burst rather than a longer park would be the signature.
+Distinguishing them needs a 15 minute strace and socket capture during one live slow evaluation, which is the next measurement to take rather than a thing to guess at now.
+
+Storage is not implicated, and that conclusion is firm rather than provisional: no storage resource was near a limit, IO wait was zero throughout, and no maintenance window overlaps the slow evaluation.
+
+## Storage and garbage collection audit
+
+Magnetite is a Hetzner CX53 KVM guest with 16 EPYC-Rome vCPUs and 30.6 GiB RAM (`MemTotal 32091048 kB`), 20 GiB available at measurement, plus a 30 GiB zram swap device carrying 2.2 GiB with no active paging.
+The pool `zroot` is single-disk, 304G, 24% allocated, 46% fragmented, ONLINE, with a scrub that repaired 0B with 0 errors on 2026-09-01.
+`zroot/root/nix` holds 62.8G compressed and 127G logical at compressratio 2.06x under a 250G quota, with 187G available and zero snapshots.
+The store contains 112779 paths by `nix path-info --all | wc -l`, `/nix/var/nix/builds` is empty, and `/nix/var/nix/gcroots` holds 5 entries.
+`zroot/root/nixos` carries a 10G reservation and `zroot/root/home` a 4G reservation, both live.
+Compression is lz4 fleet-wide with a 128K recordsize.
+Snapshots total 32 across four datasets at about 309 MiB of unique space, decomposing exactly as 4 hourly, 3 daily and 1 weekly per dataset, with none on nix, docker or podman.
+ARC sits at 5.07 GiB of a 29.6 GiB `c_max` with a 99.0% hit ratio, and no `zfs_arc_max` tuning exists anywhere in the repository.
+Nothing approaches any limit.
+
+The storage tuning cluster is late May with a June 10 incident-response pair, which at 12 weeks is the closest thing to the remembered "two months ago".
+`9bfc0c959` (2026-04-05) laid down the disko layout, pool and datasets.
+`cc1921d67` and `0425a32e7` (2026-04-09) added zram swap.
+`d5b7bf117` (2026-05-24) set `com.sun:auto-snapshot=false` on `root/nix`, `b19f746a2` (2026-05-24) set retention to frequent 0, hourly 4, daily 3, weekly 1, monthly 0, and `a0d5f6450` (2026-05-24) set min-free 5G and max-free 20G.
+`220b8a6ba` and `7051ee95a` (2026-05-25) added boot-time oneshots asserting the snapshot opt-outs.
+The two incident commits are the important ones: `aca5c708b` (2026-06-10) imposed `quota=250G` on `root/nix` with 10G and 4G reservations, in response to `/nix` consuming the entire 304G pool, and `e456caf62` (2026-06-10) raised min-free to 30G and max-free to 80G, forced `nix.gc.options` to `--delete-older-than 7d`, and added a tmpfiles rule reaping `/nix/var/nix/builds` at 1 day after an ENOSPC crash loop orphaned 201 sandboxes and 232 GiB.
+
+Garbage collection and cache management have worked, and the evidence is timer and journal history rather than declared configuration.
+`nix-gc` and `nix-optimise` each fired and finished successfully on 63 of 63 retained journal days, 2026-07-01 through 2026-09-01, with real frees each run: 29.6 GiB on Jul 20, 76.5 GiB across 56404 paths on Aug 3, 0 on Aug 23, 44.2 GiB on Aug 26, and 21.7 GiB across 24086 paths on Sep 1, alongside daily hardlink savings of 12.4 to 31.1 GiB (14.3 GiB currently).
+`niks3-gc` ran the night before the audit and completed successfully, deleting 431 old closures and 30719 objects with zero failures.
+All six ZFS assert and enforce oneshots report active, the 1-day builds reaper holds, monthly scrub and weekly zpool-trim are current, and no declared timer has failed or never fired.
+The one evidentiary boundary worth naming: the journal's retained window begins 2026-07-01, so firing between June 10 and June 30 cannot be proven from it.
+With `Persistent=true`, 63 of 63 days since, and correct current state, there is no positive evidence of a gap either; this is a limit on the evidence rather than a suspected failure.
+
+Declared intent matches measured reality on every axis checked, including the 250G quota, both reservations, the snapshot opt-outs and their exact retention counts, the 30G and 80G thresholds in the live `nix.conf`, the 7 day retention, and the empty builds directory.
+The split of `nix.optimise.automatic = true` against `auto-optimise-store = false` is intended rather than a defect: optimisation is batched nightly rather than paid per build.
+No storage or garbage-collection change is warranted; every mechanism is functioning and the store sits at roughly a quarter of its quota.
+
+Three items are recorded as unapplied recommendations.
+First, magnetite's effective `substituters` list contains `cache.nixos.org` twice, once as configured and once as `https://cache.nixos.org/` contributed by the nixpkgs default, because `nix.settings.substituters` has a list type and list options merge by concatenation across modules.
+If nix does not normalise the two forms to one store, every all-miss path pays a redundant round trip of about 145 ms, roughly 11% of the nine-endpoint fan-out; whether it normalises was not established, and `lib/caches.nix` is shared by the nixos, darwin and `flake.nix` `nixConfig` consumers, so this wants confirming before editing a cross-cutting file.
+Second, the pending nixbot input bump to `660d7182` carries nix 2.35.2 with the `srcToStore` evaluation-performance patch (NixOS/nix#16190) and a prefetch-input deduplication patch (nixbot #153); the running service predates the pin and has not restarted since 2026-08-29, so deploying it requires a deliberate restart that was out of bounds during this work.
+Third, if a hard memory reserve for concurrent evaluation is ever wanted, the lever is `boot.kernelParams = [ "zfs.zfs_arc_max=17179869184" ]` for a 16 GiB ARC cap, bounded by 30.6 GiB total RAM against a current 5.07 GiB of ARC use; it is not recommended now, since ARC is reclaimable under pressure, is not binding at a 99% hit ratio, and capping it could only hurt exactly the metadata reads this workload depends on.

--- a/modules/machines/nixos/magnetite/default.nix
+++ b/modules/machines/nixos/magnetite/default.nix
@@ -259,50 +259,9 @@ in
       # srvos both set 512 MiB / 3 GiB via mkDefault, which is undersized for
       # buildbot-nix workers materializing large closures on a CX53 with niks3
       # GC pressure. Trigger GC at 30 GiB free, free until 80 GiB available.
-      #
-      # http-connections and max-substitution-jobs raise the daemon's ceiling on
-      # concurrent cache round trips. Both were at their nix defaults, and the
-      # daemon is where every substituter byte originates: nixbot.service sets
-      # RestrictAddressFamilies=AF_UNIX and runs nix-eval-jobs under bwrap, so
-      # the evaluator reaches the network only by asking the daemon over its
-      # UNIX socket. nixbot hard-codes --check-cache-status in that invocation
-      # (nix_eval.py), so every evaluated attribute's closure is resolved
-      # against all nine configured substituters before the evaluation can
-      # finish, and neither the flag nor nixbot's eval_concurrency is reachable
-      # from its NixOS module.
-      #
-      # Measured on 2026-09-02, build 172 (117 attributes, 490 s): a ~75-90 s
-      # burst where six nix-eval-jobs workers each hold 75-85% of a core, then
-      # 6.5-7 min in which the master has no children at all and sits in
-      # unix_stream_read on the daemon socket with a flat
-      # voluntary_ctxt_switches count, taking ~48 reads/s, while the daemon
-      # itself idles at a few percent CPU holding established TLS connections
-      # to the caches. 85% of that evaluation's wall clock is this wait. Host
-      # load was 1.11 of 16 CPUs with vmstat wa=0, so it is neither CPU nor IO
-      # saturation. A path absent from every cache costs the sum over the nine
-      # endpoints, ~1.27 s of serial-equivalent latency measured by curl, of
-      # which TLS is only 30-65 ms: the cost is round trips, not handshakes,
-      # and keep-alive reuse was confirmed working (6 ms warm hit).
-      #
-      # Both dials therefore oversubscribe relative to the 16 cores on purpose,
-      # because the work they bound is latency-bound rather than CPU-bound.
-      # Neither is bounded by RAM: they live in nix-daemon.service, outside the
-      # eval cgroup whose evalMaxMemorySize x (evalWorkerCount + 1) = 14 GiB cap
-      # is the one ceiling that must stay enforceable, since exceeding it fails
-      # a pull request permanently with no retry. A curl handle costs tens of
-      # KiB, so 100 connections is single-digit MiB against 20 GiB available.
       nix.settings = {
         min-free = 30 * 1024 * 1024 * 1024;
         max-free = 80 * 1024 * 1024 * 1024;
-
-        # Default 25. Bounded by file descriptors and outbound sockets.
-        http-connections = 100;
-
-        # Default 16. Bounded by CPU for decompression and by network for the
-        # transfers themselves; unlike http-connections this one is not measured
-        # as binding, because the wait above is evaluation-time narinfo
-        # resolution rather than build-time substitution.
-        max-substitution-jobs = 32;
       };
 
       # base sets nix.gc.options fleet-wide as a plain string (modules/system/

--- a/modules/machines/nixos/magnetite/default.nix
+++ b/modules/machines/nixos/magnetite/default.nix
@@ -259,9 +259,50 @@ in
       # srvos both set 512 MiB / 3 GiB via mkDefault, which is undersized for
       # buildbot-nix workers materializing large closures on a CX53 with niks3
       # GC pressure. Trigger GC at 30 GiB free, free until 80 GiB available.
+      #
+      # http-connections and max-substitution-jobs raise the daemon's ceiling on
+      # concurrent cache round trips. Both were at their nix defaults, and the
+      # daemon is where every substituter byte originates: nixbot.service sets
+      # RestrictAddressFamilies=AF_UNIX and runs nix-eval-jobs under bwrap, so
+      # the evaluator reaches the network only by asking the daemon over its
+      # UNIX socket. nixbot hard-codes --check-cache-status in that invocation
+      # (nix_eval.py), so every evaluated attribute's closure is resolved
+      # against all nine configured substituters before the evaluation can
+      # finish, and neither the flag nor nixbot's eval_concurrency is reachable
+      # from its NixOS module.
+      #
+      # Measured on 2026-09-02, build 172 (117 attributes, 490 s): a ~75-90 s
+      # burst where six nix-eval-jobs workers each hold 75-85% of a core, then
+      # 6.5-7 min in which the master has no children at all and sits in
+      # unix_stream_read on the daemon socket with a flat
+      # voluntary_ctxt_switches count, taking ~48 reads/s, while the daemon
+      # itself idles at a few percent CPU holding established TLS connections
+      # to the caches. 85% of that evaluation's wall clock is this wait. Host
+      # load was 1.11 of 16 CPUs with vmstat wa=0, so it is neither CPU nor IO
+      # saturation. A path absent from every cache costs the sum over the nine
+      # endpoints, ~1.27 s of serial-equivalent latency measured by curl, of
+      # which TLS is only 30-65 ms: the cost is round trips, not handshakes,
+      # and keep-alive reuse was confirmed working (6 ms warm hit).
+      #
+      # Both dials therefore oversubscribe relative to the 16 cores on purpose,
+      # because the work they bound is latency-bound rather than CPU-bound.
+      # Neither is bounded by RAM: they live in nix-daemon.service, outside the
+      # eval cgroup whose evalMaxMemorySize x (evalWorkerCount + 1) = 14 GiB cap
+      # is the one ceiling that must stay enforceable, since exceeding it fails
+      # a pull request permanently with no retry. A curl handle costs tens of
+      # KiB, so 100 connections is single-digit MiB against 20 GiB available.
       nix.settings = {
         min-free = 30 * 1024 * 1024 * 1024;
         max-free = 80 * 1024 * 1024 * 1024;
+
+        # Default 25. Bounded by file descriptors and outbound sockets.
+        http-connections = 100;
+
+        # Default 16. Bounded by CPU for decompression and by network for the
+        # transfers themselves; unlike http-connections this one is not measured
+        # as binding, because the wait above is evaluation-time narinfo
+        # resolution rather than build-time substitution.
+        max-substitution-jobs = 32;
       };
 
       # base sets nix.gc.options fleet-wide as a plain string (modules/system/


### PR DESCRIPTION
Three independent findings with three different owners. Only the first is a code change; the second is an accepted architectural constraint and the third is a policy choice. Full write-up: `docs/notes/development/incidents/2026-09-02-nixbot-eval-throughput-magnetite-storage-audit.md`.

## The change, and what bounds each value

| option | old | new | bounded by |
| --- | --- | --- | --- |
| `nix.settings.http-connections` | 25 (nix default, absent from config) | 100 | **file descriptors and outbound sockets.** ~100 curl handles at tens of KiB each is single-digit MiB against 20 GiB available; `connect-timeout = 5` already caps a hung endpoint |
| `nix.settings.max-substitution-jobs` | 16 (nix default, absent from config) | 32 | **CPU for decompression, network for the transfers.** 16 vCPUs, deliberately 2x oversubscribed because the work is latency-bound |

**Neither is bounded by RAM, which is the bound that matters here.** Both apply to `nix-daemon.service`, *outside* the eval cgroup whose `evalMaxMemorySize x (evalWorkerCount + 1)` = 14 GiB ceiling must stay enforceable, because exceeding it raises `EvalOOMError` and fails a pull request permanently with no retry. `evalWorkerCount` stays **6** and `evalMaxMemorySize` stays **2048** for exactly that reason: 8 workers would imply 18 GiB against 17-20 GiB available, and a cap that cannot fire before the host exhausts is not a cap. buildbot-nix keeps 4 x 2048 for its Gitea repositories, so the combined ceiling is 22 GiB against 30.6 GiB physical.

Both dials oversubscribe the 16 cores on purpose, because latency-bound work is what an idle host blocked on cache round trips demonstrates.

## Finding 1 — per-evaluation cost is substituter fan-out through the daemon (this change)

Measured, build 172 (PR 2908, 117 attributes, 490s): a ~75-90s burst with six `nix-eval-jobs` workers each at 75-85% of a core, then **6.5-7 minutes with zero children**, master parked in `unix_stream_read_generic` on the nix-daemon socket at ~48 reads/s with a flat `voluntary_ctxt_switches` count. All 469.5s of reaped child CPU landed in that opening burst. **85% of a healthy evaluation's wall clock is that one wait.**

This reconciles the two readings that looked like evidence against any cause existing. Sampling the *evaluator* processes for established connections finds zero — correct and uninformative, because `nixbot.service` sets `RestrictAddressFamilies=AF_UNIX` and wraps `nix-eval-jobs` in bwrap, so it cannot hold a socket; all nine substituter connections belong to nix-daemon, a third process in neither sample, where 8 ESTAB TLS connections were found. A master blocked in a socket read with zero children is likewise invisible to load average, which is why six configured workers presented as one busy core.

`--check-cache-status` is hard-coded by nixbot, so every attribute's closure resolves against all **nine** substituters. Measured with curl from magnetite, all nine, hit and miss: an all-miss path costs **~1.27s of serial-equivalent latency**, of which TLS is only 30-65ms. Keep-alive reuse works (5.6-6.3ms warm vs 33.7ms cold), CLOSE-WAIT was 1, and the daemon journal shows zero download errors — so the poor-reuse hypothesis is refuted alongside the naive one.

This supplies the state dependence a static command line could not: 117 attributes produced both ~200s and 3312s evaluations, and what varies is how many paths are unknown to the narinfo cache. `main` advancing turns warm paths all-miss. Memory is ruled out by the service's own semantics: a cgroup overrun *fails* the PR, PR 2890's check had not failed, and the cgroup sat at 272 MiB of 14336 with `oom_kill=0`.

## Finding 2 — global serialization is architectural, accepted, not tuned

buildbot-nix serializes with `util.MasterLock("nix-eval")`; nixbot with `eval_concurrency = 1` as an `asyncio.Semaphore`. **Both are 1 and always were**, and the migration went *more* permissive on the only differing dial (workers 4→6, #2869). At pinned rev `660d7182` nixbot's module builds its config JSON from a closed attrset consumed directly by `ExecStart` — no freeform escape, no `evalConcurrency`/`evalTimeout` option, so neither is settable here at any value. `buildConcurrency` already resolves to 16 = CPU count. No knob remains, and patching or unpinning buys a gain the memory ceiling caps anyway against the one unrecoverable failure mode.

The apparent second concurrent evaluation is refuted from nixbot's DB: build 184 for `e8b2ceb20` is `pending` with `started_at NULL` — queued, never started — and `61b997f60` has no build row. A queued build's check run already reads `in_progress`.

## Finding 3 — queue load, with the arithmetic

Measured: `eval-gcroots` advanced 171 → 186 between 01:15 and 02:00 — **fifteen evaluations in forty-five minutes**, ~180s each, separate runs with gaps, not a retry loop.

The queue is larger than the prompting window suggested. `gh-axi pr list --state open` at 02:10: **thirty open PRs, twenty-three bot-authored** — seventeen `vanixiets-flake-updater` (2891, 2892, 2895-2909) and six `renovate` (2613, 2881, 2910-2913) — against seven human-authored (2747, 2772, 2777, 2878, 2890, 2893, 2914). So 23 of 30, not six of eight.

On a strictly serial evaluator: one evaluation per automated PR is **4140s ≈ 69 min** at the measured 180s mean, or **11270s ≈ 3h08m** at build 172's 490s. A single slow-class member is worse than the whole fast sweep — build 171's 3312s consumed 55 minutes of the only evaluator, and build 168 consumed the full 3600s timeout then failed permanently. **That is why PR 2890's check sat in progress for 100 minutes without its own evaluation being slow.**

The three findings compound. A flake-input bump invalidates the closure and converts warm paths to all-miss, so the automated PRs are each drawn from finding 1's expensive class *and* metered through finding 2's one-at-a-time queue. Seventeen are input bumps by construction. The lever is policy: batch the seventeen into one PR (loses per-input bisection), schedule or rate-limit whatever opens them (slower dependency freshness), or accept the queue knowingly — in which case a human PR's check latency is set by bot queue depth at landing and should not be read as a regression.

## Finding 3's input — this repository's own check set, priced

117 attributes, matching the service's recorded count. **11 FULL-ACT** (6 home-manager `activationPackage` in `home.nix:38`; 5 NixOS `system.build.toplevel` in `machines.nix:32`), **5 FULL-eval**, **12 MODULE**, **89 CHEAP**.

Measured evaluation cost (warm, `eval-cache false`): `home-manager-crs58` 9.26s / 2.38 GB / 20.4M thunks; `nixos-magnetite` 10.78s / 2.85 GB / 27.1M thunks; FULL-eval 2.58-3.62s; MODULE and CHEAP 1.43-1.63s against a **1.45s flake floor every check pays** because the eval cache is disabled.

Derivation-closure paths (`nix-store -q --requisites`, 113 of 117 measurable on darwin): NixOS toplevels **20,065-22,170** each, home activations **15,338-19,165**, every structural check **715**. Summed: **362,816**. Distinct union: **29,244** — the union is the real fan-out ceiling since the daemon deduplicates per path within a run, and the sum overstates. The eleven FULL-ACT checks are **9.4% of attributes, 57.2% of summed paths, and 13,872 paths reachable only through them: 47.4% of the union.** At ~1.27s/path a fully cold union bounds at ~10.3h; build 172's ~416s wait implies only a few hundred path-equivalents were actually unknown. Dropping FULL-ACT would cap the ceiling at 15,372 paths (−47%).

crs58's home config is evaluated **4x** and magnetite's NixOS config **3x**; `nix-eval-jobs` dispatches each attribute independently so no memoisation is possible across attributes — only reducing what is *bound* as a check reduces fan-out.

Reducibility, answered in both directions: FULL-ACT asserts a closure *builds* and no module-level evaluation can establish that, so it is genuinely full **in kind** and reducible only in **multiplicity** — six home activations occupy four distinct closure shapes, so canary-per-shape with the full set on scheduled runs costs per-user cache fill on PR runs, a tradeoff not a free win. The five FULL-eval checks should be **kept**: they assert real wiring of the *emitted* configurations at 715-3,121 path closures, and a minimal re-composition would assert a reconstruction instead. The repo already holds the cheaper idiom in `hm-sops-bridge-assertion-neg` and `structure/*`.

**Correction on PR 2890's `devin-worker.nix`:** its two full home-manager evaluations (lines 76-98, 125-145) evaluate *minimal probe* configurations, not this repo's `homeConfigurations`, and serialize only names, counts and booleans — on the closure-fan-out axis it is a cheap check. The follow-up proposing a third was **not located** in the PR body, its seven commit messages, either comment, the openspec corpus on that branch, or the devin files' markers; recorded as not found rather than assumed. If it lives in Linear, a pointer would let it be quoted.

## Storage and GC audit — healthy, not implicated

Verdict: **working as intended.** `nix-gc` and `nix-optimise` each fired and completed successfully **63 of 63 retained journal days** (Jul 1 - Sep 1) with real frees (76.5 GiB / 56404 paths Aug 3; 21.7 GiB / 24086 paths Sep 1) and 14.3 GiB current hardlink savings; `niks3-gc` ran clean the night before, deleting 431 closures and 30719 objects. `/nix` is 62.8G of a 250G quota with zero snapshots, pool 24% full, scrub clean, ARC 99%, `wa=0` throughout. Tuning commits: `aca5c708b` and `e456caf62` (2026-06-10 incident response), preceded by `d5b7bf117`, `b19f746a2`, `a0d5f6450`, `220b8a6ba`, `7051ee95a` (May 24-25) and `9bfc0c959` (April layout). Declared intent matches measured reality on every axis. No storage change warranted; maintenance windows are disjoint from the slow-evaluation window.

Evidentiary boundary stated rather than papered over: the journal retains from Jul 1, so Jun 10-30 firing cannot be proven from it; with `Persistent=true` and 63/63 since, there is no positive evidence of a gap either.

## Will this restore 9m41s?

It compresses the wait that is 85% of a healthy evaluation — real and measured. It will **not** by itself return check latency to 9m41s while twenty-three automated PRs are queued ahead, because latency is queue depth × per-evaluation cost and this addresses only the second factor. The single-evaluation residual is also not fully accounted for: no slow evaluation was live during measurement and `eval-gcroots` are cleaned post-build, so the per-eval query count was uncountable. Two candidates remain — closure-scale fan-out of order 10⁴-10⁵ (consistent with the 29,244-path union going cold on an input bump) versus eval-CPU variance on those branches (signature: longer burst, not longer park) — separable by a 15-minute strace during one live slow evaluation. **Storage being uninvolved is firm.**

## Verification

Configuration-only change altering no derivation logic:

- `nix eval` on the evaluated host config: `http-connections=100 max-substitution-jobs=32 evalWorkerCount=6 evalMaxMemorySize=2048` — raised values land, memory-critical ones untouched.
- Built and inspected the generated `/etc/nix/nix.conf` the daemon actually reads (`/nix/store/g7fwvgwr9xs5lyv5dllnnr7xbd4mvnm2-nix.conf`): both values present. Artifact-level proof, not option-level.
- `checks.x86_64-linux.nixos-magnetite` and `checks.x86_64-linux.nixbot-wiring` both evaluate to a drvPath, proving the host toplevel and nixbot wiring still compose.
- `gitleaks` and `treefmt` pass via pre-commit on every commit.

Deliberately not run: the full check set. Nothing outside magnetite's `nix.settings` changed, and `nixbot-wiring` pins no concurrency values (verified: neither `evalWorkerCount` nor `evalMaxMemorySize` appears in its oracle), so no other check could falsify this. Recorded per #2869's trap: the toplevel drvPath is not a comment-only invariant, since the flake source is a closure input.

The branch carries a revert and a reapply of the same commit. That is deliberate history rather than noise: the change was withdrawn on instruction and restored when the measurement reached the supervisor, and both commit messages record the reasoning so the decision is auditable rather than silently reversed.

## Boundaries observed, and one breach disclosed

No service restarted, reloaded or stopped; no check cancelled; no GC run; no store path deleted; no ZFS property or snapshot touched; kanidm, gitea and operator-facing network configuration untouched. **Deploying this requires a nix-daemon restart on magnetite, not performed here** — an evaluation the operator is waiting on was in flight throughout.

One breach to disclose: the check-set enumeration initially forced IFD, and this workstation delegates builds to `ssh-ng://builder@magnetite`, so about ten small derivations (cilium CRD YAML conversions) built there over roughly four minutes before the process was killed and `--option builders ''` was pinned for every subsequent invocation. No service state was mutated and nothing was cancelled, but it was host contact the investigation was told not to make, and it consumed a few minutes of the machine the operator was waiting on.
