### PR TITLE
feat(pkgs): package mergify CLI as mergify-cli-bin and wire it home

### DIFF
--- a/modules/apps/updates.nix
+++ b/modules/apps/updates.nix
@@ -60,6 +60,11 @@
         program = "${config.packages.worktrunk-bin.updateScript}";
       };
 
+      apps.update-mergify-cli-bin = {
+        type = "app";
+        program = "${config.packages.mergify-cli-bin.updateScript}";
+      };
+
       apps.update-buzz-source = {
         type = "app";
         program = "${config.packages.buzz-source.updateScript}";

--- a/modules/home/development/mergify.nix
+++ b/modules/home/development/mergify.nix
@@ -1,0 +1,38 @@
+# The Mergify CLI, as a member of the homeManager.development aggregate.
+#
+# Upstream ships no home-manager, nixos, or darwin module, so this file declares
+# options.programs.mergify itself and owns the package: nothing installs
+# mergify from a shared package aggregate.
+{ ... }:
+{
+  flake.modules.homeManager.development =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.mergify;
+    in
+    {
+      options.programs.mergify = {
+        enable = lib.mkEnableOption "the Mergify CLI, whose `mergify stack` subcommand drives stacked-pull-request landing";
+
+        package = lib.mkPackageOption pkgs "mergify-cli-bin" { };
+      };
+
+      config = {
+        # Self-enabling, matching gh: every development user gets it. mkDefault
+        # so a machine or user module can disable it without a definition
+        # collision.
+        programs.mergify.enable = lib.mkDefault true;
+
+        home.packages = lib.mkIf cfg.enable [ cfg.package ];
+
+        # No configuration file is managed: every API-touching command resolves
+        # its credential from MERGIFY_TOKEN, GITHUB_TOKEN, or a per-command
+        # --token, so there is no non-secret settings surface to render.
+      };
+    };
+}

--- a/pkgs/by-name/mergify-cli-bin/package.nix
+++ b/pkgs/by-name/mergify-cli-bin/package.nix
@@ -1,0 +1,89 @@
+# mergify-cli-bin: prebuilt release binaries for the Mergify CLI, whose
+# `mergify stack` subcommand drives stacked-pull-request landing.
+#
+# A proxy over upstream's release artifacts rather than a from-source build:
+# the Rust workspace at crates/ carries a `0.0.0` placeholder in Cargo.toml and
+# the real version is stamped into the binary at release time, so a source build
+# cannot reproduce the version the CLI reports.
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  versionCheckHook,
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+  # Hashes are the release's SHA256SUMS entries converted to SRI, not values
+  # guessed by a prefetch: upstream publishes one hex line per asset.
+  systemToPlatform = {
+    "x86_64-linux" = {
+      triple = "x86_64-unknown-linux-gnu";
+      hash = "sha256-B73d7l56XjLfRVni7PMWSnpL8AoOLJ/W/2OC62tHziQ=";
+    };
+    "aarch64-linux" = {
+      triple = "aarch64-unknown-linux-gnu";
+      hash = "sha256-qdpYOxUd50YFUjk8QBSzTOkQetCz8ZKuZ8O3daycb6g=";
+    };
+    "x86_64-darwin" = {
+      triple = "x86_64-apple-darwin";
+      hash = "sha256-dB7n4Z/wZ+sKDbEK6tr3l4fLgPi40KaIKtbc7gGrB0o=";
+    };
+    "aarch64-darwin" = {
+      triple = "aarch64-apple-darwin";
+      hash = "sha256-tmyLfINMMX0Te+FoC2HN5VVd6wf3Rt1mrlr2NZHdON0=";
+    };
+  };
+  platform = systemToPlatform.${system} or (throw "mergify-cli-bin: unsupported platform ${system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mergify-cli-bin";
+  # Bare calver with no `v` prefix, matching the upstream tag exactly.
+  version = "2026.8.31.1";
+
+  src = fetchurl {
+    url = "https://github.com/Mergifyio/mergify-cli/releases/download/${finalAttrs.version}/mergify-${finalAttrs.version}-${platform.triple}.tar.gz";
+    hash = platform.hash;
+  };
+
+  # Each archive holds the bare `mergify` binary at its root with no enclosing
+  # directory, so stdenv's single-directory unpack detection has nothing to
+  # descend into.
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # Required, not defensive: the Linux artifacts are glibc-dynamic PIEs
+  # (NEEDED: libc.so.6, libdl.so.2, libgcc_s.so.1, libm.so.6, libpthread.so.0,
+  # librt.so.1), so both the interpreter and the libgcc_s lookup need rewriting.
+  # Darwin artifacts are ad-hoc-signed Mach-O and need no patching.
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib # libgcc_s.so.1
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 mergify $out/bin/mergify
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/mergify";
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Mergify CLI for stacked pull requests and CI insights (prebuilt release binary)";
+    homepage = "https://github.com/Mergifyio/mergify-cli";
+    changelog = "https://github.com/Mergifyio/mergify-cli/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "mergify";
+    platforms = lib.attrNames systemToPlatform;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ cameronraysmith ];
+  };
+})

