### PR TITLE
fix(skills): preserve executable modes for Codex

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,0 +1,90 @@
+# https://docs.devin.ai/onboard-devin/environment/git-backed-blueprints
+# Nix is the only host-level dependency: it is installed through the repo's own
+# pinned bootstrap, and every other tool (just, prek, treefmt, bun, jq) comes
+# from the flake devshell, entered via direnv.
+initialize: |
+  # Pinned NixOS/nix-installer, systemd daemon planner (/run/systemd/system exists here).
+  # bootstrap rather than install-nix: the sandbox image ships /usr/bin/direnv, so
+  # install-direnv is a no-op today, but it self-heals if that ever goes away.
+  make bootstrap
+
+  # Nothing here grants trust: install-nix's `--extra-conf trusted-users` covers @sudo,
+  # which is the group the sandbox user is in, and the installer writes that into
+  # nix.conf itself. `nix store info --json` reports trusted: true after bootstrap.
+  # What is left is settings the repo has no reason to carry, written to the
+  # installer's own `!include` target, which is also the pre-activation seam the darwin
+  # hosts migrate trusted-users out of. It is rewritten whole rather than appended to,
+  # so the step is idempotent if it ever re-runs over an existing /nix, where install-nix
+  # short-circuits on `command -v nix`; the only content thereby dropped is the
+  # installer's copy of trusted-users, still in force from nix.conf.
+  # auto-allocate-uids + cgroups are what systemd-nspawn-flavor NixOS tests need,
+  # matching magnetite's and the rosetta builder's nix.settings. Their uid-range is
+  # not repeated here: nix inserts it into the default system-features on every
+  # linux (nix src/libstore/globals.cc:217-239, `nix config show system-features`).
+  printf 'accept-flake-config = true\nauto-allocate-uids = true\nextra-experimental-features = auto-allocate-uids cgroups\n' | sudo tee /etc/nix/nix.custom.conf
+  sudo systemctl restart nix-daemon.service
+
+  # Agent commands run in non-interactive shells, which read neither
+  # /etc/bash.bashrc nor /etc/profile.d/nix.sh.
+  echo "BASH_ENV=/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" >> $ENVRC
+
+  # QEMU-flavor NixOS tests run as a nix build user inside the sandbox, and
+  # nix-daemon drops supplementary groups for those users, so adding anyone to the
+  # kvm group does not reach them: qemu then reports "Could not access KVM kernel
+  # module: Permission denied" and accel=kvm:tcg falls back to TCG silently, at
+  # roughly an eighth of the speed. Widening the mode is what upstream systemd's
+  # udev defaults do. Nix bind-mounts /dev/kvm into the sandbox on its own, so no
+  # extra-sandbox-paths entry is needed.
+  printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/99-kvm.rules
+  # --settle: trigger only queues the event, so without it the mode is still 0660
+  # for a moment afterwards and anything checking it here races udevd.
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --name-match=kvm --settle
+maintenance: |
+  # Realize the devshell; its shellHook writes .pre-commit-config.yaml and installs the prek hooks.
+  nix develop --accept-flake-config --command true
+  # Warm the nix-direnv cache so later `direnv exec .` invocations skip flake evaluation.
+  direnv allow
+  # `bun install` over the root workspace (packages/*), so packages/docs is covered;
+  # incremental outside CI, unlike `bun run reinstall`, which maintenance forbids.
+  # Playwright browsers come from the devshell's PLAYWRIGHT_BROWSERS_PATH, not a download.
+  direnv exec . just install
+
+  # .agents/ is gitignored, so a fresh clone carries none of the repo's skills, and
+  # the devshell shellHook only composes AGENTS.md/CLAUDE.md - apm-skills-install is
+  # what materializes .agents/skills/, which is the only place a harness discovers
+  # them. apm rewrites apm.lock.yaml's generated_at on every run, so the tracked file
+  # is put back afterwards; the snapshot is expected to start on a clean tree.
+  cp apm.lock.yaml /tmp/apm.lock.yaml.pre-install
+  direnv exec . just agents-install
+  cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml
+knowledge:
+  - name: lint
+    contents: |
+      direnv exec . just lint  # prek run --all-files: gitleaks + treefmt
+  - name: test
+    contents: |
+      direnv exec . nix build .#checks.x86_64-linux.<name> # single check; cheapest feedback loop
+      direnv exec . just check-fast        # nix-fast-build over checks.x86_64-linux; cold runs build whole machine toplevels
+      direnv exec . just check             # full nix flake check
+      # checks.x86_64-linux currently contains no NixOS-test-framework checks, so
+      # nothing here exercises kvm or nspawn yet; `just test-integration` targets
+      # vm-test-framework and vm-boot-all-machines, neither of which the flake defines.
+      direnv exec . just test-package docs # bun unit + coverage + build + e2e
+      # just test-quick is darwin-pinned (checks.aarch64-darwin.*) and cannot run here
+  - name: build
+    contents: |
+      direnv exec . just docs-build             # typst diagrams + astro site
+      direnv exec . just build-machine cinnabar # nixos hosts: cinnabar, electrum
+  - name: startup
+    contents: |
+      direnv exec . just docs-dev  # astro dev server for packages/docs
+  - name: notes
+    contents: |
+      Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.
+      x86_64-linux only: darwinConfigurations, checks.aarch64-*, and `just activate*` cannot run here.
+      No age/sops keys are provisioned, so sops, clan vars, and secret-decrypting recipes fail by design.
+      The nix store grows quickly on the sandbox disk; reclaim with `direnv exec . just gc`.
+      AGENTS.md, CLAUDE.md and .agents/skills/ are generated and gitignored: entering the
+      devshell composes the first two, `just agents-install` deploys the skills. Never edit
+      them; edit the .apm/ fragments under modules/home/ai/plugins/ and regenerate.

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,13 @@ bootstrap: install-nix install-direnv
 # This bypasses both the Fastly CDN (HTTP 618 errors) and the shell wrapper
 # (which has template placeholders that aren't filled in for raw source files).
 # To update version, change NIX_INSTALLER_VERSION below.
-# Note: versioning jumped from 0.27.0 to 3.11.3, then back to 2.34.6 when
+# Note: versioning jumped from 0.27.0 to 3.11.3, then back to the 2.x line when
 # NixOS/nix-installer removed the 3.x tags (repo renamed from experimental-nix-installer).
+# The installer tag tracks the Nix it embeds (flake.nix: nix.url = github:NixOS/nix/<tag>),
+# so this pin is also the nix version bootstrap lands.
 # https://github.com/NixOS/nix-installer/releases
 #
-# nix-installer 2.34.6 writes /etc/nix/nix.conf in setup_standard_config
+# nix-installer 2.35.1 writes /etc/nix/nix.conf in setup_standard_config
 # (src/action/common/place_nix_configuration.rs:98-154). Its defaults are
 # extra-experimental-features = nix-command, auto-optimise-store = true (Linux
 # only), always-allow-substitutes = true, max-jobs = auto, and
@@ -107,8 +109,8 @@ bootstrap: install-nix install-direnv
 # to get flakes is an interactive prompt that --no-confirm suppresses
 # (src/cli/subcommand/install/mod.rs:119-137), so a non-interactive install
 # without the flag lands nix-command alone. Releases through 2.33.0 wrote
-# nix-command flakes unconditionally, which is why the flag is needed at this pin
-# and was not needed at the previous one.
+# nix-command flakes unconditionally, which is why the flag is needed at any
+# 2.34.4-or-later pin and was not needed before that.
 #
 # flakes is not optional here: install-direnv resolves nixpkgs#direnv and
 # 'make verify' runs 'nix flake --help'.
@@ -120,14 +122,17 @@ bootstrap: install-nix install-direnv
 # deliberately omitted. The experimental feature only makes Nix accept the
 # setting of the same name, and the setting is true nowhere in this repo except
 # magnetite (modules/machines/nixos/magnetite/default.nix:76-83), which pairs it
-# with extra-system-features = uid-range for systemd-nspawn tests. Enabling the
-# feature alone changes no build behaviour, and the daemonless mode below has no
-# daemon to allocate UIDs at all. Bootstrap's nix.conf is transient regardless:
+# with extra-system-features = uid-range for systemd-nspawn tests. That pairing is
+# belt-and-braces: nix's own getDefaultSystemFeatures
+# (nix src/libstore/globals.cc:217-239) already inserts uid-range
+# unconditionally on linux. Enabling the feature alone
+# changes no build behaviour, and the daemonless mode below has no daemon to
+# allocate UIDs at all. Bootstrap's nix.conf is transient regardless:
 # the first 'just activate' regenerates it from the host's own modules.
 #
 # trusted-users lets nix accept flake-specified substituters and public keys
 # without prompts or warnings.
-NIX_INSTALLER_VERSION := 2.34.6
+NIX_INSTALLER_VERSION := 2.35.1
 
 # A usable systemd runtime is detected by the single existence test that
 # /run/systemd/system is present if and only if the machine booted under systemd

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,14 @@ bootstrap: install-nix install-direnv
 # the first 'just activate' regenerates it from the host's own modules.
 #
 # trusted-users lets nix accept flake-specified substituters and public keys
-# without prompts or warnings.
+# without prompts or warnings. Nix's own default is `root` alone, so without
+# this the person who ran bootstrap cannot use the flake's caches and rebuilds
+# everything from source. The three admin groups are one per platform
+# convention - @admin on darwin, @wheel on nixos/fedora/arch, @sudo on
+# debian/ubuntu - because none of the three exists everywhere and nix ignores
+# the ones that do not resolve. Groups rather than $(USER) so the value is
+# static and stays right for a second admin on the same host; trusting them is
+# no escalation, since a sudoer is already root-equivalent.
 NIX_INSTALLER_VERSION := 2.35.1
 
 # A usable systemd runtime is detected by the single existence test that
@@ -184,7 +191,7 @@ install-nix: ## Install Nix using the NixOS community installer
 				"$$INSTALLER_URL" -o /tmp/nix-installer && chmod +x /tmp/nix-installer; then \
 				/tmp/nix-installer install $$PLANNER_ARGS --no-confirm \
 					--enable-flakes \
-					--extra-conf "trusted-users = root @admin @wheel" && break; \
+					--extra-conf "trusted-users = root @admin @wheel @sudo" && break; \
 			fi; \
 			attempt=$$((attempt + 1)); \
 			if [ $$attempt -le $$max_attempts ]; then \

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,56 @@ install-nix: ## Install Nix using the NixOS community installer
 		fi; \
 	fi
 
+.PHONY: uninstall-nix
+# The inverse of install-nix, and the only supported one: nix-installer records
+# its plan in /nix/receipt.json and reverses exactly that plan
+# (src/cli/subcommand/uninstall.rs), so hand-removing /nix leaves the build
+# users, the daemon unit and the shell profile snippets behind.
+#
+# The uninstaller must be the copy the install left at /nix/nix-installer, not
+# NIX_INSTALLER_VERSION: the receipt is version-checked, and a binary older than
+# the plan refuses to parse it and prints that same path as the fix
+# (uninstall.rs:110-149). The pinned release is only a fallback for a host whose
+# copy is gone, where it works when the receipt is not newer than the pin.
+#
+# No sudo: ensure_root re-execs the process under sudo --set-home itself
+# (src/cli/mod.rs:133-141), matching install-nix.
+#
+# Deliberately not wired into any aggregate target - bootstrap is the composition
+# worth having - but the pair does compose to the identity map, which is how a
+# pin bump gets verified on a real host rather than only in a container:
+#
+#   make uninstall-nix CONFIRM=1 && make bootstrap && make verify
+uninstall-nix: ## Uninstall Nix by reverting /nix/receipt.json (CONFIRM=1 to skip the prompt)
+	@echo "Uninstalling Nix..."
+	@if [ ! -e /nix/receipt.json ]; then \
+		if [ -e /nix ]; then \
+			echo "No install receipt at /nix/receipt.json, but /nix exists: this Nix was not installed by nix-installer, so refusing to guess at how to remove it."; \
+			exit 1; \
+		fi; \
+		echo "Nix is not installed."; \
+	else \
+		UNINSTALLER=/nix/nix-installer; \
+		if [ ! -x "$$UNINSTALLER" ]; then \
+			case "$$(uname -s)-$$(uname -m)" in \
+				Linux-x86_64)  PLATFORM="x86_64-linux" ;; \
+				Linux-aarch64) PLATFORM="aarch64-linux" ;; \
+				Darwin-arm64)  PLATFORM="aarch64-darwin" ;; \
+				*) echo "Unsupported platform: $$(uname -s)-$$(uname -m)"; exit 1 ;; \
+			esac; \
+			echo "No installer at /nix/nix-installer; falling back to the pinned $(NIX_INSTALLER_VERSION) release."; \
+			curl --proto '=https' --tlsv1.2 -sSf -L --retry 3 --retry-delay 5 \
+				"https://github.com/NixOS/nix-installer/releases/download/$(NIX_INSTALLER_VERSION)/nix-installer-$$PLATFORM" \
+				-o /tmp/nix-installer && chmod +x /tmp/nix-installer; \
+			UNINSTALLER=/tmp/nix-installer; \
+		fi; \
+		if [ "$(CONFIRM)" = "1" ]; then \
+			"$$UNINSTALLER" uninstall --no-confirm; \
+		else \
+			"$$UNINSTALLER" uninstall; \
+		fi; \
+	fi
+
 .PHONY: install-direnv
 install-direnv: ## Install direnv (requires nix to be installed first)
 	@echo "Installing direnv..."

--- a/modules/apps/updates.nix
+++ b/modules/apps/updates.nix
@@ -20,6 +20,11 @@
         program = "${config.packages.claude-code.updateScript}";
       };
 
