### PR TITLE
fix(stack-land): accept non-blocking check states

### DIFF
--- a/pkgs/by-name/stack-land/stack-land.sh
+++ b/pkgs/by-name/stack-land/stack-land.sh
@@ -15,7 +15,8 @@ Assertions:
   The live target base is an ancestor of the stack tip.
   Every commit in target-base..tip has exactly one Change-Id matching
   ^I[0-9a-f]{40}$.
-  Every member PR has at least one check and every check state is SUCCESS.
+  Every member PR has at least one check and every check state is SUCCESS,
+  NEUTRAL, or SKIPPED.
   Target ancestry is fetched and checked again immediately before the push.
   After a real push, every member PR reaches state MERGED with mergedAt set.
 
@@ -157,7 +158,7 @@ assert_green_pr() {
   fi
   failures="$(
     printf '%s\n' "$checks_json" |
-      jq -r '[.[] | select(.state != "SUCCESS") | "\(.name)=\(.state)"] | join(", ")'
+      jq -r '[.[] | select(.state != "SUCCESS" and .state != "NEUTRAL" and .state != "SKIPPED") | "\(.name)=\(.state)"] | join(", ")'
   )"
   if [[ -n "$failures" ]]; then
     fail "PR $pr checks are not all green: $failures"

--- a/pkgs/by-name/stack-land/test-stack-land.sh
+++ b/pkgs/by-name/stack-land/test-stack-land.sh
@@ -151,6 +151,32 @@ expect_failure() {
   printf 'ok - %s: %s\n' "$name" "$(tail -n 1 "$output")"
 }
 
+expect_success() {
+  local name="$1"
+  shift
+  if ! run_subject "$@"; then
+    printf 'not ok - %s: command failed:\n' "$name" >&2
+    sed 's/^/  /' "$output" >&2
+    return 1
+  fi
+  printf 'ok - %s\n' "$name"
+}
+
+expect_check_state_failure() {
+  local category="$1"
+  local pr="$2"
+  local state="$3"
+  local check="synthetic-$state"
+
+  printf '[{"name":"nixbot/nix-eval","state":"SUCCESS"},{"name":"%s","state":"%s"}]\n' \
+    "$check" "$state" >"$forge/checks/$pr.json"
+  reset_main
+  expect_failure \
+    "$category check state $state blocks landing" \
+    "PR $pr checks are not all green: $check=$state" \
+    --dry-run --tip "$tip_sha" "$pr"
+}
+
 git --git-dir="$remote" update-ref refs/heads/main "$competing_sha"
 expect_failure \
   'ancestry rejects a divergent target base' \
@@ -186,6 +212,33 @@ expect_failure \
   'a head with no checks is not green' \
   'PR 103 has no checks' \
   --dry-run --tip "$tip_sha" 103
+
+printf '[{"name":"nixbot/nix-eval","state":"SUCCESS"},{"name":"Mergify Merge Queue","state":"NEUTRAL"}]\n' \
+  >"$forge/checks/105.json"
+reset_main
+expect_success \
+  'a neutral check does not block landing' \
+  --dry-run --tip "$tip_sha" 105
+
+printf '[{"name":"nixbot/nix-eval","state":"SUCCESS"},{"name":"optional-check","state":"SKIPPED"}]\n' \
+  >"$forge/checks/106.json"
+reset_main
+expect_success \
+  'a skipped check does not block landing' \
+  --dry-run --tip "$tip_sha" 106
+
+pr=107
+for state in FAILURE TIMED_OUT ACTION_REQUIRED ERROR; do
+  expect_check_state_failure failing "$pr" "$state"
+  ((pr += 1))
+done
+
+for state in PENDING IN_PROGRESS QUEUED REQUESTED WAITING EXPECTED STARTUP_FAILURE STALE; do
+  expect_check_state_failure undecided "$pr" "$state"
+  ((pr += 1))
+done
+
+expect_check_state_failure unrecognised "$pr" BANANA
 
 reset_main
 export FAKE_ADVANCE_ON_PR=101


### PR DESCRIPTION
## Summary

- Accept SUCCESS, NEUTRAL, and SKIPPED check states.
- Block failing, pending, and unknown states while naming each check and state.
- Extend the synthetic guard suite across the installed gh state vocabulary and an unknown BANANA state.

## Installed gh divergence

Installed gh 2.97.0 also emits ERROR as a failure and STALE as pending. It categorizes STARTUP_FAILURE as pending rather than failing. All three block landing and now have explicit tests.

The suite missed this defect because its synthetic check payloads exercised only states the author anticipated. The expanded state matrix and unknown-state case prevent that closed-world assumption from recurring.

## Verification

- RED: the added NEUTRAL case failed against the landed package with Mergify Merge Queue=NEUTRAL.
- GREEN: the direct 27-case harness passed, including NEUTRAL, SKIPPED, every blocking state, zero checks, and BANANA.
- nix build .#checks.aarch64-darwin.package-stack-land-test-integration
- prek run --all-files

This package integration check is the narrowest repository check that executes the changed script and its immediate guard harness; no broader suite was run.