### PR TITLE
feat(stack-land): add hermetic checked landing

### DIFF
--- a/docs/notes/development/version-control/stacked-landing-settings-review.md
+++ b/docs/notes/development/version-control/stacked-landing-settings-review.md
@@ -1,0 +1,147 @@
+# Stacked landing mechanism and settings review
+
+This review is for the maintainer who will authorize the first live stacked landing.
+The settings below are proposals only; this change does not apply them.
+The mechanism was validated structurally against a local bare remote, and no commit was pushed to GitHub `main`.
+
+## Mechanism
+
+Run `just stack-land --dry-run --tip <stack-tip> <pr>...` to validate a stack without pushing.
+Run the same command without `--dry-run` to make one fast-forward-only update of `main` through `git push origin <tip>:refs/heads/main`.
+
+The script fails unless the fetched target base is an ancestor of the tip, every commit in the range carries exactly one valid `Change-Id`, every member PR has a non-empty JSON check set whose states are all `SUCCESS`, and every member PR reports `MERGED` with `mergedAt` set after the push.
+It fetches and repeats the ancestry check after the forge checks and immediately before the push.
+The push has no force option, so a competing non-fast-forward update is rejected by the remote.
+
+`bash scripts/test-stack-land.sh` creates its repository and bare `origin` below `.scratch/`, then removes that fixture when it exits.
+The test demonstrates failures for divergent ancestry, missing, duplicate, and malformed trailers, a `CANCELLED` check, an empty check set, a target change between the first and second ancestry checks, a target change in the pre-push race, and an open PR after a successful push.
+It also demonstrates a dry run that leaves `main` unchanged and a real local landing that advances `main` to the tip and observes all PRs as merged.
+
+The test is focused local evidence, not regression protection.
+The standing protection constraint leaves one design question for the flake/nixbot owner: expose this test as a nix flake check or add equivalent coverage in nixbot before making it mandatory.
+A GitHub Actions workflow or a command wrapper would not satisfy that constraint and was not added.
+
+## Nixbot proposal
+
+The unapplied repository diff is:
+
+```diff
+-effects_branches = ["*"]
+-effects_on_pull_requests = true
++effects_branches = ["main"]
++effects_on_pull_requests = false
+```
+
+The source review used `Mic92/nixbot` at `7235d8d43408c5f9cf9a43e1693256f067e3c188`, fetched read-only on 2026-09-02.
+The shallow clone's `git log --follow -1` records that boundary commit at `2026-09-01 22:12:57 +0200` for the files cited below.
+
+`nixbot/nixbot/repo_config.py:32-41` leaves `build_branches` unset unless the repository supplies it.
+`nixbot/nixbot/service.py:302-326` sends non-PR, non-default, non-merge-queue pushes through either the repository's `build_branches` or the service-wide branch rules.
+`nixbot/nixbot/webhooks.py:45-58` admits only the default branch, explicit branch rules, and the four merge-queue patterns.
+The deployed `services.nixbot.branches` evaluates to `{}`, using:
+
+```sh
+nix eval --json .#nixosConfigurations.magnetite.config.services.nixbot.branches \
+  --option builders '' \
+  --option allow-import-from-derivation false
+```
+
+Therefore pushes to `wip/*` and `stack/*` match neither the empty explicit rule set nor a merge-queue pattern and do not build.
+Pull requests still build because `service.py:308-326` applies that branch filter only when `pr_number` is absent.
+
+`nixbot/nixbot/effects.py:75-93` checks PR events first, so `effects_on_pull_requests = false` prevents PR effects even when the PR targets `main`.
+The same function always admits a non-PR default-branch event before consulting `effects_branches`, while `effects_branches = ["main"]` admits no additional effect branch.
+`nixbot/nixbot/effects_run.py:64-121` reads this gate from the default branch configuration before discovering and enqueueing effects.
+
+Nixbot creates a PR worktree at the current base and merges the head in `nixbot/nixbot/orchestrator.py:234-286` and `nixbot/nixbot/gitrepo.py:455-476`.
+It identifies the result by `HEAD^{tree}` in `gitrepo.py:205-207`.
+When the base is an ancestor of the head, a local `git merge --no-ff` probe produced the same tree for the PR merge and the head commit: `188fd7d3a743ca5b739852c31e0a74ce6da46343`.
+A fast-forward push of that head produces the same tree, so `orchestrator.py:268-286` selects the existing tree-keyed build rather than creating a second build.
+`nixbot/nixbot/build_reuse.py:124-177` then runs `maybe_run_effects` when the reused PR build has not started effects, which makes a reused `main` build deploy instead of merely replaying build checks.
+
+## Main ruleset proposal
+
+The live `nixbot` ruleset was read with `gh-axi api repos/cameronraysmith/vanixiets/rulesets/16212553` on 2026-09-02.
+It currently contains deletion protection, non-fast-forward protection, and only `nixbot/nix-build` as a required check.
+Its `strict_required_status_checks_policy` is already `false`.
+Its only bypass actor is repository role `5` in `always` mode, and the API reports `current_user_can_bypass: always` for the authenticated landing identity `cameronraysmith`.
+
+Apply this semantic diff to that ruleset, preserving its name, active enforcement, default-branch condition, deletion rule, non-fast-forward rule, and existing bypass actor:
+
+```diff
+ rules:
+   - type: deletion
+   - type: non_fast_forward
++  - type: required_linear_history
++  - type: pull_request
++    parameters:
++      allowed_merge_methods:
++        - squash
++        - rebase
++      dismiss_stale_reviews_on_push: false
++      require_code_owner_review: false
++      require_last_push_approval: false
++      required_approving_review_count: 0
++      required_review_thread_resolution: false
+   - type: required_status_checks
+     parameters:
+       strict_required_status_checks_policy: false
+       do_not_enforce_on_create: false
+       required_status_checks:
++        - context: nixbot/nix-eval
++          integration_id: 4743700
+         - context: nixbot/nix-build
+           integration_id: 4743700
+```
+
+The unchanged `strict_required_status_checks_policy: false` keeps “require branches to be up to date” off.
+The unchanged repository-role bypass lets the current administrator landing identity perform the one direct push despite the new pull-request rule.
+The diff adds no `merge_queue` rule, so GitHub's native merge queue remains disabled.
+The existing `.github/mergify.yml` describes Mergify queues for other PR traffic; the landing script does not call that service or its queue.
+
+Classic branch protection currently reports `required_linear_history.enabled: true`, while the named ruleset does not contain that rule.
+Adding it to the ruleset makes the requested ruleset self-describing without relying on the parallel classic layer.
+Classic protection also reports `allow_force_pushes.enabled: true`, but the active ruleset's `non_fast_forward` rule is the newer, ruleset-level prohibition relevant to this proposal.
+
+## Repository setting
+
+`gh-axi api repos/cameronraysmith/vanixiets` returned `delete_branch_on_merge: true` on 2026-09-02.
+“Automatically delete head branches” is already on, so the unapplied diff is empty.
+No repository-setting request is needed.
+
+## Mergify CLI settings
+
+All three repository-local keys are currently unset.
+The source review used `Mergifyio/mergify-cli` at `727ce50b8fb3be8a9a24025807e159d644dbba80`, whose shallow history boundary is dated `2026-08-27 12:50:49 +0200`.
+
+The original planning brief's line 32 says the CLI opens drafts by default.
+That conflicts with the executable source at `stack_context.rs:237-248`, which defaults the setting to `false`.
+The planning brief is not in a git repository, so its embedded “checked on 2026-09-02” statement has no git provenance to compare with the source commit.
+This review follows the executable source and leaves the policy choice explicit; a newer upstream commit changing `resolve_default_create_as_draft` would change that conclusion.
+
+`crates/mergify-stack/src/stack_context.rs:207-235` maps an unset `mergify-cli.stack-branch-prefix` to `stack/<author>`.
+Leave that key unset; its unapplied diff is empty.
+
+`stack_context.rs:237-248` maps an unset `mergify-cli.stack-create-as-draft` to `false` and recognizes only the literal value `true` as enabled.
+`crates/mergify-stack/src/changes.rs:187-196` shows that the setting marks newly created PRs as drafts while preserving the draft state of existing PRs.
+The mechanism does not determine review-readiness policy, so the owner must choose between these unapplied alternatives:
+
+```diff
+ # Keep the upstream behavior: new stack PRs are ready immediately.
+ mergify-cli.stack-create-as-draft = <unset>
+```
+
+```diff
+ # Opt in: new stack PRs are drafts.
+-mergify-cli.stack-create-as-draft = <unset>
++mergify-cli.stack-create-as-draft = true
+```
+
+`stack_context.rs:261-270` maps an unset `mergify-cli.stack-revision-history` to `true`; only the literal value `false` disables it.
+`crates/mergify-stack/src/commands/push.rs:359-550` records updated revisions in git notes and prepares the sticky PR revision-history comment before publishing.
+Leave the key unset to keep revision history on; its unapplied diff is empty.
+
+## Verification boundary
+
+Structural verification consists of `bash scripts/test-stack-land.sh`, `shellcheck scripts/stack-land.sh scripts/test-stack-land.sh`, the targeted Nix evaluation above, and `prek run --all-files` before publication.
+Runtime verification against held pull requests 2890, 2915, and 2916 remains absent because this lane has no authorization to push their tip to GitHub `main`.