+      apps.update-devin-cli = {
+        type = "app";
+        program = "${config.packages.devin-cli.updateScript}";
+      };
+
       apps.update-xsra = {
         type = "app";
         program = "${config.packages.xsra.updateScript}";

--- a/modules/checks/devin-worker.nix
+++ b/modules/checks/devin-worker.nix
@@ -37,7 +37,9 @@
 #    on the same checkout.
 #
 # 4. Each assertion clause fires on exactly its own malformed input, and a
-#    well-formed configuration fires none.
+#    well-formed configuration fires none. The token probe leaves the sibling
+#    queue fully wired, so it also shows that a queue whose own credential is
+#    missing does not borrow another queue's.
 #
 # Severity rationale (Mayo): each claim fails under a plausible incorrect
 # implementation. Dropping the `mkIf isDarwin` / `mkIf isLinux` gates puts
@@ -55,8 +57,6 @@
     let
       lib = pkgs.lib;
       mkCheck = self.lib.mkStructuralCheck pkgs;
-
-      dummyTokenPath = "/run/secrets/devin-outposts-token.dummy";
 
       # The same package set the home configurations get (see
       # modules/home/mk-home.nix): `self.legacyPackages` is the channel before
@@ -109,13 +109,22 @@
           ];
         }).config;
 
+      # Only the token files are supplied: the ids, platforms and names come
+      # from the module's own registry, so these probes also show that a
+      # partial definition merges with it instead of replacing it -- an option
+      # `default` would have dropped the entries and the platforms.
+      wired = {
+        "stibnite-01".tokenFile = "/run/secrets/devin-outposts-token-stibnite.dummy";
+        "magnetite-01".tokenFile = "/run/secrets/devin-outposts-token-magnetite.dummy";
+      };
+
       darwin = evalHome {
         system = "aarch64-darwin";
         homeDirectory = "/Users/probe";
         worker = {
           enable = true;
           workers = 2;
-          tokenFile = dummyTokenPath;
+          outposts = wired;
         };
       };
 
@@ -125,7 +134,7 @@
         worker = {
           enable = true;
           workers = 2;
-          tokenFile = dummyTokenPath;
+          outposts = wired;
         };
       };
 
@@ -140,6 +149,8 @@
           message:
           if lib.hasInfix "tokenFile is null" message then
             "token"
+          else if lib.hasInfix "id is null" message then
+            "id"
           else if lib.hasInfix "registered for platform" message then
             "platform"
           else if lib.hasInfix "not a key of" message then
@@ -149,6 +160,22 @@
           else
             "unrecognized: ${message}"
         ) (map (a: a.message) (lib.filter (a: !a.assertion) config.assertions));
+
+      # Warnings are the third platform state: neither an assertion failure nor
+      # silence.
+      warnedClauses =
+        config:
+        map (
+          message:
+          if lib.hasInfix "carries no platform" message then "platform-unset" else "unrecognized: ${message}"
+        ) (config.warnings or [ ]);
+
+      # A no-platform queue selected on a darwin host: warned, not asserted.
+      platformUnsetProbe = evalBare "aarch64-darwin" {
+        enable = true;
+        outpost = "magnetite-01";
+        outposts = wired;
+      };
 
       distinctWorkDirs = paths: paths != [ ] && lib.length (lib.unique paths) == lib.length paths;
     in
@@ -174,37 +201,86 @@
             map (name: linux.systemd.user.services.${name}.Service.WorkingDirectory) (units linux)
           );
 
+          # Selection: the exact-platform tier picks stibnite-01 on darwin, and
+          # with no linux-platform entry the no-platform tier picks
+          # magnetite-01 on linux. Both come from the module's registry, so a
+          # wrong name or a missing merge shows up here.
+          darwinOutpost = darwin.services.devin-worker.outpost;
+          darwinSelectedPlatform =
+            darwin.services.devin-worker.outposts.${darwin.services.devin-worker.outpost}.platform;
+          darwinWarned = warnedClauses darwin;
+
+          linuxOutpost = linux.services.devin-worker.outpost;
+          linuxSelectedPlatform =
+            linux.services.devin-worker.outposts.${linux.services.devin-worker.outpost}.platform;
+          # magnetite-01 carries no platform, so agreement with a linux host is
+          # unestablished rather than confirmed. Named as its own state: not a
+          # match, not a mismatch, and deliberately not an assertion, because
+          # whether a no-platform queue can serve this worker is unproven.
+          linuxWarned = warnedClauses linux;
+
           wellFormed = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              tokenFile = dummyTokenPath;
+              outposts = wired;
             }
           );
+          # The sibling queue keeps its token, so this also shows a queue whose
+          # own file is missing does not fall back to another's.
           tokenless = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              tokenFile = null;
+              outposts = {
+                "magnetite-01".tokenFile = wired."magnetite-01".tokenFile;
+              };
             }
           );
+          idless = firedClauses (
+            evalBare "aarch64-darwin" {
+              enable = true;
+              outposts = wired // {
+                "stibnite-01" = {
+                  id = null;
+                  inherit (wired."stibnite-01") tokenFile;
+                };
+              };
+            }
+          );
+          # Both platforms named and different, which is the only mismatch the
+          # module asserts on.
           platformMismatch = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              outpost = "magnetite";
-              tokenFile = dummyTokenPath;
+              outpost = "magnetite-01";
+              outposts = wired // {
+                "magnetite-01" = {
+                  platform = "linux";
+                  inherit (wired."magnetite-01") tokenFile;
+                };
+              };
             }
           );
+          platformUnsetFired = firedClauses platformUnsetProbe;
+          platformUnsetWarned = warnedClauses platformUnsetProbe;
           unknownOutpost = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
               outpost = "no-such-queue";
-              tokenFile = dummyTokenPath;
+              outposts = wired;
             }
           );
+          # Two queues naming this host's platform, so no single default
+          # resolves and the exact tier never falls through to the other.
           unresolvedOutpost = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              outposts = { };
-              tokenFile = dummyTokenPath;
+              outposts = wired // {
+                spare = {
+                  platform = "macos";
+                  id = "outpost_env-11111111111111111111111111111111";
+                  tokenFile = "/run/secrets/devin-outposts-token-spare.dummy";
+                };
+              };
             }
           );
         };
@@ -225,9 +301,19 @@
           linuxUnitEnvNames = [ "PATH" ];
           linuxWorkDirsDistinct = true;
 
+          darwinOutpost = "stibnite-01";
+          darwinSelectedPlatform = "macos";
+          darwinWarned = [ ];
+          linuxOutpost = "magnetite-01";
+          linuxSelectedPlatform = null;
+          linuxWarned = [ "platform-unset" ];
+
           wellFormed = [ ];
           tokenless = [ "token" ];
+          idless = [ "id" ];
           platformMismatch = [ "platform" ];
+          platformUnsetFired = [ ];
+          platformUnsetWarned = [ "platform-unset" ];
           unknownOutpost = [ "unknown-outpost" ];
           unresolvedOutpost = [ "unset-outpost" ];
         };

--- a/modules/checks/devin-worker.nix
+++ b/modules/checks/devin-worker.nix
@@ -191,6 +191,14 @@
           darwinWorkDirsDistinct = distinctWorkDirs (
             map (name: darwin.launchd.agents.${name}.config.WorkingDirectory) (agents darwin)
           );
+          # Restart behaviour, which is where the two supervisors differ. On
+          # darwin the worker is kept alive by the presence of its own token
+          # file, so a missing secret stops it instead of respawning at
+          # launchd's floor; `KeepAlive = true` would reintroduce that loop.
+          darwinKeepAliveOnTokenPath =
+            lib.attrNames
+              darwin.launchd.agents."devin-worker-1".config.KeepAlive.PathState;
+          darwinThrottleInterval = darwin.launchd.agents."devin-worker-1".config.ThrottleInterval;
 
           linuxUnits = units linux;
           linuxAgents = agents linux;
@@ -292,6 +300,8 @@
           darwinUnits = [ ];
           darwinPlistEnvKeys = [ "PATH" ];
           darwinWorkDirsDistinct = true;
+          darwinKeepAliveOnTokenPath = [ "/run/secrets/devin-outposts-token-stibnite.dummy" ];
+          darwinThrottleInterval = 30;
 
           linuxUnits = [
             "devin-worker-1"

--- a/modules/checks/devin-worker.nix
+++ b/modules/checks/devin-worker.nix
@@ -1,0 +1,236 @@
+# Structural check for `flake.modules.homeManager.devin`'s worker surface
+# (see modules/home/ai/devin/worker.nix).
+#
+# The module lands disabled on every host, so nothing in the machine
+# configurations exercises it. What the module promises when enabled is
+# checked here instead, with a dummy token path standing in for the sops-nix
+# secret the operator has yet to mint. Only names, counts, and booleans are
+# serialized into the diff, so this check evaluates and never builds a
+# worker's launcher.
+#
+# Two evaluation vehicles, for two different reasons.
+#
+#   * The positive claims run through a minimal real
+#     `homeManagerConfiguration` on both platforms, so launchd plist keys and
+#     systemd unit sections are validated by the actual option types rather
+#     than by a stub of them.
+#
+#   * The assertion claims run through a bare `lib.evalModules` against the
+#     same deferred module. home-manager throws on the whole configuration
+#     when any assertion fails, which makes the failure observable but hides
+#     WHICH clause fired; outside that wrapper the resolved `assertions` list
+#     is an ordinary value and each clause can be identified.
+#
+# Claims exercised:
+#
+# 1. Platform routing and instance fan-out: `workers = 2` produces exactly two
+#    launchd agents and no systemd units on darwin, and exactly two systemd
+#    user services and no launchd agents on linux.
+#
+# 2. No credential in the unit definition. A launchd plist and a systemd unit
+#    are Nix store files readable by every user on the machine, which is why
+#    the token is read from a file by the launcher at start. The service
+#    environment is therefore required to carry PATH and nothing else.
+#
+# 3. Per-instance working directories: session repositories live under
+#    `$(pwd)/repos`, so two instances sharing a working directory would race
+#    on the same checkout.
+#
+# 4. Each assertion clause fires on exactly its own malformed input, and a
+#    well-formed configuration fires none.
+#
+# Severity rationale (Mayo): each claim fails under a plausible incorrect
+# implementation. Dropping the `mkIf isDarwin` / `mkIf isLinux` gates puts
+# units on both platforms and breaks claim 1. Moving the token into
+# `EnvironmentVariables` or `Environment` -- the shortcut this module exists
+# to refuse -- adds a key and breaks claim 2. Deriving the working directory
+# from the outpost alone rather than from the instance index collapses the two
+# paths and breaks claim 3. Weakening any assertion to a tautology empties its
+# fired-clause list, and strengthening one into an always-firing predicate
+# populates `wellFormed`, so claim 4 is falsifiable in both directions.
+{ inputs, self, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      lib = pkgs.lib;
+      mkCheck = self.lib.mkStructuralCheck pkgs;
+
+      dummyTokenPath = "/run/secrets/devin-outposts-token.dummy";
+
+      # The same package set the home configurations get (see
+      # modules/home/mk-home.nix): `self.legacyPackages` is the channel before
+      # flake.overlays.default is applied, where `devin-cli` would resolve to
+      # the channel's older build rather than the one this repository vendors.
+      probePkgs =
+        system:
+        import inputs.nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+          overlays = [ self.overlays.default ];
+        };
+
+      # Real home-manager evaluation: option types enforced, assertions
+      # required to pass (home-manager throws otherwise, so reaching the
+      # values below is itself part of the positive claim).
+      evalHome =
+        {
+          system,
+          homeDirectory,
+          worker,
+        }:
+        (inputs.home-manager.lib.homeManagerConfiguration {
+          pkgs = probePkgs system;
+          modules = [
+            self.modules.homeManager.devin
+            {
+              home = {
+                username = "probe";
+                inherit homeDirectory;
+                stateVersion = "25.05";
+              };
+              services.devin-worker = worker;
+            }
+          ];
+        }).config;
+
+      # Bare module evaluation, for inspecting the assertions themselves.
+      evalBare =
+        system: worker:
+        (lib.evalModules {
+          modules = [
+            self.modules.homeManager.devin
+            {
+              _module.check = false;
+              _module.args.pkgs = probePkgs system;
+              freeformType = lib.types.lazyAttrsOf lib.types.raw;
+            }
+            { services.devin-worker = worker; }
+          ];
+        }).config;
+
+      darwin = evalHome {
+        system = "aarch64-darwin";
+        homeDirectory = "/Users/probe";
+        worker = {
+          enable = true;
+          workers = 2;
+          tokenFile = dummyTokenPath;
+        };
+      };
+
+      linux = evalHome {
+        system = "x86_64-linux";
+        homeDirectory = "/home/probe";
+        worker = {
+          enable = true;
+          workers = 2;
+          tokenFile = dummyTokenPath;
+        };
+      };
+
+      agents = config: lib.attrNames (config.launchd.agents or { });
+      units = config: lib.attrNames (config.systemd.user.services or { });
+
+      # Failing clauses, named by a distinctive substring of their message so
+      # the diff identifies the clause instead of embedding whole prose.
+      firedClauses =
+        config:
+        map (
+          message:
+          if lib.hasInfix "tokenFile is null" message then
+            "token"
+          else if lib.hasInfix "registered for platform" message then
+            "platform"
+          else if lib.hasInfix "not a key of" message then
+            "unknown-outpost"
+          else if lib.hasInfix "no default resolved" message then
+            "unset-outpost"
+          else
+            "unrecognized: ${message}"
+        ) (map (a: a.message) (lib.filter (a: !a.assertion) config.assertions));
+
+      distinctWorkDirs = paths: paths != [ ] && lib.length (lib.unique paths) == lib.length paths;
+    in
+    {
+      checks.devin-worker-structural = mkCheck {
+        name = "devin-worker-structural";
+        actual = {
+          darwinAgents = agents darwin;
+          darwinUnits = units darwin;
+          darwinPlistEnvKeys =
+            lib.attrNames
+              darwin.launchd.agents."devin-worker-1".config.EnvironmentVariables;
+          darwinWorkDirsDistinct = distinctWorkDirs (
+            map (name: darwin.launchd.agents.${name}.config.WorkingDirectory) (agents darwin)
+          );
+
+          linuxUnits = units linux;
+          linuxAgents = agents linux;
+          linuxUnitEnvNames = map (
+            entry: lib.head (lib.splitString "=" entry)
+          ) linux.systemd.user.services."devin-worker-1".Service.Environment;
+          linuxWorkDirsDistinct = distinctWorkDirs (
+            map (name: linux.systemd.user.services.${name}.Service.WorkingDirectory) (units linux)
+          );
+
+          wellFormed = firedClauses (
+            evalBare "aarch64-darwin" {
+              enable = true;
+              tokenFile = dummyTokenPath;
+            }
+          );
+          tokenless = firedClauses (
+            evalBare "aarch64-darwin" {
+              enable = true;
+              tokenFile = null;
+            }
+          );
+          platformMismatch = firedClauses (
+            evalBare "aarch64-darwin" {
+              enable = true;
+              outpost = "magnetite";
+              tokenFile = dummyTokenPath;
+            }
+          );
+          unknownOutpost = firedClauses (
+            evalBare "aarch64-darwin" {
+              enable = true;
+              outpost = "no-such-queue";
+              tokenFile = dummyTokenPath;
+            }
+          );
+          unresolvedOutpost = firedClauses (
+            evalBare "aarch64-darwin" {
+              enable = true;
+              outposts = { };
+              tokenFile = dummyTokenPath;
+            }
+          );
+        };
+        expected = {
+          darwinAgents = [
+            "devin-worker-1"
+            "devin-worker-2"
+          ];
+          darwinUnits = [ ];
+          darwinPlistEnvKeys = [ "PATH" ];
+          darwinWorkDirsDistinct = true;
+
+          linuxUnits = [
+            "devin-worker-1"
+            "devin-worker-2"
+          ];
+          linuxAgents = [ ];
+          linuxUnitEnvNames = [ "PATH" ];
+          linuxWorkDirsDistinct = true;
+
+          wellFormed = [ ];
+          tokenless = [ "token" ];
+          platformMismatch = [ "platform" ];
+          unknownOutpost = [ "unknown-outpost" ];
+          unresolvedOutpost = [ "unset-outpost" ];
+        };
+      };
+    };
+}