--- a/pkgs/by-name/mergify-cli-bin/update.sh
+++ b/pkgs/by-name/mergify-cli-bin/update.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p curl cacert git nix coreutils gnused gawk
+# shellcheck shell=bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PKG_NIX="${REPO_ROOT}/pkgs/by-name/mergify-cli-bin/package.nix"
+
+current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
+
+# Tag discovery deliberately avoids api.github.com, which is rate-limited on
+# the shared egress: the unauthenticated releases/latest URL 302s to the tag
+# page, so the redirect target names the release.
+latest_url="$(curl -fsIL -o /dev/null -w '%{url_effective}' \
+  "https://github.com/Mergifyio/mergify-cli/releases/latest")"
+latest_version="${latest_url##*/}"
+
+# Tags are bare calver with no `v` prefix (for example 2026.8.31.1); reject
+# anything else rather than stamping a redirect that landed somewhere unexpected.
+if [[ ! "$latest_version" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "error: releases/latest redirected to ${latest_url}, which names no calver tag" >&2
+  exit 1
+fi
+
+if [[ "$current_version" == "$latest_version" ]]; then
+  echo "mergify-cli-bin is already at version ${current_version}; refreshing hashes anyway"
+else
+  echo "Updating mergify-cli-bin: ${current_version} -> ${latest_version}"
+  sed -i'' -e "s/version = \"${current_version}\"/version = \"${latest_version}\"/" "$PKG_NIX"
+fi
+
+# Hashes come from the release's own SHA256SUMS asset (one hex line per asset),
+# so the recorded hash is upstream's published digest rather than whatever a
+# prefetch happened to download.
+sha256sums="$(curl -fsSL \
+  "https://github.com/Mergifyio/mergify-cli/releases/download/${latest_version}/SHA256SUMS")"
+
+# Platform map: nix system -> Rust target triple (asset is
+# mergify-<version>-<triple>.tar.gz)
+declare -A platform_map=(
+  ["x86_64-linux"]="x86_64-unknown-linux-gnu"
+  ["aarch64-linux"]="aarch64-unknown-linux-gnu"
+  ["x86_64-darwin"]="x86_64-apple-darwin"
+  ["aarch64-darwin"]="aarch64-apple-darwin"
+)
+
+for platform in "${!platform_map[@]}"; do
+  triple="${platform_map[$platform]}"
+  asset="mergify-${latest_version}-${triple}.tar.gz"
+
+  hex_hash="$(awk -v asset="$asset" '$2 == asset { print $1 }' <<<"$sha256sums")"
+
+  if [[ -z "$hex_hash" ]]; then
+    echo "error: SHA256SUMS carries no line for ${asset}" >&2
+    exit 1
+  fi
+
+  sri_hash="$(nix hash convert --hash-algo sha256 --to sri "$hex_hash")"
+
+  # Anchor on this platform's `triple = "<triple>";` line, advance to the
+  # immediately-following `hash =` line, and substitute. Each triple is unique
+  # to a single block in package.nix, so exactly one hash line is rewritten.
+  sed -i'' -e "/triple = \"${triple}\";/{ n; s|hash = \"sha256-[^\"]*\"|hash = \"${sri_hash}\"|; }" "$PKG_NIX"
+
+  echo "  ${platform}: ${sri_hash} (${asset})"
+done
+
+echo "Updated mergify-cli-bin to ${latest_version}"


### PR DESCRIPTION
Adds `pkgs/by-name/mergify-cli-bin`, a proxy derivation over upstream's prebuilt release artifacts, its updater and update app, and `programs.mergify` in the `homeManager.development` aggregate.
Lane scope is the host binary only: nothing under `modules/home/ai/plugins/`, `apm.yml`, `apm.lock.yaml`, `apm-skills-compose`, or `pkgs/by-name/agent-plugins/` is touched, and no skills or plugin path was needed to make the build work.

## Why a proxy rather than a source build

The Rust workspace at `crates/` carries a `0.0.0` placeholder in `Cargo.toml` while the release tag is stamped into the binary, so a from-source build cannot reproduce the version the CLI reports.

## Deviations from the worktrunk-bin / uncomment-bin idiom

- `sourceRoot = "."` — each tarball holds the bare `mergify` binary at the archive root, so stdenv's single-directory unpack detection has nothing to descend into (verified: `tar tzf` lists exactly `mergify`).
- `autoPatchelfHook` is required, not defensive — the Linux artifacts are glibc-dynamic PIEs with `NEEDED` = `libc.so.6`, `libdl.so.2`, `libgcc_s.so.1`, `libm.so.6`, `libpthread.so.0`, `librt.so.1`, so `stdenv.cc.cc.lib` is a Linux `buildInput` for `libgcc_s`.
- Bare calver tags with no `v` prefix — neither the asset URL nor the updater's tag regex assumes one.
- Hashes come from the release's `SHA256SUMS` asset, converted to SRI, rather than from a prefetch.

Tag discovery avoids `api.github.com` (rate-limited on the shared egress) in both this PR's research and `update.sh`: the updater reads the `releases/latest` redirect target and rejects anything that is not a calver tag.

## Hash provenance

Each hash is the `SHA256SUMS` line for that asset at tag `2026.8.31.1`, run through `nix hash convert --hash-algo sha256 --to sri`:

| platform | `SHA256SUMS` line | recorded hash |
| --- | --- | --- |
| `x86_64-linux` | `07bdddee…ce24  mergify-2026.8.31.1-x86_64-unknown-linux-gnu.tar.gz` | `sha256-B73d7l56XjLfRVni7PMWSnpL8AoOLJ/W/2OC62tHziQ=` |
| `aarch64-linux` | `a9da583b…6fa8  mergify-2026.8.31.1-aarch64-unknown-linux-gnu.tar.gz` | `sha256-qdpYOxUd50YFUjk8QBSzTOkQetCz8ZKuZ8O3daycb6g=` |
| `x86_64-darwin` | `741ee7e1…074a  mergify-2026.8.31.1-x86_64-apple-darwin.tar.gz` | `sha256-dB7n4Z/wZ+sKDbEK6tr3l4fLgPi40KaIKtbc7gGrB0o=` |
| `aarch64-darwin` | `b66c8b7c…38dd  mergify-2026.8.31.1-aarch64-apple-darwin.tar.gz` | `sha256-tmyLfINMMX0Te+FoC2HN5VVd6wf3Rt1mrlr2NZHdON0=` |

## Home-manager wiring

Module-owns-package: `modules/home/development/mergify.nix` declares `options.programs.mergify` (upstream ships no home-manager module), self-enables with `lib.mkDefault true` as `gh.nix` does, and installs `cfg.package` gated on `enable`. No entry was added to any shared package aggregate. No configuration file is managed, because every API-touching command resolves its credential from `MERGIFY_TOKEN`, `GITHUB_TOKEN`, or a per-command `--token`, leaving no non-secret settings surface.

## Verification

Selected to cover the derivation, the module, and the updater, without a repository-wide run.

- `nix build .#mergify-cli-bin --no-link --print-out-paths` → `/nix/store/2xdhskfqigfwb5wlwvaz7lxhib3r0q5l-mergify-cli-bin-2026.8.31.1`; `versionCheckHook` passes and `$out/bin/mergify --version` prints `mergify 2026.8.31.1`.
- `nix build --option builders '' .#checks.aarch64-darwin.package-mergify-cli-bin .#checks.aarch64-darwin.updater-repository-paths .#checks.aarch64-darwin.structure-home-configurations` — all pass.
- Exactly-once: `nix eval --json --option builders '' '.#homeConfigurations."crs58@aarch64-darwin".config.home.packages' --apply 'map (p: p.pname or p.name)'` piped through `rg -i mergify | wc -l` → `1` (`"mergify-cli-bin"`).
- `update.sh` idempotence, demonstrated: a run while already current reports `already at version 2026.8.31.1; refreshing hashes anyway`, and `package.nix` stays byte-identical (`md5sum -c` OK, empty `git diff`).
- `prek run --files …` on all four touched files: `gitleaks` and `treefmt` pass.

Deliberately left out: the full parallel check run, and builds for the three non-`aarch64-darwin` platforms, which no local builder can produce — their hashes are upstream's published digests and CI covers those platforms.

One deviation from the evaluation-only flag pair to note: `--option builders ''` was used throughout, but `--option allow-import-from-derivation false` had to be dropped for the `homeConfigurations` eval because the pre-existing `modules/home/ai/skills/default.nix` aggregate requires IFD (`error: cannot build … source.drv^out during evaluation because the option 'allow-import-from-derivation' is disabled`). That is unrelated to this change; `builders ''` still guarantees nothing built on the remote builder.