--- a/modules/home/tools/stack-land.nix
+++ b/modules/home/tools/stack-land.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  flake.modules.homeManager.tools =
+    { pkgs, ... }:
+    {
+      home.packages = [ pkgs.stack-land ];
+    };
+}

--- a/pkgs/by-name/stack-land/package.nix
+++ b/pkgs/by-name/stack-land/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  writeShellApplication,
+  runCommand,
+  bash,
+  git,
+  gh,
+  jq,
+  gawk,
+  coreutils,
+  gnugrep,
+  gnused,
+}:
+let
+  baseStackLand = writeShellApplication {
+    name = "stack-land";
+    runtimeInputs = [
+      git
+      gh
+      jq
+      gawk
+      coreutils
+    ];
+    text = builtins.readFile ./stack-land.sh;
+    meta = {
+      description = "Land a reviewed stacked-PR tip with one fast-forward push";
+      license = lib.licenses.mit;
+      mainProgram = "stack-land";
+    };
+  };
+
+  testStackLand = writeShellApplication {
+    name = "test-stack-land";
+    runtimeInputs = [
+      bash
+      git
+      jq
+      coreutils
+      gnugrep
+      gnused
+      baseStackLand
+    ];
+    text = builtins.readFile ./test-stack-land.sh;
+  };
+
+  integrationTest =
+    runCommand "stack-land-integration"
+      {
+        nativeBuildInputs = [ testStackLand ];
+      }
+      ''
+        test-stack-land
+        touch "$out"
+      '';
+in
+baseStackLand.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests = (old.passthru.tests or { }) // {
+      integration = integrationTest;
+    };
+  };
+})