--- a/modules/checks/devin-worker.nix
+++ b/modules/checks/devin-worker.nix
@@ -81,6 +81,9 @@
         }:
         (inputs.home-manager.lib.homeManagerConfiguration {
           pkgs = probePkgs system;
+          # Same reason as modules/home/mk-home.nix: a module formal that the
+          # module system cannot resolve throws rather than taking its default.
+          extraSpecialArgs.osConfig = null;
           modules = [
             self.modules.homeManager.devin
             {
@@ -98,6 +101,7 @@
       evalBare =
         system: worker:
         (lib.evalModules {
+          specialArgs.osConfig = null;
           modules = [
             self.modules.homeManager.devin
             {
@@ -124,6 +128,7 @@
         worker = {
           enable = true;
           workers = 2;
+          outpost = "stibnite-01";
           outposts = wired;
         };
       };
@@ -134,6 +139,7 @@
         worker = {
           enable = true;
           workers = 2;
+          outpost = "magnetite-01";
           outposts = wired;
         };
       };
@@ -155,7 +161,7 @@
             "platform"
           else if lib.hasInfix "not a key of" message then
             "unknown-outpost"
-          else if lib.hasInfix "no default resolved" message then
+          else if lib.hasInfix "has not been told which queue it serves" message then
             "unset-outpost"
           else
             "unrecognized: ${message}"
@@ -209,16 +215,15 @@
             map (name: linux.systemd.user.services.${name}.Service.WorkingDirectory) (units linux)
           );
 
-          # Selection: the exact-platform tier picks stibnite-01 on darwin, and
-          # with no linux-platform entry the no-platform tier picks
-          # magnetite-01 on linux. Both come from the module's registry, so a
-          # wrong name or a missing merge shows up here.
-          darwinOutpost = darwin.services.devin-worker.outpost;
+          # `outpost` must have nothing to resolve on its own. A default that
+          # inferred it from the host's platform is what would put every linux
+          # machine in this repository on the same queue.
+          outpostDefault = (evalBare "x86_64-linux" { }).services.devin-worker.outpost;
+
           darwinSelectedPlatform =
             darwin.services.devin-worker.outposts.${darwin.services.devin-worker.outpost}.platform;
           darwinWarned = warnedClauses darwin;
 
-          linuxOutpost = linux.services.devin-worker.outpost;
           linuxSelectedPlatform =
             linux.services.devin-worker.outposts.${linux.services.devin-worker.outpost}.platform;
           # magnetite-01 carries no platform, so agreement with a linux host is
@@ -230,6 +235,7 @@
           wellFormed = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
+              outpost = "stibnite-01";
               outposts = wired;
             }
           );
@@ -238,6 +244,7 @@
           tokenless = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
+              outpost = "stibnite-01";
               outposts = {
                 "magnetite-01".tokenFile = wired."magnetite-01".tokenFile;
               };
@@ -246,6 +253,7 @@
           idless = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
+              outpost = "stibnite-01";
               outposts = wired // {
                 "stibnite-01" = {
                   id = null;
@@ -277,18 +285,19 @@
               outposts = wired;
             }
           );
-          # Two queues naming this host's platform, so no single default
-          # resolves and the exact tier never falls through to the other.
-          unresolvedOutpost = firedClauses (
-            evalBare "aarch64-darwin" {
+          # The regression this module's shape exists to prevent, in the form
+          # it will arrive: pyrite and cinnabar are linux machines coming up
+          # shortly on this same user. Enabling the worker there without naming
+          # a queue must fail, because the alternative -- inferring one -- puts
+          # them on magnetite's queue, where they would serve its sessions
+          # perfectly well and report nothing.
+          secondLinuxHostUnnamed = firedClauses (evalBare "x86_64-linux" { enable = true; });
+          # And naming a queue whose credential this host does not have fails
+          # by name rather than borrowing a sibling's.
+          secondLinuxHostBorrowing = firedClauses (
+            evalBare "x86_64-linux" {
               enable = true;
-              outposts = wired // {
-                spare = {
-                  platform = "macos";
-                  id = "outpost_env-11111111111111111111111111111111";
-                  tokenFile = "/run/secrets/devin-outposts-token-spare.dummy";
-                };
-              };
+              outpost = "magnetite-01";
             }
           );
         };
@@ -311,10 +320,9 @@
           linuxUnitEnvNames = [ "PATH" ];
           linuxWorkDirsDistinct = true;
 
-          darwinOutpost = "stibnite-01";
+          outpostDefault = null;
           darwinSelectedPlatform = "macos";
           darwinWarned = [ ];
-          linuxOutpost = "magnetite-01";
           linuxSelectedPlatform = null;
           linuxWarned = [ "platform-unset" ];
 
@@ -325,7 +333,8 @@
           platformUnsetFired = [ ];
           platformUnsetWarned = [ "platform-unset" ];
           unknownOutpost = [ "unknown-outpost" ];
-          unresolvedOutpost = [ "unset-outpost" ];
+          secondLinuxHostUnnamed = [ "unset-outpost" ];
+          secondLinuxHostBorrowing = [ "token" ];
         };
       };
     };

--- a/modules/checks/hooks.nix
+++ b/modules/checks/hooks.nix
@@ -48,7 +48,7 @@
             # A `kill` inside a quoted search pattern is data, not a command:
             # the `|` alternations of an rg pattern are not shell operators.
             # Observed 2026-08-12: the gate pattern-matched the quoted word and
-            # stalled a crewmate on two read-only ripgrep searches.
+            # stalled an agent worker on two read-only ripgrep searches.
             "allow rg -n \"process group|kill -.*-\\$|setsid|pgid|kill_tree|_drain\" bin/*.sh | head -40"
             "allow rg -n 'watchdog|kill -9' modules/ | head -20"
             # A genuine process termination next to a quoted pattern still gates.

--- a/modules/devshells/default.nix
+++ b/modules/devshells/default.nix
@@ -102,6 +102,18 @@
           # Document typesetting
           pkgs.typstWithPackages
           pkgs.svgo
+          # The skills apm deploys into .agents/skills/ shell out to these CLIs.
+          # Home-manager supplies them on a fleet machine and nowhere else, so
+          # on a CI runner, an agent sandbox, or a fresh checkout a skill loads
+          # and then dies on its first command. duckdb here is the CLI; the
+          # python binding above is a separate output.
+          pkgs.jujutsu
+          pkgs.ghq
+          pkgs.jaq
+          pkgs.duckdb
+          self'.packages.linear-cli
+          self'.packages.mergify-cli-bin
+          inputs'.llm-agents.packages.openspec
         ]
         # buildbot-effects CLI for local dispatch of hercules-ci-effects
         # (see buildbot-nix/docs/EFFECTS.md). Linux-only: depends on bwrap.

--- a/modules/home/ai/README.md
+++ b/modules/home/ai/README.md
@@ -11,7 +11,11 @@ Two boundaries here account for most wrong edits in this subtree, and neither is
 
 **Generated outputs versus their generators.** `../tools/agents-md.nix` is the single source for every user-level agent context file — `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, and the rest, plus pi's `context` option, which is also what serves atomic through its legacy scan. Those destination files are nix-managed outputs. Edit the generator, never the generated file.
 
-**Source versus delivered.** Skills are authored under `plugins/<group>/.apm/skills/<skill>/` and delivered to `~/.claude/skills/`, `~/.factory/skills/`, and the codex and opencode equivalents as read-only nix-store symlinks. A delivered copy changes only when the build reruns, so it holds pre-change content indefinitely after the source is edited, and a nix store path reports a 1970 mtime whatever it contains. Verify an edit against the source tree; treat the delivered path as a read-only artifact.
+**Source versus delivered.** Skills are authored under `plugins/<group>/.apm/skills/<skill>/`.
+Claude Code, OpenCode, Droid, and Hermes receive read-only nix-store symlinks.
+Codex and Pi consume writable real-file copies under `~/.agents/skills`, which are materialized because Codex v0.135.0 skips symlinked skill-file leaves.
+Delivered content changes only after a build, so it can retain pre-change content indefinitely after the source is edited, and a nix store path reports a 1970 mtime whatever it contains.
+Verify an edit against the source tree and treat delivered content as generated output.
 
 ## Children
 

--- a/modules/home/ai/devin/default.nix
+++ b/modules/home/ai/devin/default.nix
@@ -1,0 +1,160 @@
+# The Devin CLI as a member of the ai aggregate: the packaged CLI plus its
+# declaratively rendered user configuration. `services.devin-worker`, in
+# worker.nix, turns a host into Outposts execution capacity and shares this
+# aspect.
+#
+# Both parts are home-manager rather than system modules because a Devin
+# session runs as a user, with that user's permissions, credentials, and --
+# on macOS -- that user's desktop session. Nothing about it belongs to a
+# system-wide service manager, and home-manager is the layer that reaches
+# every host in this repository where the user exists.
+#
+# The rendered config.json is a Nix store symlink, so the CLI cannot write it
+# back. Anything the CLI would otherwise persist itself -- the first-run theme
+# prompt, keybindings saved from `/shortcuts` -- has to be declared here
+# instead, which is what `settings` is for.
+{ config, ... }:
+{
+  flake.modules.homeManager.ai = {
+    imports = [ config.flake.modules.homeManager.devin ];
+  };
+
+  flake.modules.homeManager.devin =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.devin;
+
+      jsonFormat = pkgs.formats.json { };
+
+      # Only documented keys from
+      # https://docs.devin.ai/cli/reference/configuration/config-file
+      # are emitted, and a null-valued option emits no key at all so the CLI
+      # keeps its own default rather than being pinned to a value this module
+      # invented.
+      dropNull = lib.filterAttrs (_: v: v != null);
+
+      agentSection = dropNull { model = cfg.model; };
+
+      declared = dropNull {
+        agent = if agentSection == { } then null else agentSection;
+        auto_update = cfg.autoUpdate;
+        notify = cfg.notify;
+        theme_mode = cfg.themeMode;
+        attribution = cfg.attribution;
+      };
+    in
+    {
+      options.programs.devin = {
+        enable = lib.mkEnableOption "the Devin CLI with a declaratively rendered user configuration";
+
+        package = lib.mkPackageOption pkgs "devin-cli" { };
+
+        model = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "swe-1-6-fast";
+          description = ''
+            Default model for local CLI sessions, rendered as `agent.model`.
+            Null leaves the key unset, so the CLI applies its own default.
+
+            Model names are not enumerated here: the available set is an
+            account-level property that changes upstream, and a Nix-side enum
+            would reject a newly published model until this module caught up.
+          '';
+        };
+
+        autoUpdate = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether the CLI may download and activate new releases in the
+            background, rendered as `auto_update`.
+
+            Off by default because this CLI comes from the Nix store, where
+            the binary is read-only and the version is a property of the
+            generation. Upstream's background updater promotes a new version
+            by swapping a `current` symlink in a self-managed installation it
+            owns; under Nix there is no such installation to promote into, and
+            a worker service silently running a different build than the one
+            its generation declares is exactly the drift this repository
+            exists to prevent. `nix run .#update-devin-cli` is the update
+            path.
+          '';
+        };
+
+        notify = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "never"
+              "smart"
+              "always"
+            ]
+          );
+          default = null;
+          description = ''
+            Terminal notification policy when a session finishes or needs
+            input, rendered as `notify`. Null leaves the key unset.
+          '';
+        };
+
+        themeMode = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "light"
+              "dark"
+              "terminal-dark"
+              "terminal-light"
+              "nocolor"
+            ]
+          );
+          default = null;
+          description = ''
+            Colour theme, rendered as `theme_mode`. Null leaves the key unset,
+            which is upstream's auto-detect behaviour -- but note that
+            auto-detect asks on first run and cannot record the answer,
+            because the rendered file is a read-only store symlink.
+          '';
+        };
+
+        attribution = lib.mkOption {
+          type = lib.types.nullOr lib.types.bool;
+          default = null;
+          description = ''
+            Whether commits and pull requests the agent creates carry Devin
+            attribution, rendered as `attribution`. Null leaves the key unset.
+          '';
+        };
+
+        settings = lib.mkOption {
+          type = jsonFormat.type;
+          default = { };
+          example = lib.literalExpression ''
+            {
+              permissions.deny = [ "Exec(sudo)" ];
+              keymap.global.clear_screen = "ctrl-shift-k";
+            }
+          '';
+          description = ''
+            Additional configuration merged over the keys the typed options
+            above produce. This is the escape hatch for the rest of the
+            documented surface -- permissions, keymap, proxy, sandbox,
+            read_config_from -- without this module having to mirror every
+            option upstream defines.
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        home.packages = [ cfg.package ];
+
+        xdg.configFile."devin/config.json".source = jsonFormat.generate "devin-config.json" (
+          lib.recursiveUpdate declared cfg.settings
+        );
+      };
+    };
+}

--- a/modules/home/ai/devin/worker.nix
+++ b/modules/home/ai/devin/worker.nix
@@ -13,6 +13,16 @@
 # queue when starting the session and cannot know which worker is free.
 # Concurrency belongs on the worker count.
 #
+# Which queue a host serves is named per host, never derived. `outpost` has no
+# default: enabling the service without naming a queue fails evaluation and
+# names the host. The tempting inference -- serve the queue whose platform
+# matches this host -- is wrong here, because this repository carries six
+# NixOS machines and four darwin ones, so it would put every linux host that
+# enabled the service onto the same linux queue. Those workers would serve
+# another machine's sessions perfectly well, since N workers on one queue
+# serve N concurrent sessions, which is exactly why nothing would report it.
+# `platform` validates the pairing a host names; it never picks one.
+#
 # Per host the platform decides the supervisor:
 #
 #   * darwin gets a launchd USER AGENT, deliberately not a system daemon.
@@ -85,6 +95,9 @@
       config,
       lib,
       pkgs,
+      # Supplied as a specialArg by home-manager's NixOS and nix-darwin
+      # modules, absent in a standalone home configuration.
+      osConfig ? null,
       ...
     }:
     let
@@ -92,24 +105,20 @@
 
       hostOutpostPlatform = if pkgs.stdenv.hostPlatform.isDarwin then "macos" else "linux";
 
-      # A registry entry's platform may be null: the account permits creating
-      # an outpost without one, and the reference reads a null platform as the
-      # account default rather than as any particular OS. Candidates are
-      # therefore resolved in two tiers -- entries that name this host's
-      # platform, and only if there are none, entries that name no platform at
-      # all. That gives each host in this fleet exactly one candidate
-      # (stibnite-01 names macos; magnetite-01 names nothing) without treating
-      # a null as equal to linux.
-      exactPlatformOutposts = lib.attrNames (
-        lib.filterAttrs (_: outpost: outpost.platform == hostOutpostPlatform) cfg.outposts
-      );
-
-      unsetPlatformOutposts = lib.attrNames (
-        lib.filterAttrs (_: outpost: outpost.platform == null) cfg.outposts
-      );
-
-      platformOutposts =
-        if exactPlatformOutposts != [ ] then exactPlatformOutposts else unsetPlatformOutposts;
+      # Which host serves which queue is a deployment decision, so it is named
+      # rather than derived. `platform` validates the pairing; it does not pick
+      # it. Deriving the queue from the platform looked adequate while one
+      # darwin and one linux host had queues, but this repository already
+      # carries six NixOS machines and four darwin ones: under that rule every
+      # further linux host that enabled the service would default onto
+      # magnetite's queue and silently serve its sessions, which Devin permits
+      # -- N workers on one queue serve N concurrent sessions -- and so would
+      # not surface as an error anywhere.
+      hostLabel =
+        if osConfig != null then
+          osConfig.networking.hostName
+        else
+          "${config.home.username or "this user"}@${pkgs.stdenv.hostPlatform.system}";
 
       selected = if cfg.outpost == null then null else cfg.outposts.${cfg.outpost} or null;
 
@@ -340,20 +349,22 @@
 
         outpost = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
-          default = if lib.length platformOutposts == 1 then lib.head platformOutposts else null;
-          defaultText = lib.literalMD ''
-            the single entry of `outposts` naming this host's platform, or when
-            none names it, the single entry naming no platform; `null` when
-            zero or several remain
-          '';
+          default = null;
           example = "magnetite-01";
           description = ''
-            Queue this host's workers serve. The default resolves whenever the
-            registry holds exactly one queue for this platform, which is what
-            makes the two hosts in this repository work without configuration;
-            a third host of an existing platform has to name its own queue,
-            because serving another machine's queue would send that machine's
-            sessions here.
+            Queue this host's workers serve, named per host. Required whenever
+            the service is enabled: enabling without it fails evaluation and
+            names the host.
+
+            There is deliberately no default to infer it from. Which machine
+            serves which queue is a deployment decision, not a computable
+            fact, and the obvious inference -- take the queue whose platform
+            matches this host -- is actively wrong at fleet scale: with six
+            NixOS machines in this repository, every linux host that enabled
+            the service would land on the same linux queue and quietly serve
+            another machine's sessions. Devin allows that, since N workers on
+            one queue serve N concurrent sessions, so nothing upstream would
+            report it.
           '';
         };
 