--- a/pkgs/by-name/stack-land/stack-land.sh
+++ b/pkgs/by-name/stack-land/stack-land.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: stack-land [--dry-run] [--remote REMOTE] [--target BRANCH] --tip REV PR...
+
+Land a reviewed stacked-PR tip with one fast-forward push.
+
+Defaults:
+  --remote origin
+  --target main
+
+Assertions:
+  The live target base is an ancestor of the stack tip.
+  Every commit in target-base..tip has exactly one Change-Id matching
+  ^I[0-9a-f]{40}$.
+  Every member PR has at least one check and every check state is SUCCESS.
+  Target ancestry is fetched and checked again immediately before the push.
+  After a real push, every member PR reaches state MERGED with mergedAt set.
+
+The push has no force option. The remote rejects it if the target update is
+not a fast-forward. Dry-run performs every pre-push assertion and no push.
+EOF
+}
+
+fail() {
+  printf 'fatal: %s\n' "$*" >&2
+  exit 1
+}
+
+dry_run=false
+remote=origin
+target=main
+tip=
+prs=()
+
+while (($#)); do
+  case "$1" in
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    --remote)
+      (($# >= 2)) || fail '--remote requires a value'
+      remote="$2"
+      shift 2
+      ;;
+    --target)
+      (($# >= 2)) || fail '--target requires a value'
+      target="$2"
+      shift 2
+      ;;
+    --tip)
+      (($# >= 2)) || fail '--tip requires a value'
+      tip="$2"
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while (($#)); do
+        prs+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      prs+=("$1")
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$tip" ]] || fail '--tip is required'
+((${#prs[@]} > 0)) || fail 'at least one PR number is required'
+[[ "$remote" != -* ]] || fail 'remote must not begin with a hyphen'
+git check-ref-format --branch "$target" >/dev/null 2>&1 || fail "invalid target branch: $target"
+
+for pr in "${prs[@]}"; do
+  [[ "$pr" =~ ^[1-9][0-9]*$ ]] || fail "invalid PR number: $pr"
+done
+
+gh_bin="${GH_BIN:-gh}"
+command -v "$gh_bin" >/dev/null 2>&1 || fail "GitHub CLI not found: $gh_bin"
+command -v jq >/dev/null 2>&1 || fail 'jq is required'
+
+tip_sha="$(git rev-parse --verify "$tip^{commit}" 2>/dev/null)" || fail "stack tip is not a commit: $tip"
+
+fetch_target_base() {
+  git fetch --quiet "$remote" "refs/heads/$target" ||
+    fail "could not fetch target branch $remote/$target"
+  git rev-parse --verify 'FETCH_HEAD^{commit}'
+}
+
+assert_ancestry() {
+  local base_sha="$1"
+  if ! git merge-base --is-ancestor "$base_sha" "$tip_sha"; then
+    fail "target base $base_sha is not an ancestor of stack tip $tip_sha"
+  fi
+}
+
+assert_change_ids() {
+  local base_sha="$1"
+  local commit_sha
+  local trailer_count
+  local trailer_values
+  local change_id
+
+  while IFS= read -r commit_sha; do
+    [[ -n "$commit_sha" ]] || continue
+    trailer_values="$(
+      git show -s \
+        --format='%(trailers:key=Change-Id,valueonly,separator=%x0A)' \
+        "$commit_sha"
+    )"
+    trailer_count="$(printf '%s\n' "$trailer_values" | awk 'NF { count++ } END { print count + 0 }')"
+    if [[ "$trailer_count" != 1 ]]; then
+      fail "commit $commit_sha has $trailer_count Change-Id trailers; expected exactly one"
+    fi
+    change_id="$(printf '%s\n' "$trailer_values" | awk 'NF { print; exit }')"
+    if [[ ! "$change_id" =~ ^I[0-9a-f]{40}$ ]]; then
+      fail "commit $commit_sha has invalid Change-Id trailer: $change_id"
+    fi
+  done < <(git rev-list --reverse "$base_sha..$tip_sha")
+}
+
+checks_json_for() {
+  local pr="$1"
+  local checks_json
+  local gh_status
+
+  set +e
+  checks_json="$("$gh_bin" pr checks "$pr" --json name,state)"
+  gh_status=$?
+  set -e
+
+  if ! printf '%s\n' "$checks_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    fail "PR $pr check query did not return a JSON array (gh exit $gh_status)"
+  fi
+  printf '%s\n' "$checks_json"
+}
+
+assert_green_pr() {
+  local pr="$1"
+  local checks_json
+  local failures
+
+  checks_json="$(checks_json_for "$pr")"
+  if [[ "$(printf '%s\n' "$checks_json" | jq 'length')" == 0 ]]; then
+    fail "PR $pr has no checks"
+  fi
+  failures="$(
+    printf '%s\n' "$checks_json" |
+      jq -r '[.[] | select(.state != "SUCCESS") | "\(.name)=\(.state)"] | join(", ")'
+  )"
+  if [[ -n "$failures" ]]; then
+    fail "PR $pr checks are not all green: $failures"
+  fi
+}
+
+pr_is_merged() {
+  local pr="$1"
+  local pr_json
+
+  pr_json="$("$gh_bin" pr view "$pr" --json state,mergedAt)" ||
+    fail "could not query merged state for PR $pr"
+  if ! printf '%s\n' "$pr_json" |
+    jq -e 'type == "object" and .state == "MERGED" and (.mergedAt | type == "string")' \
+      >/dev/null 2>&1; then
+    return 1
+  fi
+}
+
+base_sha="$(fetch_target_base)"
+assert_ancestry "$base_sha"
+printf 'assertion passed: target base %s is an ancestor of stack tip %s\n' \
+  "$base_sha" "$tip_sha"
+
+assert_change_ids "$base_sha"
+printf 'assertion passed: every commit in %s..%s has exactly one valid Change-Id\n' \
+  "$base_sha" "$tip_sha"
+
+for pr in "${prs[@]}"; do
+  assert_green_pr "$pr"
+  printf 'assertion passed: PR %s checks are all green\n' "$pr"
+done
+
+base_sha="$(fetch_target_base)"
+assert_ancestry "$base_sha"
+printf 'assertion passed immediately before push: target base %s is an ancestor of stack tip %s\n' \
+  "$base_sha" "$tip_sha"
+
+if [[ "$dry_run" == true ]]; then
+  printf 'dry run: would push %s to %s/%s\n' "$tip_sha" "$remote" "$target"
+  printf 'dry run: post-push merged-state assertion was not run because no push occurred\n'
+  exit 0
+fi
+
+git push "$remote" "$tip_sha:refs/heads/$target"
+
+for _attempt in {1..10}; do
+  all_merged=true
+  for pr in "${prs[@]}"; do
+    if ! pr_is_merged "$pr"; then
+      all_merged=false
+    fi
+  done
+  if [[ "$all_merged" == true ]]; then
+    printf 'landed stack and verified merged PRs: %s\n' "${prs[*]}"
+    exit 0
+  fi
+  sleep 1
+done
+
+for pr in "${prs[@]}"; do
+  if ! pr_is_merged "$pr"; then
+    fail "PR $pr did not close as merged after push"
+  fi
+done
+
+fail 'post-push merged-state verification failed'

--- a/pkgs/by-name/stack-land/test-stack-land.sh
+++ b/pkgs/by-name/stack-land/test-stack-land.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+subject="$(command -v stack-land)"
+scratch_parent="${TMPDIR:?}/stack-land-test"
+mkdir -p "$scratch_parent"
+scratch="$(mktemp -d "$scratch_parent/run.XXXXXX")"
+trap 'chmod -R u+w "$scratch" 2>/dev/null || true; command rm -rf "$scratch"' EXIT
+
+remote="$scratch/remote.git"
+work="$scratch/work"
+forge="$scratch/forge"
+fake_bin="$scratch/bin"
+mkdir -p "$forge/checks" "$fake_bin"
+
+git init --quiet --bare --initial-branch=main "$remote"
+git init --quiet --initial-branch=main "$work"
+git -C "$work" config user.name "Stack Landing Test"
+git -C "$work" config user.email "stack-landing@example.invalid"
+git -C "$work" remote add origin "$remote"
+
+commit_file() {
+  local filename="$1"
+  local content="$2"
+  local subject_line="$3"
+  local change_id="${4:-}"
+  printf '%s\n' "$content" >"$work/$filename"
+  git -C "$work" add "$filename"
+  if [[ -n "$change_id" ]]; then
+    git -C "$work" commit --quiet -m "$subject_line" -m "Change-Id: $change_id"
+  else
+    git -C "$work" commit --quiet -m "$subject_line"
+  fi
+}
+
+commit_file base.txt base base
+base_sha="$(git -C "$work" rev-parse HEAD)"
+git -C "$work" push --quiet origin HEAD:main
+
+git -C "$work" switch --quiet -c stack
+commit_file lower.txt lower lower I1111111111111111111111111111111111111111
+commit_file upper.txt upper upper I2222222222222222222222222222222222222222
+tip_sha="$(git -C "$work" rev-parse HEAD)"
+
+git -C "$work" switch --quiet -c missing-trailer "$base_sha"
+commit_file missing.txt missing missing
+missing_sha="$(git -C "$work" rev-parse HEAD)"
+
+git -C "$work" switch --quiet -c duplicate-trailer "$base_sha"
+printf '%s\n' duplicate >"$work/duplicate.txt"
+git -C "$work" add duplicate.txt
+git -C "$work" commit --quiet \
+  -m duplicate \
+  -m $'Change-Id: I3333333333333333333333333333333333333333\nChange-Id: I4444444444444444444444444444444444444444'
+duplicate_sha="$(git -C "$work" rev-parse HEAD)"
+
+git -C "$work" switch --quiet -c malformed-trailer "$base_sha"
+commit_file malformed.txt malformed malformed Inot-a-forty-digit-hex-value
+malformed_sha="$(git -C "$work" rev-parse HEAD)"
+
+git -C "$work" switch --quiet -c competing "$base_sha"
+commit_file competing.txt competing competing I5555555555555555555555555555555555555555
+competing_sha="$(git -C "$work" rev-parse HEAD)"
+git -C "$work" push --quiet origin competing:refs/heads/test-competing
+git -C "$work" switch --quiet stack
+
+{
+  printf '#!%s\n' "$BASH"
+  cat <<'EOF'
+set -euo pipefail
+
+if [[ "$1 $2" == "pr checks" ]]; then
+  pr="$3"
+  [[ "$4 $5" == "--json name,state" ]]
+  cat "$FAKE_FORGE/checks/$pr.json"
+  if [[ "${FAKE_ADVANCE_ON_PR:-}" == "$pr" ]]; then
+    git --git-dir="$FAKE_REMOTE" update-ref refs/heads/main "$FAKE_ADVANCE_SHA"
+  fi
+  jq -e 'length > 0 and all(.[]; .state == "SUCCESS")' \
+    "$FAKE_FORGE/checks/$pr.json" >/dev/null
+  exit
+fi
+
+if [[ "$1 $2" == "pr view" ]]; then
+  pr="$3"
+  [[ "$4 $5" == "--json state,mergedAt" ]]
+  if [[ "${FAKE_BLOCKED_PR:-}" == "$pr" ]]; then
+    printf '{"state":"OPEN","mergedAt":null}\n'
+  elif git --git-dir="$FAKE_REMOTE" merge-base --is-ancestor \
+    "$FAKE_TIP_SHA" refs/heads/main; then
+    printf '{"state":"MERGED","mergedAt":"2026-09-02T12:00:00Z"}\n'
+  else
+    printf '{"state":"OPEN","mergedAt":null}\n'
+  fi
+  exit
+fi
+
+printf 'unexpected forge invocation: %q ' "$@" >&2
+printf '\n' >&2
+exit 64
+EOF
+} >"$fake_bin/gh"
+chmod +x "$fake_bin/gh"
+
+mkdir -p "$work/.git/hooks"
+{
+  printf '#!%s\n' "$BASH"
+  cat <<'EOF'
+set -euo pipefail
+if [[ -f "$FAKE_FORGE/advance-in-pre-push" ]]; then
+  advance_sha="$(<"$FAKE_FORGE/advance-in-pre-push")"
+  git --git-dir="$FAKE_REMOTE" update-ref refs/heads/main "$advance_sha"
+  command rm "$FAKE_FORGE/advance-in-pre-push"
+fi
+EOF
+} >"$work/.git/hooks/pre-push"
+chmod +x "$work/.git/hooks/pre-push"
+
+printf '[{"name":"nixbot/nix-eval","state":"SUCCESS"},{"name":"nixbot/nix-build","state":"SUCCESS"}]\n' >"$forge/checks/101.json"
+printf '[{"name":"nixbot/nix-eval","state":"SUCCESS"},{"name":"nixbot/nix-build","state":"CANCELLED"}]\n' >"$forge/checks/102.json"
+printf '[]\n' >"$forge/checks/103.json"
+printf '[{"name":"nixbot/nix-eval","state":"SUCCESS"},{"name":"nixbot/nix-build","state":"SUCCESS"}]\n' >"$forge/checks/104.json"
+
+output="$scratch/output"
+export FAKE_FORGE="$forge"
+export FAKE_REMOTE="$remote"
+export FAKE_TIP_SHA="$tip_sha"
+export GH_BIN="$fake_bin/gh"
+
+reset_main() {
+  git --git-dir="$remote" update-ref refs/heads/main "$base_sha"
+}
+
+run_subject() {
+  (cd "$work" && "$subject" "$@") >"$output" 2>&1
+}
+
+expect_failure() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+  if run_subject "$@"; then
+    printf 'not ok - %s: command succeeded\n' "$name" >&2
+    return 1
+  fi
+  if ! grep -Eq "$pattern" "$output"; then
+    printf 'not ok - %s: expected /%s/ in:\n' "$name" "$pattern" >&2
+    sed 's/^/  /' "$output" >&2
+    return 1
+  fi
+  printf 'ok - %s: %s\n' "$name" "$(tail -n 1 "$output")"
+}
+
+git --git-dir="$remote" update-ref refs/heads/main "$competing_sha"
+expect_failure \
+  'ancestry rejects a divergent target base' \
+  "target base .* is not an ancestor of stack tip $tip_sha" \
+  --dry-run --tip "$tip_sha" 101
+
+reset_main
+expect_failure \
+  'missing Change-Id names its commit' \
+  "commit $missing_sha has 0 Change-Id trailers; expected exactly one" \
+  --dry-run --tip "$missing_sha" 101
+
+reset_main
+expect_failure \
+  'duplicate Change-Id names its commit' \
+  "commit $duplicate_sha has 2 Change-Id trailers; expected exactly one" \
+  --dry-run --tip "$duplicate_sha" 101
+
+reset_main
+expect_failure \
+  'malformed Change-Id names its commit' \
+  "commit $malformed_sha has invalid Change-Id trailer" \
+  --dry-run --tip "$malformed_sha" 101
+
+reset_main
+expect_failure \
+  'cancelled check is not green' \
+  'PR 102 checks are not all green: nixbot/nix-build=CANCELLED' \
+  --dry-run --tip "$tip_sha" 102
+
+reset_main
+expect_failure \
+  'a head with no checks is not green' \
+  'PR 103 has no checks' \
+  --dry-run --tip "$tip_sha" 103
+
+reset_main
+export FAKE_ADVANCE_ON_PR=101
+export FAKE_ADVANCE_SHA="$competing_sha"
+expect_failure \
+  'ancestry is rechecked after forge checks' \
+  "target base $competing_sha is not an ancestor of stack tip $tip_sha" \
+  --dry-run --tip "$tip_sha" 101
+unset FAKE_ADVANCE_ON_PR FAKE_ADVANCE_SHA
+
+reset_main
+printf '%s\n' "$competing_sha" >"$forge/advance-in-pre-push"
+expect_failure \
+  'the fast-forward push rejects a concurrent target update' \
+  '(non-fast-forward|failed to push some refs)' \
+  --tip "$tip_sha" 101
+
+reset_main
+PATH=/unusable GH_BIN="$fake_bin/gh" run_subject --dry-run --tip "$tip_sha" 101
+[[ "$(git --git-dir="$remote" rev-parse refs/heads/main)" == "$base_sha" ]]
+grep -Fq "dry run: would push $tip_sha to origin/main" "$output"
+printf 'ok - installed wrapper supplies its runtime commands with an unusable PATH\n'
+
+reset_main
+run_subject --dry-run --tip "$tip_sha" 101
+[[ "$(git --git-dir="$remote" rev-parse refs/heads/main)" == "$base_sha" ]]
+grep -Fq "dry run: would push $tip_sha to origin/main" "$output"
+printf 'ok - dry run validates without updating main\n'
+
+reset_main
+run_subject --tip "$tip_sha" 101
+[[ "$(git --git-dir="$remote" rev-parse refs/heads/main)" == "$tip_sha" ]]
+grep -Fq 'landed stack and verified merged PRs: 101' "$output"
+printf 'ok - valid stack fast-forwards main and verifies merged state\n'
+
+git -C "$work" switch --quiet stack
+commit_file next.txt next next I6666666666666666666666666666666666666666
+next_tip_sha="$(git -C "$work" rev-parse HEAD)"
+export FAKE_TIP_SHA="$next_tip_sha"
+export FAKE_BLOCKED_PR=104
+expect_failure \
+  'post-push state requires every PR to be merged' \
+  'PR 104 did not close as merged after push' \
+  --tip "$next_tip_sha" 101 104
+unset FAKE_BLOCKED_PR


### PR DESCRIPTION
## What this changes

This packages `stack-land` under `pkgs/by-name/stack-land` with `writeShellApplication`.
Its runtime dependencies are explicit: git, gh, jq, gawk, and coreutils.
The home `tools` module installs the command in the same form as repo-sync, ghq-sync, and dependency-sources.

The interface is the installed `stack-land` command or `nix run .#stack-land -- ...`.
There is no just recipe because it would only alias `nix run`, and no explicit flake app because the package `mainProgram` already provides that entry point.

The acceptance harness is also a `writeShellApplication` and runs as `checks.<system>.package-stack-land-test-integration` through `passthru.tests.integration`.
Its scratch repository and bare remote are created inside the Nix build sandbox.
No GitHub Actions workflow was added.

The settings review remains in `docs/notes/development/version-control/stacked-landing-settings-review.md` and is unchanged as required by the correction.
That creates a known documentation mismatch: the review still names the superseded raw-script and just-recipe paths, which the policy/documentation lane must reconcile.

## Guard evidence

The flake check requires both a nonzero exit and the specific expected cause for each invalid fixture.

- Ancestry fails for a divergent base and separately fails when the target changes after the first check, proving the immediate pre-push recheck.
- Change identity fails with the offending SHA for missing, duplicate, and malformed `Change-Id` trailers.
- Structured pull-request checks reject a `CANCELLED` state and an empty check array.
- A concurrent pre-push target update is rejected as non-fast-forward.
- Post-push verification names a member PR that remains open.
- Dry-run leaves the remote unchanged, and the valid local landing advances `main` to the stack tip and verifies merged state.
- The built wrapper completes the dry-run with an unusable ambient `PATH`.

## Verification

- `nix build .#checks.aarch64-darwin.package-stack-land-test-integration`
- Deliberate `SC2034` mutation: `nix build path:$PWD#stack-land` failed in the `writeShellApplication` ShellCheck phase; restoring the source restored its exact SHA-256.
- `nix run path:$PWD#stack-land -- --help`
- `prek run` on all four mechanism files: gitleaks and treefmt passed.
- Every commit in `origin/main..HEAD` has exactly one `Change-Id`, a valid `G` signature, and Cameron Smith in both author and committer fields.

A direct home activation evaluation with `allow-import-from-derivation=false` stops earlier in the pre-existing `programs.opencode.skills` IFD path, so it does not provide evidence for this module.
The package and its flake check evaluate and build with that option disabled.

The first live landing against pull requests 2890, 2915, and 2916 remains separately authorized and was not performed here.