@@ -433,9 +444,14 @@
             {
               assertion = cfg.outpost != null;
               message = ''
-                services.devin-worker.outpost is unset and no default resolved:
-                ${toString (lib.length platformOutposts)} queues in services.devin-worker.outposts are candidates for this
-                host (platform "${hostOutpostPlatform}", or no platform when none names it). Name the queue this host serves.
+                services.devin-worker is enabled on ${hostLabel} but services.devin-worker.outpost is
+                unset, so this host has not been told which queue it serves. Name it, e.g.
+                services.devin-worker.outpost = "magnetite-01"; known queues are
+                ${lib.concatStringsSep ", " (lib.attrNames cfg.outposts)}.
+
+                There is no default on purpose. Inferring the queue from this host's platform would
+                put every linux host in this repository on the same queue, serving another machine's
+                sessions without any error to notice.
               '';
             }
             {

--- a/modules/home/ai/devin/worker.nix
+++ b/modules/home/ai/devin/worker.nix
@@ -1,0 +1,386 @@
+# Devin Outposts workers: one option surface, two service backends.
+#
+# An outpost is a named QUEUE of sessions in Devin Cloud, not a machine. A
+# worker is a process that watches one queue, claims a session, and executes
+# every command, file edit, and repository operation locally while Devin's
+# planning loop stays in their cloud; it needs outbound HTTPS only. N workers
+# on one outpost therefore serve N concurrent sessions.
+#
+# That is why `outposts` is a registry of queues and `workers` is a count, and
+# why queues are NOT named per machine index. Naming them `stibnite-1`,
+# `stibnite-2` would partition the queue: a session dispatched to a busy queue
+# would wait while its sibling queue sat idle, because the operator picks a
+# queue when starting the session and cannot know which worker is free.
+# Concurrency belongs on the worker count.
+#
+# Per host the platform decides the supervisor:
+#
+#   * darwin gets a launchd USER AGENT, deliberately not a system daemon.
+#     Devin's computer-use features drive the machine's existing desktop
+#     session and need Screen Recording (screenshots) and Accessibility
+#     (input) granted to the worker process. A system daemon has no desktop
+#     session, so those features would fail with no configuration error to
+#     point at. Note that macOS keys those grants to the executable, which is
+#     a store path here: a CLI version bump changes the path and the grants
+#     have to be given again.
+#
+#   * linux gets a user-scoped systemd service. A user manager stops with the
+#     last login session, so a host serving a queue with nobody logged in also
+#     needs `users.users.<name>.linger = true`. That is a NixOS-level option
+#     this module cannot reach from home-manager; for the machines in this
+#     repository the clan users inventory already sets it (see
+#     modules/clan/inventory/services/users/cameron.nix, which lingers
+#     cameron on magnetite among others), so the seam is closed at the layer
+#     that owns system users rather than duplicated here.
+#
+# Each worker instance gets its own working directory because a session's
+# repositories are checked out under `$(pwd)/repos`: two workers sharing a
+# directory would race on the same checkout. Each also gets its own explicit
+# acceptor id, since the upstream default is generated per worker DATA
+# directory -- which the instances on one host share -- and an id must never
+# be shared, across instances or across machines.
+{ ... }:
+{
+  flake.modules.homeManager.devin =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.services.devin-worker;
+
+      hostOutpostPlatform = if pkgs.stdenv.hostPlatform.isDarwin then "macos" else "linux";
+
+      platformOutposts = lib.attrNames (
+        lib.filterAttrs (_: outpost: outpost.platform == hostOutpostPlatform) cfg.outposts
+      );
+
+      selected = if cfg.outpost == null then null else cfg.outposts.${cfg.outpost} or null;
+
+      indices = lib.genList (index: index + 1) cfg.workers;
+
+      unitName = index: "devin-worker-${toString index}";
+
+      workDir = index: "${cfg.workRoot}/${cfg.outpost}-${toString index}";
+
+      logFile = index: "${cfg.stateDir}/${unitName index}.log";
+
+      # Exit code the launcher uses for a missing credential, distinguishing a
+      # permanently misconfigured worker from a transient failure so systemd
+      # can decline to restart it. EX_CONFIG from sysexits(3).
+      configErrorExit = 78;
+
+      launcher =
+        index:
+        pkgs.writeShellApplication {
+          name = unitName index;
+          runtimeInputs = [
+            cfg.package
+            pkgs.coreutils
+            # Required, not optional: every repository operation in a session
+            # is a git invocation on this machine.
+            pkgs.git
+          ];
+          meta.description = "Devin Outposts worker ${toString index} for the ${toString cfg.outpost} queue";
+          text = ''
+            work_dir=${lib.escapeShellArg (workDir index)}
+            install -d -m 0700 "$work_dir/repos"
+
+            # The token reaches the process from a sops-rendered file read
+            # here, at start, and never from the unit definition: a launchd
+            # plist and a systemd unit both land in the world-readable Nix
+            # store, so a credential written into either is a credential
+            # published to every user on the machine.
+            token_file=${lib.escapeShellArg (if cfg.tokenFile == null then "" else cfg.tokenFile)}
+            if [ ! -s "$token_file" ]; then
+              echo "${unitName index}: no Outposts token at '$token_file'." >&2
+              echo "${unitName index}: set services.devin-worker.tokenFile to the sops-nix path holding a v3 API token whose service-user role grants Outposts read and write scope." >&2
+              echo "${unitName index}: refusing to start. Without a token the CLI would fall back to the operator's interactive login, authenticating as a person rather than this machine and implicitly creating an outpost upstream." >&2
+              exit ${toString configErrorExit}
+            fi
+            DEVIN_OUTPOSTS_TOKEN="$(cat "$token_file")"
+            export DEVIN_OUTPOSTS_TOKEN
+
+            # Stable across restarts, distinct per instance, and carrying the
+            # machine's own name so it cannot collide with a worker elsewhere
+            # in the fleet. Read at runtime rather than at eval time because
+            # home-manager has no hostname to read.
+            nodename="$(uname -n)"
+            DEVIN_WORKER_ACCEPTOR_ID="''${nodename%%.*}-${cfg.outpost}-${toString index}"
+            export DEVIN_WORKER_ACCEPTOR_ID
+
+            cd "$work_dir"
+            exec devin worker start --outpost=${lib.escapeShellArg cfg.outpost} ${lib.escapeShellArgs cfg.extraArgs}
+          '';
+        };
+
+      # launchd and a user systemd unit both start with a minimal PATH, and a
+      # session shells out to whatever the repository's own tooling needs.
+      servicePath = lib.concatStringsSep ":" (
+        [ "${config.home.profileDirectory}/bin" ]
+        ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+          "/usr/local/bin"
+          "/opt/homebrew/bin"
+        ]
+        ++ [
+          "/usr/bin"
+          "/bin"
+          "/usr/sbin"
+          "/sbin"
+        ]
+      );
+    in
+    {
+      options.services.devin-worker = {
+        enable = lib.mkEnableOption ''
+          long-running Devin Outposts workers serving one outpost queue on this
+          host. Off by default: a worker is owned execution capacity that
+          claims sessions and runs them with this user's permissions, so
+          enabling it is a per-host decision taken alongside minting its token
+        '';
+
+        package = lib.mkPackageOption pkgs "devin-cli" { };
+
+        outposts = lib.mkOption {
+          type = lib.types.attrsOf (
+            lib.types.submodule {
+              options = {
+                platform = lib.mkOption {
+                  type = lib.types.enum [
+                    "linux"
+                    "macos"
+                    "windows"
+                  ];
+                  description = ''
+                    Machine platform the queue was created for. The worker
+                    refuses a queue whose platform does not match the machine
+                    it runs on, so this is asserted at evaluation time rather
+                    than discovered when a session is claimed and released.
+                  '';
+                };
+
+                description = lib.mkOption {
+                  type = lib.types.str;
+                  default = "";
+                  description = "Human-readable description, as shown for the outpost in the Devin web app.";
+                };
+              };
+            }
+          );
+          default = {
+            stibnite = {
+              platform = "macos";
+              description = "Apple silicon workstation with a live desktop session for computer use";
+            };
+            magnetite = {
+              platform = "linux";
+              description = "x86_64 server capacity for headless sessions";
+            };
+          };
+          description = ''
+            Outpost queues this repository knows about, keyed by the name they
+            carry in Devin Cloud. Recording them here is a declaration, not a
+            creation: creating and deleting an outpost is an account-level
+            action taken through the web app or `devin worker outpost create`,
+            and nothing in this module reaches upstream to do it.
+          '';
+        };
+
+        outpost = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = if lib.length platformOutposts == 1 then lib.head platformOutposts else null;
+          defaultText = lib.literalMD ''
+            the single entry of `outposts` whose `platform` matches this host,
+            or `null` when zero or several match
+          '';
+          example = "magnetite";
+          description = ''
+            Queue this host's workers serve. The default resolves whenever the
+            registry holds exactly one queue for this platform, which is what
+            makes the two hosts in this repository work without configuration;
+            a third host of an existing platform has to name its own queue,
+            because serving another machine's queue would send that machine's
+            sessions here.
+          '';
+        };
+
+        workers = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 1;
+          description = ''
+            Number of worker instances on this host, and therefore the number
+            of sessions it serves concurrently; further sessions wait in the
+            queue. Each instance gets its own working directory and acceptor
+            id.
+
+            Raising this above one on a macOS host is only useful for sessions
+            that do not use computer use: instances share the machine's single
+            desktop session, so two of them driving mouse and keyboard would
+            fight over it.
+          '';
+        };
+
+        tokenFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = lib.literalExpression ''config.sops.secrets."devin-outposts-token".path'';
+          description = ''
+            Path to a file holding the worker's v3 API token, normally a
+            sops-nix secret rendered at activation. The token belongs to a
+            service user whose role grants Outposts read and write scope.
+
+            It is a bearer credential, so it must never be written into a Nix
+            store path: not into a rendered configuration file, and not into a
+            launchd plist's EnvironmentVariables or a systemd unit's
+            Environment, both of which are store files readable by every user
+            on the machine. The launcher reads this file at start and passes
+            the value through DEVIN_OUTPOSTS_TOKEN, and refuses to start when
+            the file is missing or empty rather than falling back to the CLI's
+            interactive login.
+
+            Left null deliberately: minting the token is an account-level
+            action for the operator, and until it exists this option has
+            nothing correct to point at.
+          '';
+        };
+
+        workRoot = lib.mkOption {
+          type = lib.types.path;
+          default = "${config.home.homeDirectory}/devin/workers";
+          defaultText = lib.literalExpression ''"''${config.home.homeDirectory}/devin/workers"'';
+          description = ''
+            Parent directory of the per-instance working directories, each
+            `<workRoot>/<outpost>-<index>`. Sessions check their repositories
+            out under an instance's `repos` subdirectory and are free to write
+            anywhere beneath it, so this is deliberately a plain directory in
+            the user's home rather than anything this repository manages
+            declaratively.
+          '';
+        };
+
+        stateDir = lib.mkOption {
+          type = lib.types.path;
+          default = "${config.xdg.stateHome}/devin-worker";
+          defaultText = lib.literalExpression ''"''${config.xdg.stateHome}/devin-worker"'';
+          description = "Directory holding each instance's service log.";
+        };
+
+        extraArgs = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "--poll-interval-secs=15" ];
+          description = "Extra arguments appended to `devin worker start`.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = cfg.outpost != null;
+            message = ''
+              services.devin-worker.outpost is unset and no default resolved:
+              services.devin-worker.outposts holds ${toString (lib.length platformOutposts)} queues for this host's platform (${hostOutpostPlatform}). Name the queue this host serves.
+            '';
+          }
+          {
+            assertion = cfg.outpost == null || selected != null;
+            message = ''
+              services.devin-worker.outpost is "${toString cfg.outpost}", which is not a key of
+              services.devin-worker.outposts (${lib.concatStringsSep ", " (lib.attrNames cfg.outposts)}).
+            '';
+          }
+          {
+            assertion = cfg.outpost == null || selected == null || selected.platform == hostOutpostPlatform;
+            message = ''
+              services.devin-worker.outpost "${toString cfg.outpost}" is registered for platform
+              "${toString (selected.platform or null)}" but this host is "${hostOutpostPlatform}". The worker
+              validates the machine's OS against the outpost's platform and refuses to serve a mismatch.
+            '';
+          }
+          {
+            assertion = cfg.tokenFile != null;
+            message = ''
+              services.devin-worker is enabled but services.devin-worker.tokenFile is null.
+              Point it at the sops-nix path holding the Outposts token, e.g.
+
+                sops.secrets."devin-outposts-token" = { };
+                services.devin-worker.tokenFile = config.sops.secrets."devin-outposts-token".path;
+
+              Starting without a token is not a fallback worth taking: the CLI would authenticate as
+              the operator's personal login and implicitly create an outpost upstream.
+            '';
+          }
+        ];
+
+        # launchd opens the log file and systemd enters the working directory
+        # before the launcher runs, so neither can be left to the launcher to
+        # create on first start.
+        home.activation.devinWorkerDirectories =
+          lib.hm.dag.entryBefore
+            [
+              "setupLaunchAgents"
+              "reloadSystemd"
+            ]
+            ''
+              $DRY_RUN_CMD install -d -m 0700 ${lib.escapeShellArg cfg.stateDir} ${
+                lib.escapeShellArgs (map (index: workDir index) indices)
+              }
+            '';
+
+        launchd.agents = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
+          lib.listToAttrs (
+            map (
+              index:
+              lib.nameValuePair (unitName index) {
+                enable = true;
+                config = {
+                  ProgramArguments = [ (lib.getExe (launcher index)) ];
+                  RunAtLoad = true;
+                  KeepAlive = true;
+                  WorkingDirectory = workDir index;
+                  StandardOutPath = logFile index;
+                  StandardErrorPath = logFile index;
+                  # Not "Background": that class caps CPU and I/O priority,
+                  # and a session on this worker runs the repository's builds
+                  # and tests.
+                  ProcessType = "Standard";
+                  # PATH only. A credential here would be a store-published
+                  # credential; see services.devin-worker.tokenFile.
+                  EnvironmentVariables.PATH = servicePath;
+                };
+              }
+            ) indices
+          )
+        );
+
+        systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+          lib.listToAttrs (
+            map (
+              index:
+              lib.nameValuePair (unitName index) {
+                Unit = {
+                  Description = "Devin Outposts worker ${toString index} serving the ${toString cfg.outpost} queue";
+                  After = [ "network-online.target" ];
+                  Wants = [ "network-online.target" ];
+                };
+                Service = {
+                  ExecStart = lib.getExe (launcher index);
+                  WorkingDirectory = workDir index;
+                  Restart = "on-failure";
+                  # A worker that cannot authenticate stays down instead of
+                  # polling the API on a loop; every other failure is treated
+                  # as transient and retried on a slow cadence.
+                  RestartPreventExitStatus = configErrorExit;
+                  RestartSec = 30;
+                  Environment = [ "PATH=${servicePath}" ];
+                };
+                Install.WantedBy = [ "default.target" ];
+              }
+            ) indices
+          )
+        );
+      };
+    };
+}

--- a/modules/home/ai/devin/worker.nix
+++ b/modules/home/ai/devin/worker.nix
@@ -39,6 +39,32 @@
 # acceptor id, since the upstream default is generated per worker DATA
 # directory -- which the instances on one host share -- and an id must never
 # be shared, across instances or across machines.
+#
+# One token file per queue, for rotation rather than for containment. The web
+# UI issues a token when an outpost is created, but a token issued for one
+# outpost lists every outpost through the account-level endpoint: measured
+# against the live account, these credentials are account-scoped for reads
+# despite being issued per outpost. Separate files therefore buy independent
+# rotation, not blast-radius containment, and no registry entry may fall back
+# to a sibling's file -- a queue without its own token refuses to start, so a
+# worker never runs addressed at one queue with another queue's credential.
+#
+# Rotating one, in three steps:
+#
+#   1. Rotate the token in the Devin UI for that outpost. No rebuild is
+#      needed for this step alone -- nothing in this repository holds the
+#      value, and the running worker still holds the old one.
+#   2. Replace that one key's value in
+#      secrets/home-manager/users/crs58/secrets.yaml. The other outpost's key
+#      is a separate entry and is not touched.
+#   3. Re-activate that host so the new value reaches the worker's runtime
+#      path, then restart the worker service
+#      (`launchctl kickstart -k gui/$UID/devin-worker-1` on darwin,
+#      `systemctl --user restart devin-worker-1` on linux).
+#
+# Step 3's restart is not optional: the launcher reads the token from the file
+# once, at process start, so a running worker keeps using the old value until
+# it is restarted, however current the file on disk has become.
 { ... }:
 {
   flake.modules.homeManager.devin =
@@ -53,11 +79,39 @@
 
       hostOutpostPlatform = if pkgs.stdenv.hostPlatform.isDarwin then "macos" else "linux";
 
-      platformOutposts = lib.attrNames (
+      # A registry entry's platform may be null: the account permits creating
+      # an outpost without one, and the reference reads a null platform as the
+      # account default rather than as any particular OS. Candidates are
+      # therefore resolved in two tiers -- entries that name this host's
+      # platform, and only if there are none, entries that name no platform at
+      # all. That gives each host in this fleet exactly one candidate
+      # (stibnite-01 names macos; magnetite-01 names nothing) without treating
+      # a null as equal to linux.
+      exactPlatformOutposts = lib.attrNames (
         lib.filterAttrs (_: outpost: outpost.platform == hostOutpostPlatform) cfg.outposts
       );
 
+      unsetPlatformOutposts = lib.attrNames (
+        lib.filterAttrs (_: outpost: outpost.platform == null) cfg.outposts
+      );
+
+      platformOutposts =
+        if exactPlatformOutposts != [ ] then exactPlatformOutposts else unsetPlatformOutposts;
+
       selected = if cfg.outpost == null then null else cfg.outposts.${cfg.outpost} or null;
+
+      # Neither a match nor a mismatch: whether a queue with no platform can
+      # serve this host is unproven here, so the module reports the state and
+      # leaves the worker's own OS validation as the authority at claim time.
+      selectedPlatformUnset = selected != null && selected.platform == null;
+
+      # Both resolve to a harmless empty value when the registry entry is
+      # missing or incomplete, so the assertions below are what report the
+      # problem rather than an evaluation error from deep inside the launcher.
+      selectedOutpostId =
+        if selected == null then "" else (if selected.id == null then "" else selected.id);
+
+      selectedTokenFile = if selected == null then null else selected.tokenFile;
 
       indices = lib.genList (index: index + 1) cfg.workers;
 
@@ -93,10 +147,16 @@
             # plist and a systemd unit both land in the world-readable Nix
             # store, so a credential written into either is a credential
             # published to every user on the machine.
-            token_file=${lib.escapeShellArg (if cfg.tokenFile == null then "" else cfg.tokenFile)}
+            #
+            # This queue's own file, with no shared option to fall back to, so
+            # a queue whose file is missing refuses to start rather than
+            # running with a sibling's credential. That is addressing
+            # discipline, not isolation: the credentials are account-scoped
+            # for reads.
+            token_file=${lib.escapeShellArg (if selectedTokenFile == null then "" else selectedTokenFile)}
             if [ ! -s "$token_file" ]; then
-              echo "${unitName index}: no Outposts token at '$token_file'." >&2
-              echo "${unitName index}: set services.devin-worker.tokenFile to the sops-nix path holding a v3 API token whose service-user role grants Outposts read and write scope." >&2
+              echo "${unitName index}: no Outposts token for the ${toString cfg.outpost} queue at '$token_file'." >&2
+              echo "${unitName index}: set services.devin-worker.outposts.${toString cfg.outpost}.tokenFile to the sops-nix path holding that outpost's worker token." >&2
               echo "${unitName index}: refusing to start. Without a token the CLI would fall back to the operator's interactive login, authenticating as a person rather than this machine and implicitly creating an outpost upstream." >&2
               exit ${toString configErrorExit}
             fi
@@ -111,8 +171,12 @@
             DEVIN_WORKER_ACCEPTOR_ID="''${nodename%%.*}-${cfg.outpost}-${toString index}"
             export DEVIN_WORKER_ACCEPTOR_ID
 
+            # Addressed by id rather than by name: a name can be renamed in
+            # the web UI, and a stale name would surface as a failure at claim
+            # time on a machine nobody is watching, while the id is stable for
+            # the queue's lifetime.
             cd "$work_dir"
-            exec devin worker start --outpost=${lib.escapeShellArg cfg.outpost} ${lib.escapeShellArgs cfg.extraArgs}
+            exec devin worker start --outpost=${lib.escapeShellArg selectedOutpostId} ${lib.escapeShellArgs cfg.extraArgs}
           '';
         };
 
@@ -147,17 +211,89 @@
           type = lib.types.attrsOf (
             lib.types.submodule {
               options = {
-                platform = lib.mkOption {
-                  type = lib.types.enum [
-                    "linux"
-                    "macos"
-                    "windows"
-                  ];
+                id = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "outpost_env-0123456789abcdef0123456789abcdef";
                   description = ''
-                    Machine platform the queue was created for. The worker
-                    refuses a queue whose platform does not match the machine
-                    it runs on, so this is asserted at evaluation time rather
-                    than discovered when a session is claimed and released.
+                    Stable identifier the web UI issues for the queue, of the
+                    form `outpost_env-<32 hex>`. `devin worker start
+                    --outpost=` accepts either a name or an id, and this
+                    module passes the id: the name is the operator's label and
+                    can be changed in the UI, at which point a name-addressed
+                    worker would keep polling and fail when it tried to claim,
+                    on a machine nobody is watching.
+
+                    Null until the queue exists, because the id is issued
+                    rather than chosen. Enabling a worker for an entry with no
+                    id fails evaluation, naming the outpost: a queue that
+                    cannot be addressed is not a working default. Fill it in
+                    here, beside the platform, once the queue is created --
+                    the id is an identifier, not a credential.
+                  '';
+                };
+
+                tokenFile = lib.mkOption {
+                  type = lib.types.nullOr lib.types.path;
+                  default = null;
+                  example = lib.literalExpression ''config.sops.secrets."devin-outposts-token-magnetite".path'';
+                  description = ''
+                    Path to a file holding this queue's worker token, normally
+                    a sops-nix secret rendered at activation.
+
+                    One file per queue, for rotation rather than for
+                    containment. The web UI issues a token when an outpost is
+                    created, but a token issued for one outpost lists every
+                    outpost through the account-level endpoint -- measured
+                    against the live account -- so these credentials are
+                    account-scoped for reads despite being issued per outpost.
+                    Separate files buy independent rotation, not a smaller
+                    blast radius.
+
+                    There is deliberately no host-level or module-level token
+                    option, so a queue whose file is missing cannot fall back
+                    to a sibling's: it refuses to start, and a worker never
+                    runs addressed at one queue holding another's credential.
+
+                    The token is a bearer credential, so it must never be
+                    written into a Nix store path: not into a rendered
+                    configuration file, and not into a launchd plist's
+                    EnvironmentVariables or a systemd unit's Environment, both
+                    of which are store files readable by every user on the
+                    machine. The launcher reads this file at start and passes
+                    the value through DEVIN_OUTPOSTS_TOKEN.
+
+                    Left null in the registry defaults deliberately: minting
+                    the token is an account-level action for the operator, and
+                    until it exists this option has nothing correct to point
+                    at.
+                  '';
+                };
+
+                platform = lib.mkOption {
+                  type = lib.types.nullOr (
+                    lib.types.enum [
+                      "linux"
+                      "macos"
+                      "windows"
+                    ]
+                  );
+                  default = null;
+                  description = ''
+                    Machine platform the queue was created for, or null when
+                    the outpost was created without one -- which the account
+                    permits, and which the reference reads as the account
+                    default rather than as a particular OS.
+
+                    A platform that names a different OS than this host is a
+                    mismatch and fails evaluation: the worker validates the
+                    machine's OS against the outpost's platform, and failing
+                    here beats discovering it as sessions are claimed and
+                    released. A null platform is neither a match nor a
+                    mismatch. Whether a queue with no platform can serve this
+                    host is not established, so it is reported as its own
+                    state -- a warning naming the outpost -- and the worker's
+                    own validation remains the authority at claim time.
                   '';
                 };
 
@@ -169,22 +305,23 @@
               };
             }
           );
-          default = {
-            stibnite = {
-              platform = "macos";
-              description = "Apple silicon workstation with a live desktop session for computer use";
-            };
-            magnetite = {
-              platform = "linux";
-              description = "x86_64 server capacity for headless sessions";
-            };
-          };
+          default = { };
           description = ''
             Outpost queues this repository knows about, keyed by the name they
             carry in Devin Cloud. Recording them here is a declaration, not a
             creation: creating and deleting an outpost is an account-level
             action taken through the web app or `devin worker outpost create`,
             and nothing in this module reaches upstream to do it.
+
+            The fleet's own queues are populated by this module's config layer
+            rather than by this option's default, because an option default is
+            replaced wholesale by any definition: a caller adding one entry's
+            `id` or `tokenFile` through a default-carried registry would drop
+            every other entry, and drop the `platform` of the entry it was
+            editing. Definitions merge, so with the registry in the config
+            layer a caller writing `outposts.magnetite.tokenFile = ...` adds
+            to it. Overriding a value this module sets needs `lib.mkForce`,
+            since the module's own entries are `lib.mkDefault`.
           '';
         };
 
@@ -222,30 +359,6 @@
           '';
         };
 
-        tokenFile = lib.mkOption {
-          type = lib.types.nullOr lib.types.path;
-          default = null;
-          example = lib.literalExpression ''config.sops.secrets."devin-outposts-token".path'';
-          description = ''
-            Path to a file holding the worker's v3 API token, normally a
-            sops-nix secret rendered at activation. The token belongs to a
-            service user whose role grants Outposts read and write scope.
-
-            It is a bearer credential, so it must never be written into a Nix
-            store path: not into a rendered configuration file, and not into a
-            launchd plist's EnvironmentVariables or a systemd unit's
-            Environment, both of which are store files readable by every user
-            on the machine. The launcher reads this file at start and passes
-            the value through DEVIN_OUTPOSTS_TOKEN, and refuses to start when
-            the file is missing or empty rather than falling back to the CLI's
-            interactive login.
-
-            Left null deliberately: minting the token is an account-level
-            action for the operator, and until it exists this option has
-            nothing correct to point at.
-          '';
-        };
-
         workRoot = lib.mkOption {
           type = lib.types.path;
           default = "${config.home.homeDirectory}/devin/workers";
@@ -275,112 +388,168 @@
         };
       };
 
-      config = lib.mkIf cfg.enable {
-        assertions = [
-          {
-            assertion = cfg.outpost != null;
-            message = ''
-              services.devin-worker.outpost is unset and no default resolved:
-              services.devin-worker.outposts holds ${toString (lib.length platformOutposts)} queues for this host's platform (${hostOutpostPlatform}). Name the queue this host serves.
-            '';
-          }
-          {
-            assertion = cfg.outpost == null || selected != null;
-            message = ''
-              services.devin-worker.outpost is "${toString cfg.outpost}", which is not a key of
-              services.devin-worker.outposts (${lib.concatStringsSep ", " (lib.attrNames cfg.outposts)}).
-            '';
-          }
-          {
-            assertion = cfg.outpost == null || selected == null || selected.platform == hostOutpostPlatform;
-            message = ''
-              services.devin-worker.outpost "${toString cfg.outpost}" is registered for platform
-              "${toString (selected.platform or null)}" but this host is "${hostOutpostPlatform}". The worker
-              validates the machine's OS against the outpost's platform and refuses to serve a mismatch.
-            '';
-          }
-          {
-            assertion = cfg.tokenFile != null;
-            message = ''
-              services.devin-worker is enabled but services.devin-worker.tokenFile is null.
-              Point it at the sops-nix path holding the Outposts token, e.g.
+      config = lib.mkMerge [
+        # Unconditional, and pure data: the registry has to be readable for
+        # `outpost` to resolve its default, and describing a queue commits this
+        # host to nothing.
+        {
+          # Read from the live account through the fleet API, not assumed: the
+          # names carry an -01 suffix, and magnetite-01 was created without a
+          # platform. Addressing by id is what makes the suffix a labelling
+          # detail rather than a claim-time failure.
+          services.devin-worker.outposts = {
+            "stibnite-01" = {
+              id = lib.mkDefault "outpost_env-f47bd2ee30824fe6bc5f9330f67f3670";
+              platform = lib.mkDefault "macos";
+              description = lib.mkDefault "Apple silicon workstation with a live desktop session for computer use";
+            };
+            "magnetite-01" = {
+              id = lib.mkDefault "outpost_env-e178cc2f14f84011b05f52ea17ccdb66";
+              # Platform deliberately left null, mirroring the account: the
+              # outpost was created without one, and asserting linux here
+              # would be this module inventing a fact the account does not
+              # carry.
+              description = lib.mkDefault "x86_64 server capacity for headless sessions";
+            };
+          };
+        }
 
-                sops.secrets."devin-outposts-token" = { };
-                services.devin-worker.tokenFile = config.sops.secrets."devin-outposts-token".path;
+        (lib.mkIf cfg.enable {
+          assertions = [
+            {
+              assertion = cfg.outpost != null;
+              message = ''
+                services.devin-worker.outpost is unset and no default resolved:
+                ${toString (lib.length platformOutposts)} queues in services.devin-worker.outposts are candidates for this
+                host (platform "${hostOutpostPlatform}", or no platform when none names it). Name the queue this host serves.
+              '';
+            }
+            {
+              assertion = cfg.outpost == null || selected != null;
+              message = ''
+                services.devin-worker.outpost is "${toString cfg.outpost}", which is not a key of
+                services.devin-worker.outposts (${lib.concatStringsSep ", " (lib.attrNames cfg.outposts)}).
+              '';
+            }
+            {
+              assertion =
+                cfg.outpost == null
+                || selected == null
+                || selected.platform == null
+                || selected.platform == hostOutpostPlatform;
+              message = ''
+                services.devin-worker.outpost "${toString cfg.outpost}" is registered for platform
+                "${toString (selected.platform or null)}" but this host is "${hostOutpostPlatform}". The worker
+                validates the machine's OS against the outpost's platform and refuses to serve a mismatch.
+              '';
+            }
+            {
+              assertion = cfg.outpost == null || selected == null || selected.id != null;
+              message = ''
+                services.devin-worker.outposts.${toString cfg.outpost}.id is null, so this host has no
+                stable address for the queue it is meant to serve. The web UI issues the id as
+                outpost_env-<32 hex> when the outpost is created; set it beside that entry's platform.
 
-              Starting without a token is not a fallback worth taking: the CLI would authenticate as
-              the operator's personal login and implicitly create an outpost upstream.
-            '';
-          }
-        ];
+                The name is not used as the address on purpose: renaming the outpost in the UI would
+                leave a name-addressed worker failing at claim time rather than here.
+              '';
+            }
+            {
+              assertion = cfg.outpost == null || selected == null || selected.tokenFile != null;
+              message = ''
+                services.devin-worker is enabled but
+                services.devin-worker.outposts.${toString cfg.outpost}.tokenFile is null.
+                Point it at the sops-nix path holding that outpost's own worker token, e.g.
 
-        # launchd opens the log file and systemd enters the working directory
-        # before the launcher runs, so neither can be left to the launcher to
-        # create on first start.
-        home.activation.devinWorkerDirectories =
-          lib.hm.dag.entryBefore
-            [
-              "setupLaunchAgents"
-              "reloadSystemd"
-            ]
-            ''
-              $DRY_RUN_CMD install -d -m 0700 ${lib.escapeShellArg cfg.stateDir} ${
-                lib.escapeShellArgs (map (index: workDir index) indices)
-              }
-            '';
+                  sops.secrets."devin-outposts-token-<host>" = { mode = "0400"; };
+                  services.devin-worker.outposts."${toString cfg.outpost}".tokenFile =
+                    config.sops.secrets."devin-outposts-token-<host>".path;
 
-        launchd.agents = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
-          lib.listToAttrs (
-            map (
-              index:
-              lib.nameValuePair (unitName index) {
-                enable = true;
-                config = {
-                  ProgramArguments = [ (lib.getExe (launcher index)) ];
-                  RunAtLoad = true;
-                  KeepAlive = true;
-                  WorkingDirectory = workDir index;
-                  StandardOutPath = logFile index;
-                  StandardErrorPath = logFile index;
-                  # Not "Background": that class caps CPU and I/O priority,
-                  # and a session on this worker runs the repository's builds
-                  # and tests.
-                  ProcessType = "Standard";
-                  # PATH only. A credential here would be a store-published
-                  # credential; see services.devin-worker.tokenFile.
-                  EnvironmentVariables.PATH = servicePath;
-                };
-              }
-            ) indices
-          )
-        );
+                No entry falls back to another's file, so this cannot be satisfied by a sibling
+                queue's token even though the credentials are account-scoped for reads. Starting
+                without one is not a fallback worth taking: the CLI would authenticate as the
+                operator's personal login and implicitly create an outpost upstream.
+              '';
+            }
+          ];
 
-        systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
-          lib.listToAttrs (
-            map (
-              index:
-              lib.nameValuePair (unitName index) {
-                Unit = {
-                  Description = "Devin Outposts worker ${toString index} serving the ${toString cfg.outpost} queue";
-                  After = [ "network-online.target" ];
-                  Wants = [ "network-online.target" ];
-                };
-                Service = {
-                  ExecStart = lib.getExe (launcher index);
-                  WorkingDirectory = workDir index;
-                  Restart = "on-failure";
-                  # A worker that cannot authenticate stays down instead of
-                  # polling the API on a loop; every other failure is treated
-                  # as transient and retried on a slow cadence.
-                  RestartPreventExitStatus = configErrorExit;
-                  RestartSec = 30;
-                  Environment = [ "PATH=${servicePath}" ];
-                };
-                Install.WantedBy = [ "default.target" ];
-              }
-            ) indices
-          )
-        );
-      };
+          warnings = lib.optional selectedPlatformUnset ''
+            services.devin-worker.outposts."${toString cfg.outpost}" carries no platform, so this
+            host's agreement with it is unestablished rather than confirmed: the account permits an
+            outpost without a platform and the reference reads that as the account default. This is
+            neither a match nor a mismatch here, and the worker's own OS validation is the authority
+            when it claims a session. Set the platform on the outpost upstream, and on this entry, to
+            have the disagreement caught at evaluation instead.
+          '';
+
+          # launchd opens the log file and systemd enters the working directory
+          # before the launcher runs, so neither can be left to the launcher to
+          # create on first start.
+          home.activation.devinWorkerDirectories =
+            lib.hm.dag.entryBefore
+              [
+                "setupLaunchAgents"
+                "reloadSystemd"
+              ]
+              ''
+                $DRY_RUN_CMD install -d -m 0700 ${lib.escapeShellArg cfg.stateDir} ${
+                  lib.escapeShellArgs (map (index: workDir index) indices)
+                }
+              '';
+
+          launchd.agents = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
+            lib.listToAttrs (
+              map (
+                index:
+                lib.nameValuePair (unitName index) {
+                  enable = true;
+                  config = {
+                    ProgramArguments = [ (lib.getExe (launcher index)) ];
+                    RunAtLoad = true;
+                    KeepAlive = true;
+                    WorkingDirectory = workDir index;
+                    StandardOutPath = logFile index;
+                    StandardErrorPath = logFile index;
+                    # Not "Background": that class caps CPU and I/O priority,
+                    # and a session on this worker runs the repository's builds
+                    # and tests.
+                    ProcessType = "Standard";
+                    # PATH only. A credential here would be a store-published
+                    # credential; see services.devin-worker.tokenFile.
+                    EnvironmentVariables.PATH = servicePath;
+                  };
+                }
+              ) indices
+            )
+          );
+
+          systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+            lib.listToAttrs (
+              map (
+                index:
+                lib.nameValuePair (unitName index) {
+                  Unit = {
+                    Description = "Devin Outposts worker ${toString index} serving the ${toString cfg.outpost} queue";
+                    After = [ "network-online.target" ];
+                    Wants = [ "network-online.target" ];
+                  };
+                  Service = {
+                    ExecStart = lib.getExe (launcher index);
+                    WorkingDirectory = workDir index;
+                    Restart = "on-failure";
+                    # A worker that cannot authenticate stays down instead of
+                    # polling the API on a loop; every other failure is treated
+                    # as transient and retried on a slow cadence.
+                    RestartPreventExitStatus = configErrorExit;
+                    RestartSec = 30;
+                    Environment = [ "PATH=${servicePath}" ];
+                  };
+                  Install.WantedBy = [ "default.target" ];
+                }
+              ) indices
+            )
+          );
+        })
+      ];
     };
 }

--- a/modules/home/ai/devin/worker.nix
+++ b/modules/home/ai/devin/worker.nix
@@ -33,6 +33,19 @@
 #     cameron on magnetite among others), so the seam is closed at the layer
 #     that owns system users rather than duplicated here.
 #
+# The two supervisors do not reach exact parity on restart, and the difference
+# is stated here rather than implied away. systemd stops a worker that exits
+# with the config-error code and retries anything else after 30s
+# (`RestartPreventExitStatus`). launchd has no per-exit-code equivalent, and
+# its `KeepAlive` dictionary conditions are ORed, so only one is usable:
+# `PathState` on the token file. What darwin therefore does on a missing token
+# is stop -- there is no path to keep alive, so no respawn -- and start on its
+# own once the secret is rendered there. What it does NOT do is distinguish a
+# token file that exists but is empty or unreadable: the launcher still refuses
+# to start, and launchd still respawns it, every 30s under the
+# `ThrottleInterval` set here rather than at its ten-second floor. That case is
+# a slow loop on darwin where linux would stop.
+#
 # Each worker instance gets its own working directory because a session's
 # repositories are checked out under `$(pwd)/repos`: two workers sharing a
 # directory would race on the same checkout. Each also gets its own explicit
@@ -319,9 +332,9 @@
             `id` or `tokenFile` through a default-carried registry would drop
             every other entry, and drop the `platform` of the entry it was
             editing. Definitions merge, so with the registry in the config
-            layer a caller writing `outposts.magnetite.tokenFile = ...` adds
-            to it. Overriding a value this module sets needs `lib.mkForce`,
-            since the module's own entries are `lib.mkDefault`.
+            layer a caller writing `outposts."magnetite-01".tokenFile = ...`
+            adds to it. Overriding a value this module sets needs
+            `lib.mkForce`, since the module's own entries are `lib.mkDefault`.
           '';
         };
 
@@ -329,10 +342,11 @@
           type = lib.types.nullOr lib.types.str;
           default = if lib.length platformOutposts == 1 then lib.head platformOutposts else null;
           defaultText = lib.literalMD ''
-            the single entry of `outposts` whose `platform` matches this host,
-            or `null` when zero or several match
+            the single entry of `outposts` naming this host's platform, or when
+            none names it, the single entry naming no platform; `null` when
+            zero or several remain
           '';
-          example = "magnetite";
+          example = "magnetite-01";
           description = ''
             Queue this host's workers serve. The default resolves whenever the
             registry holds exactly one queue for this platform, which is what
@@ -506,7 +520,25 @@
                   config = {
                     ProgramArguments = [ (lib.getExe (launcher index)) ];
                     RunAtLoad = true;
-                    KeepAlive = true;
+                    # launchd has no per-exit-code equivalent of systemd's
+                    # RestartPreventExitStatus, and its dictionary conditions
+                    # are ORed, so exactly one is meaningful. PathState on the
+                    # token file is the one that matches the failure this
+                    # module actually produces: with no secret rendered there
+                    # is nothing to keep alive, so the worker stops instead of
+                    # respawning at launchd's floor, and it starts on its own
+                    # once the path appears. A plain `true` here would loop a
+                    # tokenless worker every ten seconds forever.
+                    KeepAlive =
+                      if selectedTokenFile == null then
+                        true
+                      else
+                        {
+                          PathState.${toString selectedTokenFile} = true;
+                        };
+                    # Matches RestartSec on the systemd side for the failures
+                    # that do respawn; also lifts launchd's ten-second floor.
+                    ThrottleInterval = 30;
                     WorkingDirectory = workDir index;
                     StandardOutPath = logFile index;
                     StandardErrorPath = logFile index;
@@ -515,7 +547,7 @@
                     # and tests.
                     ProcessType = "Standard";
                     # PATH only. A credential here would be a store-published
-                    # credential; see services.devin-worker.tokenFile.
+                    # credential; see the outpost entry's tokenFile.
                     EnvironmentVariables.PATH = servicePath;
                   };
                 }
@@ -528,11 +560,7 @@
               map (
                 index:
                 lib.nameValuePair (unitName index) {
-                  Unit = {
-                    Description = "Devin Outposts worker ${toString index} serving the ${toString cfg.outpost} queue";
-                    After = [ "network-online.target" ];
-                    Wants = [ "network-online.target" ];
-                  };
+                  Unit.Description = "Devin Outposts worker ${toString index} serving the ${toString cfg.outpost} queue";
                   Service = {
                     ExecStart = lib.getExe (launcher index);
                     WorkingDirectory = workDir index;

--- a/modules/home/ai/skills/default.nix
+++ b/modules/home/ai/skills/default.nix
@@ -78,13 +78,13 @@
       # nix store; codex (v0.135.0) skips symlinked file leaves in its loader and
       # therefore sees no skills. Materializing the tree as real files via a
       # home.activation copy (below) avoids the symlink leaves. -L dereferences
-      # any symlinks so the result is real files; --no-preserve=mode makes the
-      # copies writable (store files are read-only).
+      # any symlinks so the result is real files while preserving whether each
+      # source file is executable. The activation copy below adds user write permission.
       agentsSkillsTree = pkgs.runCommandLocal "agents-skills" { } (
         lib.concatStringsSep "\n" (
           lib.mapAttrsToList (name: path: ''
             mkdir -p "$out/${name}"
-            cp -RL --no-preserve=mode ${toFileSource path}/. "$out/${name}/"
+            cp -RL ${toFileSource path}/. "$out/${name}/"
           '') fileSkills
         )
       );
@@ -131,7 +131,8 @@
         home.activation.agentsSkillsRealFiles = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD rm -rf "$HOME/.agents/skills"
           $DRY_RUN_CMD install -d "$HOME/.agents/skills"
-          $DRY_RUN_CMD cp -RL --no-preserve=mode ${agentsSkillsTree}/. "$HOME/.agents/skills/"
+          $DRY_RUN_CMD cp -RL ${agentsSkillsTree}/. "$HOME/.agents/skills/"
+          $DRY_RUN_CMD chmod -R u+w "$HOME/.agents/skills"
         '';
       };
     };

--- a/modules/home/mk-home.nix
+++ b/modules/home/mk-home.nix
@@ -21,6 +21,14 @@
         flake = config.flake // {
           inherit inputs;
         };
+        # home-manager's NixOS and nix-darwin modules pass the enclosing system
+        # configuration under this name; a standalone home configuration has no
+        # such system, and saying so explicitly is what keeps a module that
+        # takes the argument evaluable here. An absent module argument is not
+        # the same as one that is null: the module system binds every formal it
+        # knows about, including optional ones, to a thunk that throws when the
+        # name cannot be resolved, so the formal's own default never applies.
+        osConfig = null;
       };
       modules = config.flake.users.${user}.modules;
     };

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -247,6 +247,49 @@ let
       # modules/home/ai/moshi for how the launcher consumes it.
       services.moshi-hook.pairingTokenFile = config.sops.secrets.moshi-pairing-token.path;
 
+      # Devin Outposts worker tokens, one file per outpost queue so each can be
+      # rotated on its own. Not a containment boundary: a token issued for one
+      # outpost lists every outpost through the account-level endpoint, so both
+      # are account-scoped for reads. See modules/home/ai/devin/worker.nix for
+      # the rotation procedure and for why the launcher reads the path rather
+      # than receiving the value.
+      #
+      # sops rather than clan vars: clan vars is effectively NixOS-shaped in
+      # this fleet -- magnetite carries 41 generators against stibnite's one,
+      # this repository already records a related clan feature as NixOS-only,
+      # and sops-nix through home-manager already delivers secrets to the
+      # darwin host for four existing tools.
+      #
+      # Declaration and wiring are gated on the service, not because either is
+      # conditional in spirit but because sops-nix validates every declared key
+      # against the sops file when the manifest is built (check-mode=sopsfile):
+      # declaring a key whose ciphertext is not yet in secrets.yaml would fail
+      # home-manager activation on both hosts for a service that is off. The
+      # operator's two actions -- add the two ciphertexts, enable the worker on
+      # a host -- therefore land together, and enabling without the ciphertext
+      # fails at build time naming the missing key.
+      #
+      # Carried as an inline module because `sops.secrets` is already defined
+      # in the attribute set above, and a conditional slice of it cannot be a
+      # second definition of the same attribute path in one literal.
+      imports = [
+        {
+          sops.secrets = lib.mkIf config.services.devin-worker.enable {
+            devin-outposts-token-stibnite = {
+              mode = "0400";
+            };
+            devin-outposts-token-magnetite = {
+              mode = "0400";
+            };
+          };
+
+          services.devin-worker.outposts = lib.mkIf config.services.devin-worker.enable {
+            "stibnite-01".tokenFile = config.sops.secrets.devin-outposts-token-stibnite.path;
+            "magnetite-01".tokenFile = config.sops.secrets.devin-outposts-token-magnetite.path;
+          };
+        }
+      ];
+
       # Deploy radicle public key (not secret - can be plaintext, but identity-bound)
       # This is the SSH public key used for Radicle node identity
       home.file.".radicle/keys/radicle.pub".text = ''

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -265,29 +265,60 @@ let
       # against the sops file when the manifest is built (check-mode=sopsfile):
       # declaring a key whose ciphertext is not yet in secrets.yaml would fail
       # home-manager activation on both hosts for a service that is off. The
-      # operator's two actions -- add the two ciphertexts, enable the worker on
-      # a host -- therefore land together, and enabling without the ciphertext
-      # fails at build time naming the missing key.
+      # operator's actions -- add a ciphertext, enable the worker on that host
+      # -- therefore land together, and enabling without it fails at build time
+      # naming the missing key.
+      #
+      # Each host declares only the key for the queue it serves, so the two
+      # stay independent. Declaring both everywhere would couple them through
+      # the sops manifest: the same build-time validation means one host could
+      # not be enabled, nor its token rotated, until the other's ciphertext
+      # also existed and validated on that machine, and each machine would
+      # decrypt a credential it never uses.
+      #
+      # The discriminator is the host platform rather than
+      # `services.devin-worker.outpost`, because these are definitions OF
+      # `outposts` and that option's default is computed FROM `outposts`:
+      # conditioning them on the resolved name is a cycle. Platform is what the
+      # module's own two-tier selection keys on, so the two agree by
+      # construction here, and if a host is ever pointed at a different queue
+      # the module's tokenFile assertion fires by name rather than silently
+      # serving with no credential.
       #
       # Carried as an inline module because `sops.secrets` is already defined
       # in the attribute set above, and a conditional slice of it cannot be a
       # second definition of the same attribute path in one literal.
       imports = [
-        {
-          sops.secrets = lib.mkIf config.services.devin-worker.enable {
-            devin-outposts-token-stibnite = {
-              mode = "0400";
-            };
-            devin-outposts-token-magnetite = {
-              mode = "0400";
-            };
-          };
+        (
+          let
+            devinEnabled = config.services.devin-worker.enable;
+            servesStibnite = devinEnabled && pkgs.stdenv.hostPlatform.isDarwin;
+            servesMagnetite = devinEnabled && pkgs.stdenv.hostPlatform.isLinux;
+          in
+          {
+            sops.secrets = lib.mkMerge [
+              (lib.mkIf servesStibnite {
+                devin-outposts-token-stibnite = {
+                  mode = "0400";
+                };
+              })
+              (lib.mkIf servesMagnetite {
+                devin-outposts-token-magnetite = {
+                  mode = "0400";
+                };
+              })
+            ];
 
-          services.devin-worker.outposts = lib.mkIf config.services.devin-worker.enable {
-            "stibnite-01".tokenFile = config.sops.secrets.devin-outposts-token-stibnite.path;
-            "magnetite-01".tokenFile = config.sops.secrets.devin-outposts-token-magnetite.path;
-          };
-        }
+            services.devin-worker.outposts = lib.mkMerge [
+              (lib.mkIf servesStibnite {
+                "stibnite-01".tokenFile = config.sops.secrets.devin-outposts-token-stibnite.path;
+              })
+              (lib.mkIf servesMagnetite {
+                "magnetite-01".tokenFile = config.sops.secrets.devin-outposts-token-magnetite.path;
+              })
+            ];
+          }
+        )
       ];
 
       # Deploy radicle public key (not secret - can be plaintext, but identity-bound)

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -10,6 +10,8 @@ let
       pkgs,
       lib,
       flake, # from extraSpecialArgs
+      # from home-manager's NixOS and nix-darwin modules; absent standalone
+      osConfig ? null,
       ...
     }:
     let
@@ -264,26 +266,29 @@ let
       # conditional in spirit but because sops-nix validates every declared key
       # against the sops file when the manifest is built (check-mode=sopsfile):
       # declaring a key whose ciphertext is not yet in secrets.yaml would fail
-      # home-manager activation on both hosts for a service that is off. The
-      # operator's actions -- add a ciphertext, enable the worker on that host
-      # -- therefore land together, and enabling without it fails at build time
-      # naming the missing key.
+      # home-manager activation for a service that is off. The operator's
+      # actions -- add a ciphertext, enable the worker on that host -- land
+      # together, and enabling without it fails at build time naming the
+      # missing key.
       #
-      # Each host declares only the key for the queue it serves, so the two
-      # stay independent. Declaring both everywhere would couple them through
-      # the sops manifest: the same build-time validation means one host could
-      # not be enabled, nor its token rotated, until the other's ciphertext
-      # also existed and validated on that machine, and each machine would
-      # decrypt a credential it never uses.
+      # They are gated again on the queue the host actually serves, so a host
+      # declares exactly one key and exactly one tokenFile, and a host serving
+      # no queue declares neither. Declaring every key everywhere would couple
+      # the machines through that same validation: none could be enabled, nor
+      # its token rotated, until every other ciphertext existed and validated
+      # on it too, and each machine would decrypt credentials it never uses.
       #
-      # The discriminator is the host platform rather than
-      # `services.devin-worker.outpost`, because these are definitions OF
-      # `outposts` and that option's default is computed FROM `outposts`:
-      # conditioning them on the resolved name is a cycle. Platform is what the
-      # module's own two-tier selection keys on, so the two agree by
-      # construction here, and if a host is ever pointed at a different queue
-      # the module's tokenFile assertion fires by name rather than silently
-      # serving with no credential.
+      # The second gate sits on the leaf rather than on the attribute set: the
+      # outpost names are literals either way, so `outposts` contributes the
+      # same attribute names whatever the condition, and only the tokenFile
+      # value is conditional. Nothing consults a tokenFile to learn the names
+      # or the platforms, so there is no cycle here.
+      #
+      # Which queue each host serves is a deployment fact, so it is keyed on
+      # the machine, not on its platform: six NixOS machines share this user,
+      # and a platform-keyed rule would put every one of them on magnetite's
+      # queue. A machine absent from this table serves no queue, and enabling
+      # the worker there fails evaluation naming it.
       #
       # Carried as an inline module because `sops.secrets` is already defined
       # in the attribute set above, and a conditional slice of it cannot be a
@@ -291,32 +296,50 @@ let
       imports = [
         (
           let
-            devinEnabled = config.services.devin-worker.enable;
-            servesStibnite = devinEnabled && pkgs.stdenv.hostPlatform.isDarwin;
-            servesMagnetite = devinEnabled && pkgs.stdenv.hostPlatform.isLinux;
+            outpostByHost = {
+              stibnite = "stibnite-01";
+              magnetite = "magnetite-01";
+            };
+
+            hostName = if osConfig == null then null else osConfig.networking.hostName;
+            hostOutpost = if hostName == null then null else outpostByHost.${hostName} or null;
+
+            # Both conjuncts matter. The host's own entry in the table is what
+            # makes a machine with no queue declare nothing, even if someone
+            # names another machine's queue on it -- that host then has no
+            # credential and the module's tokenFile assertion fails the build
+            # by name, rather than the host quietly serving sessions from a
+            # queue that is not its own on a credential that is not its own.
+            # The second conjunct keeps a key from being declared on a host
+            # whose assignment has been pointed elsewhere.
+            serves =
+              name:
+              config.services.devin-worker.enable
+              && hostOutpost == name
+              && config.services.devin-worker.outpost == name;
           in
           {
+            services.devin-worker.outpost = lib.mkIf (hostOutpost != null) (lib.mkDefault hostOutpost);
+
             sops.secrets = lib.mkMerge [
-              (lib.mkIf servesStibnite {
+              (lib.mkIf (serves "stibnite-01") {
                 devin-outposts-token-stibnite = {
                   mode = "0400";
                 };
               })
-              (lib.mkIf servesMagnetite {
+              (lib.mkIf (serves "magnetite-01") {
                 devin-outposts-token-magnetite = {
                   mode = "0400";
                 };
               })
             ];
 
-            services.devin-worker.outposts = lib.mkMerge [
-              (lib.mkIf servesStibnite {
-                "stibnite-01".tokenFile = config.sops.secrets.devin-outposts-token-stibnite.path;
-              })
-              (lib.mkIf servesMagnetite {
-                "magnetite-01".tokenFile = config.sops.secrets.devin-outposts-token-magnetite.path;
-              })
-            ];
+            services.devin-worker.outposts = {
+              "stibnite-01".tokenFile =
+                lib.mkIf (serves "stibnite-01") config.sops.secrets.devin-outposts-token-stibnite.path;
+              "magnetite-01".tokenFile =
+                lib.mkIf (serves "magnetite-01") config.sops.secrets.devin-outposts-token-magnetite.path;
+            };
           }
         )
       ];

--- a/pkgs/by-name/devin-cli/package.nix
+++ b/pkgs/by-name/devin-cli/package.nix
@@ -1,0 +1,92 @@
+# Devin CLI, vendored from nixpkgs pkgs/by-name/de/devin-cli.
+#
+# The derivation body is upstream's, unmodified. It lives here because the
+# pinned nixpkgs channel carries 3000.3.22 while the Outposts worker surface
+# this repository declares (`services.devin-worker`) is documented against the
+# 3000.6 CLI. modules/nixpkgs/compose.nix merges the by-name set into
+# flake.overlays.default after the channel overlays, so this attribute shadows
+# the channel's `devin-cli` on every machine; `nix run .#update-devin-cli`
+# keeps it current independently of the channel bump.
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+let
+  version = "3000.6.2";
+
+  throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-x86_64-unknown-linux.tar.gz";
+      hash = "sha256-6p5wSh4DXCjfWkwfsROtjOR1fTw9WoRx1CPUvPSBZ4g=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-unknown-linux.tar.gz";
+      hash = "sha256-cmsBAHzHBG/BZdMsxx1AxzmO2rMEV903v0jA0kdKfqE=";
+    };
+
+    aarch64-darwin = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-apple-darwin.tar.gz";
+      hash = "sha256-lxbqBCDqEg6iyInwe0IW7vINXqm2db5FgK79gstG8fQ=";
+    };
+  };
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "devin-cli";
+  inherit version;
+
+  outputs = [
+    "out"
+    "man"
+    "doc"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = srcs.${stdenvNoCC.hostPlatform.system} or throwSystem;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin ./bin/devin
+    installManPage ./share/man/man1/*.1
+
+    mkdir -p $out/share/doc
+
+    mv ./share/devin/docs/* $out/share/doc
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Cognition's Devin Agent CLI";
+    homepage = "https://devin.ai/cli";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      ethancedwards8
+      nhshah15
+    ];
+    mainProgram = "devin";
+  };
+})

--- a/pkgs/by-name/devin-cli/package.nix
+++ b/pkgs/by-name/devin-cli/package.nix
@@ -16,24 +16,24 @@
 }:
 
 let
-  version = "3000.6.2";
+  version = "3000.6.7";
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
 
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-x86_64-unknown-linux.tar.gz";
-      hash = "sha256-6p5wSh4DXCjfWkwfsROtjOR1fTw9WoRx1CPUvPSBZ4g=";
+      hash = "sha256-+I7azqaSVTkQ1y8nVRW9C1K10nHVUlCYGwxBARFC0ns=";
     };
 
     aarch64-linux = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-unknown-linux.tar.gz";
-      hash = "sha256-cmsBAHzHBG/BZdMsxx1AxzmO2rMEV903v0jA0kdKfqE=";
+      hash = "sha256-jelew2I9k+bzywg0+mWf19ZpjU/v8/t+dS6XerxApuA=";
     };
 
     aarch64-darwin = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-apple-darwin.tar.gz";
-      hash = "sha256-lxbqBCDqEg6iyInwe0IW7vINXqm2db5FgK79gstG8fQ=";
+      hash = "sha256-/dBoEgd9XP7lZM7XolbQueJD7kZ9VSGUJmKXFETF2lQ=";
     };
   };
 in

--- a/pkgs/by-name/devin-cli/update.sh
+++ b/pkgs/by-name/devin-cli/update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p bash curl jq cacert git nix
+# shellcheck shell=bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PKG_NIX="${REPO_ROOT}/pkgs/by-name/devin-cli/package.nix"
+
+current_version="$(sed -n 's/.*version = "\(.*\)";/\1/p' "$PKG_NIX" | head -1)"
+
+latest_version="$(curl -fsSL https://static.devin.ai/cli/current/manifest.json | jq -r '.version')"
+
+if [[ -z "$latest_version" || "$latest_version" == "null" ]]; then
+  echo "error: failed to discover a version from https://static.devin.ai/cli/current/manifest.json" >&2
+  exit 1
+fi
+
+if [[ "$current_version" == "$latest_version" ]]; then
+  echo "devin-cli is already at version ${current_version}; refreshing hashes anyway"
+else
+  echo "Updating devin-cli: ${current_version} -> ${latest_version}"
+  sed -i'' -e "s/version = \"${current_version}\"/version = \"${latest_version}\"/" "$PKG_NIX"
+fi
+
+# Platform map: nix system -> release asset triple. Upstream publishes no
+# x86_64-darwin asset, so that system stays absent from package.nix and hits
+# its throwSystem branch.
+declare -A platform_map=(
+  ["x86_64-linux"]="x86_64-unknown-linux"
+  ["aarch64-linux"]="aarch64-unknown-linux"
+  ["aarch64-darwin"]="aarch64-apple-darwin"
+)
+
+for platform in "${!platform_map[@]}"; do
+  triple="${platform_map[$platform]}"
+  url="https://static.devin.ai/cli/${latest_version}/devin-${latest_version}-${triple}.tar.gz"
+
+  echo "Prefetching ${platform} (devin-${latest_version}-${triple}.tar.gz)..."
+  sri_hash="$(nix store prefetch-file --json --hash-type sha256 "$url" | jq -r .hash)"
+
+  if [[ -z "$sri_hash" || "$sri_hash" == "null" ]]; then
+    echo "error: failed to compute hash for ${platform} from ${url}" >&2
+    exit 1
+  fi
+
+  # The url line interpolates ${version} in Nix source, so each asset triple is
+  # a literal that appears exactly once; advance to the following hash line and
+  # substitute there.
+  sed -i'' -e "\|-${triple}\.tar\.gz|{ n; s|hash = \"sha256-[^\"]*\"|hash = \"${sri_hash}\"|; }" "$PKG_NIX"
+
+  echo "  ${platform}: ${sri_hash}"
+done
+
+echo "Updated devin-cli to ${latest_version}"


### PR DESCRIPTION
## Summary

- Preserve executable classification while materializing the shared agent-skills store tree.
- Preserve those modes during home delivery, then explicitly add user write permission.
- Correct the AI README to distinguish writable real-file delivery for Codex and Pi from symlink delivery for the other harnesses.

## Verification

- Before the change, built the relevant home configuration and observed 37 of 37 files under `scripts/` were non-executable; source `collect_metrics.sh` was `0755` while its built copy was `0444`.
- Ran `prek run --files modules/home/ai/skills/default.nix modules/home/ai/README.md`; gitleaks and treefmt passed.
- Built `.#homeConfigurations."crs58@aarch64-darwin".activationPackage` with `--option builders ""`.
- Observed `collect_metrics.sh` as `0555` in the rebuilt store tree and `0755` after simulated delivery.
- Simulated the copy-and-chmod delivery twice in an ignored worktree-local scratch tree; all 870 regular files were writable after delivery.
- Inspected the built activation script and confirmed it contains the real-file copy followed by `chmod -R u+w`.

This is the narrowest build that evaluates and materializes the changed Home Manager module and its activation script. The full repository check suite was not run because the change is confined to this delivery derivation and its local README. No activation was run, so the live home directory was not modified.