### PR TITLE
refactor(skills): put every skill and repository citation on one convention

### DIFF
--- a/modules/home/ai/plugins/README.md
+++ b/modules/home/ai/plugins/README.md
@@ -73,7 +73,7 @@ Three separate, independently-operated mechanisms currently suppress or withhold
 
 1. **`disable-model-invocation: true` frontmatter**, set per skill, prevents that skill from auto-triggering on a description match; the skill is still delivered and still invocable by explicit name or slash command. 21 of the 126 skills in this corpus carry the flag set to `true`, and 2 carry it explicitly set to `false`. Factually, all 21 are operational or command-style skills — meta-tooling commands, event-modeling workflow steps, document-conversion utilities, and git/jj/nix operational commands — and none of them are `preferences-*` conceptual-foundation skills; no `preferences-*` skill in this corpus carries the flag.
 2. **The delivery exclusion list** (`excludedSkills` in `../skills/default.nix`) removes a skill from every delivered harness target (`~/.claude/skills`, `~/.factory/skills`, codex, opencode) even though the skill still exists in the composed tree. It currently withholds `tdd` and `harborize`, each for a documented reason in that file.
-3. **The `@` force-load prefix** in `../../tools/agents-md.nix` (this file's sibling) inlines a skill's full body into the generated context file itself, bypassing both delivery and description-based discovery. Only one skill carries it after this change; see "Archived skill index" below for the one that no longer does.
+3. **A named reference with an explicit loading condition**, in `../../tools/agents-md.nix` (this file's sibling), states a skill's name in the generated context text alongside a stated condition for when to load it, rather than inlining the skill's full body via a path-based force-load prefix and bypassing both delivery and description-based discovery. Only one skill carries this treatment; see "Archived skill index" below for the one that used to carry the old `@` force-load prefix instead.
 
 The `issues-beads-*` family (`issues-beads`, `issues-beads-audit`, `issues-beads-checkpoint`, `issues-beads-evolve`, `issues-beads-init`, `issues-beads-orient`, `issues-beads-prime`, `issues-beads-seed`) previously sat behind mechanisms 1 and 2 above; both are now moot for that family because the eight directories were deleted outright on 2026-08-26, since beads no longer owns the work — Linear and OpenSpec now do. Recover any of them from history, once this deletion is committed, with `git log --diff-filter=D -- modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/`, which finds the deleting commit by path prefix rather than by a hash that does not exist yet.
 
@@ -83,85 +83,85 @@ The `issues-beads-*` family (`issues-beads`, `issues-beads-audit`, `issues-beads
 <summary>Frozen snapshot of the proactive-read skill index, taken 2026-08-26, removed from <code>../../tools/agents-md.nix</code></summary>
 
 This list is not maintained.
-It is a byte-for-byte copy of the bullets that were force-loaded or proactively read from `agents-md.nix` at the moment they were deleted from that file, kept only so a reader can see what a session used to be told to read.
+It is a byte-for-byte copy of the descriptive glosses that were force-loaded or proactively read from `agents-md.nix` at the moment they were deleted from that file, kept only so a reader can see what a session used to be told to read.
 Do not treat any gloss below as current: a skill's own `description` frontmatter in its `SKILL.md` is the authoritative, currently-maintained source, and drift between these glosses and that frontmatter has already been observed at least once.
-`skillsPath` below is the literal Nix interpolation as it appeared in the generator, expanding to `${config.home.homeDirectory}/.claude/skills`.
+Each entry's reference below is normalized to a bare skill name rather than reproducing the generator's original `skillsPath` interpolation (a machine-local `~/.claude/skills` prefix, with an `@` prefix on the two entries that force-loaded), since this README publishes into the marketplace and must not carry machine-local paths.
 
-- style and conventions: @${skillsPath}/preferences-style-and-conventions/SKILL.md
-- git version control: @${skillsPath}/preferences-git-version-control/SKILL.md
-- prose clarity (sentence-level writing discipline, reader processing cost, calibrated claims, editing others' text): ${skillsPath}/preferences-prose-clarity/SKILL.md
-- essential complexity (complexity pays rent in domain invariants; refinement-chain care scaling; falsifiable rigor, sorry-debt): ${skillsPath}/preferences-essential-complexity/SKILL.md
-- git history cleanup: ${skillsPath}/preferences-git-history-cleanup/SKILL.md
-- comment cleanup (uncomment-driven noise-comment removal, load-bearing marker preservation; operational arm of the code-comments policy): ${skillsPath}/preferences-comment-cleanup/SKILL.md
-- jj version control: ${skillsPath}/jj-summary/SKILL.md
-- jj workflow (full): ${skillsPath}/jj-workflow/SKILL.md
-- jj history cleanup (atomic reorder/squash/split, conventional-commit narrative; jj analog of git history cleanup; see also jj-git-interactive-rebase-to-jj): ${skillsPath}/jj-history-cleanup/SKILL.md
-- documentation (three tiers — user-facing Diataxis, development AMDiRE, and the local README hierarchy with its index/leaf roles and earns-its-place bar; prose defers to prose-clarity, diagrams to architecture-diagramming): ${skillsPath}/preferences-documentation/SKILL.md
-- change management: ${skillsPath}/preferences-change-management/SKILL.md
-- agentic planning and development (state-machine router across the Linear-canonical board Backlog -> Todo -> In Progress -> In Review -> Done; AFK/HIL/Manual execution-mode fork; four file-anchored OpenSpec-artifact forward gates): ${skillsPath}/agentic-planning-development-workflow/SKILL.md
-- linear project management (Linear Method ontology, workspace safety gate, ownership-by-layer: Linear + OpenSpec own the work): ${skillsPath}/linear-project-management/SKILL.md
-- superpowers discipline gate (invoke the relevant skill before any response or action, including clarifying questions; process-skills-first): ${skillsPath}/using-superpowers/SKILL.md
-- session resumption (resume command, atuin history, session continuation): ${skillsPath}/meta-session-resume/SKILL.md
-- session search (session transcript discovery, keyword intersection): ${skillsPath}/meta-search-sessions/SKILL.md
-- knowledge graph grounding (cognee reference-corpus indexing/retrieval for grounding technical writing and review; a reference-knowledge index, not agent session memory): ${skillsPath}/knowledge-graph/SKILL.md
-- team orchestration initiate (master-orchestrator mission start; team-level analog of orientation; actor-critic / worker-orchestrator decomposition): ${skillsPath}/meta-orchestrator-initiate/SKILL.md
-- team orchestration checkpoint (master-level cross-cycle state capture and handoff): ${skillsPath}/meta-orchestrator-checkpoint/SKILL.md
-- architectural patterns: ${skillsPath}/preferences-architectural-patterns/SKILL.md
-- architecture diagramming (C4, format selection, diagram compendium): ${skillsPath}/preferences-architecture-diagramming/SKILL.md
-- functional domain modeling (DDD, types, aggregates): ${skillsPath}/preferences-domain-modeling/SKILL.md
-- event sourcing (event replay, state reconstruction, CQRS): ${skillsPath}/preferences-event-sourcing/SKILL.md
-- event catalog tooling (EventCatalog, schema documentation): ${skillsPath}/preferences-event-catalog-tooling/SKILL.md
-- qlerify to eventcatalog (transformation workflow): ${skillsPath}/preferences-event-catalog-qlerify/SKILL.md
-- event modeling (Event Modeling, Qlerify, D2 diagrams): ${skillsPath}/preferences-event-modeling/SKILL.md
-- discovery process: ${skillsPath}/preferences-discovery-process/SKILL.md
-- collaborative modeling (EventStorming, Domain Storytelling): ${skillsPath}/preferences-collaborative-modeling/SKILL.md
-- strategic domain analysis (Core/Supporting/Generic classification): ${skillsPath}/preferences-strategic-domain-analysis/SKILL.md
-- bounded context design (context mapping, integration, ACL): ${skillsPath}/preferences-bounded-context-design/SKILL.md
-- functional reactive programming (FRP foundations, arrows, presheaves): ${skillsPath}/preferences-functional-reactive-programming/SKILL.md
-- algebraic data types (sum/product types, discriminated unions, pattern matching, making illegal states unrepresentable): ${skillsPath}/preferences-algebraic-data-types/SKILL.md
-- theoretical foundations (category/type-theory keystone; capability interfaces over transformer stacks, graded effects/coeffects, Lean-spec-beside-implementation; pairs with refinement-driven-development): ${skillsPath}/preferences-theoretical-foundations/SKILL.md
-- computational system taxonomy (closed vs open systems from automata theory and process calculi; batch/stream/services terminology mapping; heterogeneous composition patterns): ${skillsPath}/preferences-computational-system-taxonomy/SKILL.md
-- algebraic laws (functor/monad laws, property-based testing): ${skillsPath}/preferences-algebraic-laws/SKILL.md
-- refinement-driven development (dependently-typed Lean 4 spec, refine/lower to a Charon/Aeneas-safe Rust subset, lift via Aeneas.Charon, check by translation validation; mechanical proof the ideal not a requirement): ${skillsPath}/refinement-driven-development/SKILL.md
-- requirements engineering (WRSPM pentad; the two obligations W∧S⇒R, the satisfaction argument, and P⇒S; the four dark corners; the designation table; indicative/optative separation; KAOS goal-obstacle analysis; Parnas four-variable model; the WRSPM-versus-AMDiRE shear): ${skillsPath}/preferences-requirements-engineering/SKILL.md
-- satisfaction argument audit (three-gate chain across proof institutions; blind informalization for specification-versus-intent; the trust-surface inventory; the claims status table with satisfiability, non-vacuity, co-vacuity; safe external wording; the never-claim-end-to-end prohibition): ${skillsPath}/satisfaction-argument-audit/SKILL.md
-- nucleus platform (thin router for the spec-anchored approximately-verifiable data-modeling monorepo; Lean 4 structural source of truth; instantiate-then-reconstruct round trip driving structural drift toward zero): ${skillsPath}/nucleus-platform/SKILL.md
-- adaptive planning (control theory, buffer sizing, planning horizons, VSM mapping): ${skillsPath}/preferences-adaptive-planning/SKILL.md
-- workflow orchestration algebra (Dagster/Flyte read through Build Systems à la Carte; free-term vs store-interpreter split, lawful IO managers; data-pipeline orchestration, not agent DAGs): ${skillsPath}/preferences-workflow-orchestration-algebra/SKILL.md
-- validation assurance (severity, evidence quality, confidence, test adequacy, regression, refinement): ${skillsPath}/preferences-validation-assurance/SKILL.md
-- compositional continuous verification (CCV — operating-envelope-plus-regulator pairs composing into a closure operator; theoretical anchor for system-level approximate correctness): ${skillsPath}/preferences-compositional-continuous-verification/SKILL.md
-- acceptance-test-driven development (ATDD outer loop wrapping inner TDD; routes each proposition to BDD / property / law / proof / smoke): ${skillsPath}/atdd-outer-loop/SKILL.md
-- test-driven development (red-green-refactor; no production code without a failing test first): ${skillsPath}/test-driven-development/SKILL.md
-- systematic debugging (root-cause-before-fix discipline; question the architecture after repeated failed fixes; see also diagnosing-bugs): ${skillsPath}/systematic-debugging/SKILL.md
-- verification before completion (evidence before claims; run the verification command before asserting done/passing/fixed/committing): ${skillsPath}/verification-before-completion/SKILL.md
-- code review (two-axis Standards + Spec review of the diff; requesting-code-review author side, receiving-code-review responder side): ${skillsPath}/code-review/SKILL.md
-- observability engineering (structured events, traces, SLOs, instrumentation, telemetry architecture): ${skillsPath}/preferences-observability-engineering/SKILL.md
-- production readiness (ODD, progressive delivery, health checks, incident learning, CI/CD observability): ${skillsPath}/preferences-production-readiness/SKILL.md
-- distributed systems (CAP/PACELC/linearizability, consistency models, CRDTs, idempotency, sagas, dual-write avoidance, deterministic replay): ${skillsPath}/preferences-distributed-systems/SKILL.md
-- scalable probabilistic modeling (Bayesian workflow, simulation-based inference, stochastic dynamical systems): ${skillsPath}/preferences-scalable-probabilistic-modeling-workflow/SKILL.md
-- scientific inquiry methodology (Peircean pragmatism, effective theories, Mayo severity, iterative model building; hierarchy of mechanistic evidence): ${skillsPath}/preferences-scientific-inquiry-methodology/SKILL.md
-- smart constructors and validation patterns: see preferences-domain-modeling
-- error handling and workflow composition (Result types, railway-oriented): ${skillsPath}/preferences-railway-oriented-programming/SKILL.md
-- data modeling (database schemas, normalization, ER diagrams): ${skillsPath}/preferences-data-modeling/SKILL.md
-- json querying (duckdb, jaq): ${skillsPath}/preferences-json-querying/SKILL.md
-- schema versioning: ${skillsPath}/preferences-schema-versioning/SKILL.md
-- web application deployment: ${skillsPath}/preferences-web-application-deployment/SKILL.md
-- cloudflare wrangler configuration: ${skillsPath}/preferences-cloudflare-wrangler-reference/SKILL.md
-- secrets management: ${skillsPath}/preferences-secrets/SKILL.md
-- nix development (flakes, derivations, modules, code style; new files need tracking before a flake build can see them, since flake sources are git-tracked only; verify with targeted `nix eval`/`nix build` probes and `just check-fast` rather than a bare `nix flake check` sweep — see nix flake PR cycle): ${skillsPath}/preferences-nix-development/SKILL.md
-- nix flake checks architecture (check taxonomy, derivation patterns, VM tests): ${skillsPath}/preferences-nix-checks-architecture/SKILL.md
-- nix CI/CD integration (nix-fast-build, buildbot-nix, effects, migration): ${skillsPath}/preferences-nix-ci-cd-integration/SKILL.md
-- nix flake PR cycle (enumerate checks, probe via nix eval/build, just check-fast, draft PR, buildbot monitor, ready, Mergify): ${skillsPath}/nix-flake-pr-cycle/SKILL.md
-- CI workflow log verification (GHA + buildbot unified retrieval, full log archives, buildbot-logs): ${skillsPath}/ci-log-verification/SKILL.md
-- python development: ${skillsPath}/preferences-python-development/SKILL.md
-- rust development: ${skillsPath}/preferences-rust-development/SKILL.md
-- haskell development: ${skillsPath}/preferences-haskell-development/SKILL.md
-- typescript/node.js development: ${skillsPath}/preferences-typescript-nodejs-development/SKILL.md
-- react/ui development: ${skillsPath}/preferences-react-tanstack-ui-development/SKILL.md
-- web platform foundations (15 properties, capability ladder, paradigm routing): ${skillsPath}/preferences-web-platform-foundations/SKILL.md
-- hypermedia/server-driven UI development: ${skillsPath}/preferences-hypermedia-development/SKILL.md
-- hypermedia document authoring (presentations, SVG, MathML, standalone experiments): ${skillsPath}/preferences-hypermedia-documents/SKILL.md
-- scientific data visualization (figures, tables, diagrams, colormaps): ${skillsPath}/scientific-visualization/SKILL.md
-- text-to-visual iteration (compile-inspect-refine loop, SVG/PNG/PDF pipelines): ${skillsPath}/text-to-visual-iteration/SKILL.md
+- style and conventions: `preferences-style-and-conventions`
+- git version control: `preferences-git-version-control`
+- prose clarity (sentence-level writing discipline, reader processing cost, calibrated claims, editing others' text): `preferences-prose-clarity`
+- essential complexity (complexity pays rent in domain invariants; refinement-chain care scaling; falsifiable rigor, sorry-debt): `preferences-essential-complexity`
+- git history cleanup: `preferences-git-history-cleanup`
+- comment cleanup (uncomment-driven noise-comment removal, load-bearing marker preservation; operational arm of the code-comments policy): `preferences-comment-cleanup`
+- jj version control: `jj-summary`
+- jj workflow (full): `jj-workflow`
+- jj history cleanup (atomic reorder/squash/split, conventional-commit narrative; jj analog of git history cleanup; see also jj-git-interactive-rebase-to-jj): `jj-history-cleanup`
+- documentation (three tiers — user-facing Diataxis, development AMDiRE, and the local README hierarchy with its index/leaf roles and earns-its-place bar; prose defers to prose-clarity, diagrams to architecture-diagramming): `preferences-documentation`
+- change management: `preferences-change-management`
+- agentic planning and development (state-machine router across the Linear-canonical board Backlog -> Todo -> In Progress -> In Review -> Done; AFK/HIL/Manual execution-mode fork; four file-anchored OpenSpec-artifact forward gates): `agentic-planning-development-workflow`
+- linear project management (Linear Method ontology, workspace safety gate, ownership-by-layer: Linear + OpenSpec own the work): `linear-project-management`
+- superpowers discipline gate (invoke the relevant skill before any response or action, including clarifying questions; process-skills-first): `using-superpowers`
+- session resumption (resume command, atuin history, session continuation): `meta-session-resume`
+- session search (session transcript discovery, keyword intersection): `meta-search-sessions`
+- knowledge graph grounding (cognee reference-corpus indexing/retrieval for grounding technical writing and review; a reference-knowledge index, not agent session memory): `knowledge-graph`
+- team orchestration initiate (master-orchestrator mission start; team-level analog of orientation; actor-critic / worker-orchestrator decomposition): `meta-orchestrator-initiate`
+- team orchestration checkpoint (master-level cross-cycle state capture and handoff): `meta-orchestrator-checkpoint`
+- architectural patterns: `preferences-architectural-patterns`
+- architecture diagramming (C4, format selection, diagram compendium): `preferences-architecture-diagramming`
+- functional domain modeling (DDD, types, aggregates): `preferences-domain-modeling`
+- event sourcing (event replay, state reconstruction, CQRS): `preferences-event-sourcing`
+- event catalog tooling (EventCatalog, schema documentation): `preferences-event-catalog-tooling`
+- qlerify to eventcatalog (transformation workflow): `preferences-event-catalog-qlerify`
+- event modeling (Event Modeling, Qlerify, D2 diagrams): `preferences-event-modeling`
+- discovery process: `preferences-discovery-process`
+- collaborative modeling (EventStorming, Domain Storytelling): `preferences-collaborative-modeling`
+- strategic domain analysis (Core/Supporting/Generic classification): `preferences-strategic-domain-analysis`
+- bounded context design (context mapping, integration, ACL): `preferences-bounded-context-design`
+- functional reactive programming (FRP foundations, arrows, presheaves): `preferences-functional-reactive-programming`
+- algebraic data types (sum/product types, discriminated unions, pattern matching, making illegal states unrepresentable): `preferences-algebraic-data-types`
+- theoretical foundations (category/type-theory keystone; capability interfaces over transformer stacks, graded effects/coeffects, Lean-spec-beside-implementation; pairs with refinement-driven-development): `preferences-theoretical-foundations`
+- computational system taxonomy (closed vs open systems from automata theory and process calculi; batch/stream/services terminology mapping; heterogeneous composition patterns): `preferences-computational-system-taxonomy`
+- algebraic laws (functor/monad laws, property-based testing): `preferences-algebraic-laws`
+- refinement-driven development (dependently-typed Lean 4 spec, refine/lower to a Charon/Aeneas-safe Rust subset, lift via Aeneas.Charon, check by translation validation; mechanical proof the ideal not a requirement): `refinement-driven-development`
+- requirements engineering (WRSPM pentad; the two obligations W∧S⇒R, the satisfaction argument, and P⇒S; the four dark corners; the designation table; indicative/optative separation; KAOS goal-obstacle analysis; Parnas four-variable model; the WRSPM-versus-AMDiRE shear): `preferences-requirements-engineering`
+- satisfaction argument audit (three-gate chain across proof institutions; blind informalization for specification-versus-intent; the trust-surface inventory; the claims status table with satisfiability, non-vacuity, co-vacuity; safe external wording; the never-claim-end-to-end prohibition): `satisfaction-argument-audit`
+- nucleus platform (thin router for the spec-anchored approximately-verifiable data-modeling monorepo; Lean 4 structural source of truth; instantiate-then-reconstruct round trip driving structural drift toward zero): `nucleus-platform`
+- adaptive planning (control theory, buffer sizing, planning horizons, VSM mapping): `preferences-adaptive-planning`
+- workflow orchestration algebra (Dagster/Flyte read through Build Systems à la Carte; free-term vs store-interpreter split, lawful IO managers; data-pipeline orchestration, not agent DAGs): `preferences-workflow-orchestration-algebra`
+- validation assurance (severity, evidence quality, confidence, test adequacy, regression, refinement): `preferences-validation-assurance`
+- compositional continuous verification (CCV — operating-envelope-plus-regulator pairs composing into a closure operator; theoretical anchor for system-level approximate correctness): `preferences-compositional-continuous-verification`
+- acceptance-test-driven development (ATDD outer loop wrapping inner TDD; routes each proposition to BDD / property / law / proof / smoke): `atdd-outer-loop`
+- test-driven development (red-green-refactor; no production code without a failing test first): `test-driven-development`
+- systematic debugging (root-cause-before-fix discipline; question the architecture after repeated failed fixes; see also diagnosing-bugs): `systematic-debugging`
+- verification before completion (evidence before claims; run the verification command before asserting done/passing/fixed/committing): `verification-before-completion`
+- code review (two-axis Standards + Spec review of the diff; requesting-code-review author side, receiving-code-review responder side): `code-review`
+- observability engineering (structured events, traces, SLOs, instrumentation, telemetry architecture): `preferences-observability-engineering`
+- production readiness (ODD, progressive delivery, health checks, incident learning, CI/CD observability): `preferences-production-readiness`
+- distributed systems (CAP/PACELC/linearizability, consistency models, CRDTs, idempotency, sagas, dual-write avoidance, deterministic replay): `preferences-distributed-systems`
+- scalable probabilistic modeling (Bayesian workflow, simulation-based inference, stochastic dynamical systems): `preferences-scalable-probabilistic-modeling-workflow`
+- scientific inquiry methodology (Peircean pragmatism, effective theories, Mayo severity, iterative model building; hierarchy of mechanistic evidence): `preferences-scientific-inquiry-methodology`
+- smart constructors and validation patterns: see `preferences-domain-modeling`
+- error handling and workflow composition (Result types, railway-oriented): `preferences-railway-oriented-programming`
+- data modeling (database schemas, normalization, ER diagrams): `preferences-data-modeling`
+- json querying (duckdb, jaq): `preferences-json-querying`
+- schema versioning: `preferences-schema-versioning`
+- web application deployment: `preferences-web-application-deployment`
+- cloudflare wrangler configuration: `preferences-cloudflare-wrangler-reference`
+- secrets management: `preferences-secrets`
+- nix development (flakes, derivations, modules, code style; new files need tracking before a flake build can see them, since flake sources are git-tracked only; verify with targeted `nix eval`/`nix build` probes and `just check-fast` rather than a bare `nix flake check` sweep — see nix flake PR cycle): `preferences-nix-development`
+- nix flake checks architecture (check taxonomy, derivation patterns, VM tests): `preferences-nix-checks-architecture`
+- nix CI/CD integration (nix-fast-build, buildbot-nix, effects, migration): `preferences-nix-ci-cd-integration`
+- nix flake PR cycle (enumerate checks, probe via nix eval/build, just check-fast, draft PR, buildbot monitor, ready, Mergify): `nix-flake-pr-cycle`
+- CI workflow log verification (GHA + buildbot unified retrieval, full log archives, buildbot-logs): `ci-log-verification`
+- python development: `preferences-python-development`
+- rust development: `preferences-rust-development`
+- haskell development: `preferences-haskell-development`
+- typescript/node.js development: `preferences-typescript-nodejs-development`
+- react/ui development: `preferences-react-tanstack-ui-development`
+- web platform foundations (15 properties, capability ladder, paradigm routing): `preferences-web-platform-foundations`
+- hypermedia/server-driven UI development: `preferences-hypermedia-development`
+- hypermedia document authoring (presentations, SVG, MathML, standalone experiments): `preferences-hypermedia-documents`
+- scientific data visualization (figures, tables, diagrams, colormaps): `scientific-visualization`
+- text-to-visual iteration (compile-inspect-refine loop, SVG/PNG/PDF pipelines): `text-to-visual-iteration`
 
 </details>

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-agent-teams/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-agent-teams/SKILL.md
@@ -23,11 +23,11 @@ Keep both in sync: when a team task completes, update the corresponding story or
 ## Teammate lifecycle: orient, work, checkpoint, shutdown, replace
 
 Teammate lifecycle management integrates with the orient/checkpoint pattern.
-Every new teammate should be instructed to execute `/session-orient` at session start to establish full context on the issue graph and current state.
+Every new teammate should be instructed to execute `session-orient` at session start to establish full context on the issue graph and current state.
 For repos without the full workflow (no `session-*` skills installed), instruct the teammate to establish context from the repository's own AGENTS.md and current branch state.
-Teammates should monitor context usage and, when approaching 50% capacity (approximately 100k tokens), execute `/session-checkpoint` to capture learnings, update issue status, and produce a handoff narrative.
+Teammates should monitor context usage and, when approaching 50% capacity (approximately 100k tokens), execute `session-checkpoint` to capture learnings, update issue status, and produce a handoff narrative.
 For repos without the full workflow, have the teammate write the checkpoint narrative to a dated file under `docs/notes/` for the successor.
-After checkpoint, the teammate requests shutdown; the orchestrator spawns a replacement oriented with `/session-orient` to continue the work.
+After checkpoint, the teammate requests shutdown; the orchestrator spawns a replacement oriented with `session-orient` to continue the work.
 This creates a clean lifecycle: orient, work, checkpoint, shutdown, replace.
 
 ## Subagent identity in team context
@@ -45,13 +45,13 @@ The subagent inherits the teammate's working directory and operates against the 
 
 Dispatched subagent Task input omits `isolation: "worktree"`.
 In jj-mode repositories setting it raises an ask at the Agent tool surface, and the answer is normally no: the subagent inherits the shared `@` and the orchestrator routes its diff, so a second tree would fragment the coordination surface rather than protect it.
-Teammates omit the parameter unconditionally to keep behavior consistent across modes, and reach for a worktree only when something outside the team needs its own filesystem tree, per `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop".
-The subagent edits at `@` (which in tier 3 is the wip commit atop the development join, per `~/.claude/skills/jj-version-control/SKILL.md`'s composite maintenance invariant), and the orchestrator routes the resulting changes to the appropriate chain via the route-and-extend recipe (`jj new -A <chain-tip> --no-edit -m "..."` then `jj squash --from @ --into <new-change-id> --keep-emptied` then `jj bookmark move <name> --to <new-change-id>`).
+Teammates omit the parameter unconditionally to keep behavior consistent across modes, and reach for a worktree only when something outside the team needs its own filesystem tree, per `jj-version-control` §"Worktree interop".
+The subagent edits at `@` (which in tier 3 is the wip commit atop the development join, per `jj-version-control`'s composite maintenance invariant), and the orchestrator routes the resulting changes to the appropriate chain via the route-and-extend recipe (`jj new -A <chain-tip> --no-edit -m "..."` then `jj squash --from @ --into <new-change-id> --keep-emptied` then `jj bookmark move <name> --to <new-change-id>`).
 All teammates edit that same `@`=`[wip]`, which is the shared coordination surface that makes N concurrent editors safe by construction; routing the diff downward with `--keep-emptied` is load-bearing because it leaves `@` an empty `[wip]` in place for the others still writing it.
 Never `jj describe @` into content and never relocate `@` below the join via positional `jj rebase -r @ --insert-before/--insert-after` (nor the `--revisions @` form); both drift the shared surface off `[wip]`.
-Full canon — including the sanctioned destination-form `jj rebase -r @ -d <chain-a> -d <chain-b> …`, naming one `-d` per chain the join is to carry afterward, and the complete editor-safe routing-down templates — lives in `~/.claude/skills/jj-version-control/SKILL.md` invariant (iii-b)/(vi).
+Full canon — including the sanctioned destination-form `jj rebase -r @ -d <chain-a> -d <chain-b> …`, naming one `-d` per chain the join is to carry afterward, and the complete editor-safe routing-down templates — lives in `jj-version-control` invariant (iii-b)/(vi).
 
-This is the agent-team specialization of the binding orchestrator-dispatch discipline documented in `~/.claude/CLAUDE.md`.
+This is the agent-team specialization of the binding orchestrator-dispatch discipline documented in the user-level agent context file.
 The same pattern applies to any orchestrator subject to a harness-level edit-gate (background sessions, future isolation requirements); teammates are simply the most common case in team-coordinated work.
 
-The implicit assumption that `@` is stable for the dispatch lifetime breaks during master-orchestrated restructures; see `meta-orchestrator-initiate/01-discipline-and-cycle-patterns.md` §"Subagent-@-inheritance race during restructure" for the pre-restructure quiescence, post-restructure inspection, and routed re-entry disciplines that preserve diamond shape under that race.
+The implicit assumption that `@` is stable for the dispatch lifetime breaks during master-orchestrated restructures; see the `meta-orchestrator-initiate` skill's `01-discipline-and-cycle-patterns.md` §"Subagent-@-inheritance race during restructure" for the pre-restructure quiescence, post-restructure inspection, and routed re-entry disciplines that preserve diamond shape under that race.

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-create-workspace-agents-md/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-create-workspace-agents-md/SKILL.md
@@ -32,8 +32,8 @@ This command is designed for a specific development pattern where workspaces con
 
 1. **Primary Development Repository**: Main project under active development
 2. **Adjacent Git Worktrees**: Multiple experimental branches checked out as separate directories for parallel development (e.g., `project-686-feature`, `project-690-bugfix`).
-   In jj-colocated repos (where `.jj/` is present), parallel chains within the primary repo are handled by default via the diamond workflow's development join (see `~/.claude/skills/jj-version-control/tiered-ceremony.md`) rather than adjacent worktrees.
-   An adjacent worktree is still the right structure when something outside the session needs its own filesystem tree — an external agent framework, a long-running build, a side-by-side comparison — under the discipline in `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop".
+   In jj-colocated repos (where `.jj/` is present), parallel chains within the primary repo are handled by default via the diamond workflow's development join (see the `jj-version-control` skill's `tiered-ceremony.md`) rather than adjacent worktrees.
+   An adjacent worktree is still the right structure when something outside the session needs its own filesystem tree — an external agent framework, a long-running build, a side-by-side comparison — under the discipline in `jj-version-control` §"Worktree interop".
 3. **Dependency Source Code**: Full source repositories of libraries and frameworks used
 4. **Reference Materials**: Documentation, papers, tutorials, and related method implementations
 5. **Development Tools**: Utilities, scripts, and analysis tools
@@ -57,7 +57,7 @@ workspace-root/
 
 ## Command Parameters
 
-**Usage:** `/create-workspace-claude [mode] [workspace-name] [primary-repo] [context]`
+**Usage:** `meta-create-workspace-agents-md [mode] [workspace-name] [primary-repo] [context]`
 
 ### Parameter Definitions
 
@@ -72,25 +72,25 @@ workspace-root/
 
 ```bash
 # Auto-detect everything (current behavior)
-/create-workspace-claude
+meta-create-workspace-agents-md
 
 # Auto-detect with workspace name
-/create-workspace-claude auto jax-workspace
+meta-create-workspace-agents-md auto jax-workspace
 
 # Force create new workspace documentation
-/create-workspace-claude create
+meta-create-workspace-agents-md create
 
 # Force create with full specification
-/create-workspace-claude create ai-research-workspace langchain machine-learning
+meta-create-workspace-agents-md create ai-research-workspace langchain machine-learning
 
 # Force update existing documentation
-/create-workspace-claude update
+meta-create-workspace-agents-md update
 
 # Update with additional context
-/create-workspace-claude update planning-workspace docs-framework documentation
+meta-create-workspace-agents-md update planning-workspace docs-framework documentation
 
 # Specify primary repo to help detection
-/create-workspace-claude auto my-workspace pytorch deep-learning-research
+meta-create-workspace-agents-md auto my-workspace pytorch deep-learning-research
 ```
 
 ### Parameter Processing Logic

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-checkpoint/01-handoff-payload-schema.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-checkpoint/01-handoff-payload-schema.md
@@ -1,6 +1,6 @@
 # Handoff payload schema
 
-Explicit schema for the handoff payload that `/meta-orchestrator-checkpoint` produces and that `/meta-orchestrator-initiate` consumes.
+Explicit schema for the handoff payload that `meta-orchestrator-checkpoint` produces and that `meta-orchestrator-initiate` consumes.
 Load when authoring a handoff payload (in checkpoint) or when parsing one (in initiate).
 
 ## Format
@@ -45,7 +45,7 @@ Required per pair:
 - *Pair identity*: `team_name`, AC name, WO name
 - *Stream*: stream slug, target repo, jj chain lineage
 - *Status*: `active` / `retired` / `completed`
-- *Session-checkpoint pointer* (retired pairs only): absolute path to the AC's `/session-checkpoint` output; absolute path to the WO's `/session-checkpoint` output (if WO produced one)
+- *Session-checkpoint pointer* (retired pairs only): absolute path to the AC's `session-checkpoint` output; absolute path to the WO's `session-checkpoint` output (if WO produced one)
 - *Deliverables*: commits landed, PRs created or merged (with URLs in closure variant), artifacts shipped via dependency map
 - *Surprise observed*: divergence between strategic frame and execution; honest assessment
 - *Design decisions captured*: architectural choices, calibration thresholds, conventions established
@@ -98,7 +98,7 @@ Parameterization-calibration data from mission execution:
 
 ## Embed vs reference for ephemeral artifacts
 
-Pointers to artifacts under `${CLAUDE_JOB_DIR}` — per-AC `/session-checkpoint` outputs, observation logs, spawn prompts, in-flight surface-up drafts — are best-effort references rather than durable storage, because that directory is ephemeral and silently swept between sessions.
+Pointers to artifacts under `${CLAUDE_JOB_DIR}` — per-AC `session-checkpoint` outputs, observation logs, spawn prompts, in-flight surface-up drafts — are best-effort references rather than durable storage, because that directory is ephemeral and silently swept between sessions.
 Canonical content that the next master needs to act on MUST be embedded verbatim in the payload body, not only referenced by path: ratified design decisions, mission-frame summaries and addendum, in-flight surface-up text the resuming master must respond to, and any open-thread artifact whose loss would erase meaning rather than convenience.
 Rule of thumb: if losing the referenced file between checkpoint and resumption would lose meaning the next master needs to reconstruct, embed it; if losing the file would only sacrifice convenience or audit trail, a reference suffices.
 
@@ -165,13 +165,13 @@ Parameterization candidates: spawn-prompt template's WO bootstrap section may wa
 
 ## Parser notes
 
-When `/meta-orchestrator-initiate` parses a payload at step 1:
+When `meta-orchestrator-initiate` parses a payload at step 1:
 
 1. Read frontmatter; if `variant: closure`, the mission is complete and re-invocation is unexpected — surface to user for confirmation
 2. Restore mission frame summary, master observation log path, retired-AC enumeration with pointers
 3. Restore accumulated design decisions and goal-2 insights into master's working memory
 4. Restore parameterization-calibration data (carry forward to inform calibration decisions in the resumed mission)
 5. Read open threads and in-flight work; identify the in-flight surface-up to respond to first
-6. Skip to step 4 of `/meta-orchestrator-initiate` protocol (decomposition refinement, not fresh decomposition) unless the mission frame itself has shifted (user supersession during checkpoint window)
+6. Skip to step 4 of `meta-orchestrator-initiate` protocol (decomposition refinement, not fresh decomposition) unless the mission frame itself has shifted (user supersession during checkpoint window)
 
 Writer (checkpoint) and parser (initiate) must agree on the schema; this file is the normative definition.

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-checkpoint/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-checkpoint/SKILL.md
@@ -4,44 +4,43 @@ description: >-
   Team-level checkpoint and handoff for missions coordinated through the master
   orchestrator pattern. Captures cross-cycle accumulated state across the
   master plus retired ACs and their WO cycles, producing a handoff payload that
-  the next master session can resume via /meta-orchestrator-initiate. Two
+  the next master session can resume via `meta-orchestrator-initiate`. Two
   variants: handoff (mid-mission) and closure (mission completion).
 ---
 
 # Meta-orchestrator checkpoint
 
-Symlink location: `~/.claude/skills/meta-orchestrator-checkpoint/SKILL.md`
-Slash command: `/meta-orchestrator-checkpoint`
+Invoke by name: `meta-orchestrator-checkpoint`
 
 Team-level state capture and handoff for the planning master orchestrator.
-Captures cross-cycle accumulated state across the master, retired ACs and their respective WO cycles, parameterization calibration data, and any in-flight work, producing a handoff payload that a fresh master session can consume via `/meta-orchestrator-initiate` to resume the mission.
+Captures cross-cycle accumulated state across the master, retired ACs and their respective WO cycles, parameterization calibration data, and any in-flight work, producing a handoff payload that a fresh master session can consume via `meta-orchestrator-initiate` to resume the mission.
 
-This skill is the team-level analog of `/session-checkpoint`.
-Where `/session-checkpoint` captures one session's state for handoff to the same role's replacement, this captures the master's team-level state for handoff to a fresh master session.
+This skill is the team-level analog of `session-checkpoint`.
+Where `session-checkpoint` captures one session's state for handoff to the same role's replacement, this captures the master's team-level state for handoff to a fresh master session.
 
-## Scope distinction from `/session-checkpoint`
+## Scope distinction from `session-checkpoint`
 
 Two checkpoint scopes exist; do not conflate.
 
-- *`/session-checkpoint`* — session-level scope; each AC and WO runs this at cycle end to capture its own session state and produce a handoff payload for its same-role replacement. Invoked when the AC or WO approaches its own context fill. Owned by whichever role is checkpointing.
-- *`/meta-orchestrator-checkpoint`* — team-level scope; master runs this at mission-level pause points to capture team-level state across the master plus retired ACs and their WO cycles. Invoked when the master approaches its own context fill or at mission natural pause points. Owned by master.
+- *`session-checkpoint`* — session-level scope; each AC and WO runs this at cycle end to capture its own session state and produce a handoff payload for its same-role replacement. Invoked when the AC or WO approaches its own context fill. Owned by whichever role is checkpointing.
+- *`meta-orchestrator-checkpoint`* — team-level scope; master runs this at mission-level pause points to capture team-level state across the master plus retired ACs and their WO cycles. Invoked when the master approaches its own context fill or at mission natural pause points. Owned by master.
 
-The two compose: master's `/meta-orchestrator-checkpoint` payload includes pointers to each retired AC's `/session-checkpoint` output rather than duplicating their content.
+The two compose: master's `meta-orchestrator-checkpoint` payload includes pointers to each retired AC's `session-checkpoint` output rather than duplicating their content.
 
 ## When to invoke
 
 Three triggers with response patterns:
 
-- *Master self-detection of context fill (~50%).* Master invokes `/meta-orchestrator-checkpoint` immediately; does not spawn new pairs; completes the checkpoint and surfaces handoff narrative to user before context exhaustion.
-- *AC surfaces "we should checkpoint and hand off" via wrapper.* Master assesses: is the mission at a natural pause? Is master also near fill? If both yes, checkpoint. If only AC near fill (mission ongoing, master has budget), replace AC instead via the AC's `/session-checkpoint` output as orient addendum for a new AC; do not invoke team-level checkpoint.
-- *User directive to wrap up* ("we need to circle back" / "checkpoint the mission state" / explicit `/meta-orchestrator-checkpoint` slash invocation). Takes priority over any in-flight spawning; master halts new spawns and proceeds to checkpoint.
+- *Master self-detection of context fill (~50%).* Master invokes `meta-orchestrator-checkpoint` immediately; does not spawn new pairs; completes the checkpoint and surfaces handoff narrative to user before context exhaustion.
+- *AC surfaces "we should checkpoint and hand off" via wrapper.* Master assesses: is the mission at a natural pause? Is master also near fill? If both yes, checkpoint. If only AC near fill (mission ongoing, master has budget), replace AC instead via the AC's `session-checkpoint` output as orient addendum for a new AC; do not invoke team-level checkpoint.
+- *User directive to wrap up* ("we need to circle back" / "checkpoint the mission state" / explicit `meta-orchestrator-checkpoint` invocation). Takes priority over any in-flight spawning; master halts new spawns and proceeds to checkpoint.
 
 In all three cases, the invocation can be either handoff variant (mid-mission, mission continues in a fresh master session) or closure variant (mission complete, no further master session needed). Master determines variant from the trigger and state.
 
 ## Composed skills
 
-- `/meta-orchestrator-initiate` — accepts this skill's output as input (payload path); the new master session resumes from documented state rather than re-deriving from a fresh mission frame
-- `/session-checkpoint` — each retired AC runs this; this skill's payload references their outputs by path
+- `meta-orchestrator-initiate` — accepts this skill's output as input (payload path); the new master session resumes from documented state rather than re-deriving from a fresh mission frame
+- `session-checkpoint` — each retired AC runs this; this skill's payload references their outputs by path
 - `meta-agent-teams` — shared task list and teammate lifecycle remain authoritative through the checkpoint and across master handoff
 
 ## Protocol
@@ -57,7 +56,7 @@ For each pair, record:
 - Pair identity (`team_name`, AC name, WO name)
 - Stream name and target repo
 - Current status: active / retired / completed
-- For retired pairs: pointer to the retiring AC's `/session-checkpoint` output path
+- For retired pairs: pointer to the retiring AC's `session-checkpoint` output path
 - For active pairs: current phase and most-recent surface-up state
 
 The enumeration is the scope for steps 2 and 3.
@@ -113,7 +112,7 @@ Payload fields (canonical schema; see sub-file for details):
 
 - Mission frame summary
 - Master observation log path
-- Pair enumeration with retired-pair `/session-checkpoint` pointers
+- Pair enumeration with retired-pair `session-checkpoint` pointers
 - Per-pair synthesis output (step 2)
 - Cross-pair synthesis (step 3)
 - Open threads and in-flight work (step 4)
@@ -128,7 +127,7 @@ Write the payload to `${CLAUDE_JOB_DIR}/handoff/meta-orchestrator-payload.md` (f
 For the handoff variant, draft the continuation prompt the user will send to the fresh master session:
 
 ```
-/meta-orchestrator-initiate <payload-path>
+meta-orchestrator-initiate <payload-path>
 ```
 
 Plus a brief narrative wrapper for the user: what the mission is, where it stands, what the fresh master should expect to find in the payload, what the next action is.
@@ -144,12 +143,12 @@ This skill produces:
 
 The user routes the payload path to the fresh master session (handoff) or files the closure summary (closure).
 
-## Composition with `/meta-orchestrator-initiate`
+## Composition with `meta-orchestrator-initiate`
 
-This skill's output feeds the next `/meta-orchestrator-initiate` invocation.
+This skill's output feeds the next `meta-orchestrator-initiate` invocation.
 The initiate skill's step 1 parses the payload and restores: mission frame, retired-AC enumeration with pointers, accumulated design decisions, parameterization-calibration data, master's observation log path, open threads, in-flight work, next-spawn recommendations.
 
-Canonical text in `/meta-orchestrator-initiate` is the normative source for protocol items (wrapper canon, precedence rule, etc.); this skill does not redefine them. The handoff payload references but does not duplicate canonical text.
+Canonical text in `meta-orchestrator-initiate` is the normative source for protocol items (wrapper canon, precedence rule, etc.); this skill does not redefine them. The handoff payload references but does not duplicate canonical text.
 
 ## Variants: handoff vs closure
 
@@ -177,9 +176,9 @@ Determination of variant: closure if all streams have integrated to main and no 
 ---
 
 *Related skills:*
-- `/meta-orchestrator-initiate` — team-level orchestrator initialization; consumes this skill's output
+- `meta-orchestrator-initiate` — team-level orchestrator initialization; consumes this skill's output
 - `meta-agent-teams` — teammate isolation, issue-to-task-list mirroring, orient/checkpoint lifecycle
-- `/session-checkpoint` — session-level checkpoint each AC and WO runs at cycle end; this skill references their outputs
+- `session-checkpoint` — session-level checkpoint each AC and WO runs at cycle end; this skill references their outputs
 
 *Theoretical anchors:*
 - `preferences-adaptive-planning` — surprise threshold derivation; replanning decision rule; the handoff narrative's load-bearing role in the receding-horizon cycle

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/01-discipline-and-cycle-patterns.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/01-discipline-and-cycle-patterns.md
@@ -6,7 +6,7 @@ Load when configuring a new pair's discipline, when calibrating critique posture
 ## Longevity budget heuristic
 
 Target: AC consumes approximately 15-20% of its context window per WO cycle.
-This budget supports 4-5 WO cycles before AC itself requires replacement via `/session-checkpoint`.
+This budget supports 4-5 WO cycles before AC itself requires replacement via `session-checkpoint`.
 
 The budget derives from the observation that a single AC cycle includes: ingest of WO surface-up, dispatch of critique-supporting subagents (if any), composition of critique via wrapper, master coordination on gate transitions.
 A cycle costing more than 25% truncates AC's effective lifespan; a cycle costing less than 10% suggests AC is either pre-cooking operational detail or not engaging at the architectural depth the wrapper forcing-function demands.
@@ -54,10 +54,10 @@ Soft guide; defer to task shape.
 
 | Skill | Owner | When |
 |---|---|---|
-| `/session-orient` | Both (dual-use) | AC reorients on master directive; AC produces addendum for WO; WO runs with AC addendum |
-| `/session-plan` | Situational | If beads-graph-seeding applies; may not apply to all tasks |
-| `/session-review` | AC | Convergence audit (System 3-star posture) |
-| `/session-checkpoint` | Owning role | Whichever role is checkpointing (master, AC, or WO) |
+| `session-orient` | Both (dual-use) | AC reorients on master directive; AC produces addendum for WO; WO runs with AC addendum |
+| `session-plan` | Situational | If beads-graph-seeding applies; may not apply to all tasks |
+| `session-review` | AC | Convergence audit (System 3-star posture) |
+| `session-checkpoint` | Owning role | Whichever role is checkpointing (master, AC, or WO) |
 
 The wrapper-forced critique rule is the load-bearing role-preservation mechanism, not skill allocation.
 Skill allocation is a soft guide that depends on task shape (beads-seeded epic vs single-unit refactor vs cross-cutting investigation).
@@ -79,7 +79,7 @@ Canonical four-case example (user-bookmark-correction supersession context):
 
 Why this works: enumeration covers an axis of receiver-state uncertainty; each case names the state precondition and corresponding action; ordering minimizes total round-trips compared to a request-state-then-direct-action protocol; receiver-side selection avoids sender re-roundtrip.
 
-Distinguished from the cross-time conflict rule in `meta-orchestrator-initiate/SKILL.md`: cross-time is authority-precedence reconciliation across user directives over time (A then master(B) then C); state-dependent recovery is message-passing-latency mitigation within a single coordination episode.
+Distinguished from the cross-time conflict rule in `SKILL.md`: cross-time is authority-precedence reconciliation across user directives over time (A then master(B) then C); state-dependent recovery is message-passing-latency mitigation within a single coordination episode.
 
 ## Post-long-in-turn-operation interim rule
 
@@ -133,11 +133,11 @@ A subagent inherits the master's working-copy pointer at dispatch time but does 
 If the master orchestrates a `[merge]` restructure during the dispatch window, an in-flight return will tangle into the wrong chain and produce cross-namespace commits that violate diamond shape.
 The first discipline is pre-restructure quiescence: before initiating any restructure, master halts in-flight subagents via wrapper directive with the explicit form "do NOT commit any in-flight subagent return until master signals restructure-complete."
 The second discipline is post-restructure inspection: master reads `jj op log --limit N` across the abandons-during-restructure window before declaring state classification, since the empirical failure mode is master misclassifying state (a)-vs-(c) ambiguity from the state-dependent recovery enumeration because the inspection step was skipped.
-The third discipline is routed re-entry: a subagent that returns into the post-restructure window surfaces its diff back to master rather than self-committing, and master routes the diff into the post-restructure correct chain via the append-route (see `jj-version-control/SKILL.md` §"Routing to a chain: append vs amend").
+The third discipline is routed re-entry: a subagent that returns into the post-restructure window surfaces its diff back to master rather than self-committing, and master routes the diff into the post-restructure correct chain via the append-route (see `jj-version-control` §"Routing to a chain: append vs amend").
 
 ## Diamond-invariant pre-flight on adjudications
 
 Any binding adjudication touching diamond shape — chain creation, chain removal, chain restructure, parent-set change, or wip placement — requires a two-point pre-flight in the propagation chain so the directive cannot land as a shape violation downstream.
-Issue-side: before composing the wrapper that carries the directive, master asks whether the directive, applied as written, would preserve all six diamond invariants (i)-(vi) enumerated in `jj-version-control/SKILL.md` §"Diamond invariants"; if any invariant would fail, the directive is reworked before issuance.
+Issue-side: before composing the wrapper that carries the directive, master asks whether the directive, applied as written, would preserve all six diamond invariants (i)-(vi) enumerated in `jj-version-control` §"Diamond invariants"; if any invariant would fail, the directive is reworked before issuance.
 Receive-side: before AC propagates a master adjudication down to WO's spawn or surface-up follow-up, AC repeats the same check, and failure halts propagation back to master with the violated invariant named explicitly.
 The issue-side pre-flight also folds in recipient-state: master checks whether the recipient has already executed the implicit work before forwarding, because redundant "do X now" directives to a recipient who already did X are a noise-and-confusion pattern the pre-flight is meant to catch.

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/02-tier-and-gate.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/02-tier-and-gate.md
@@ -64,7 +64,7 @@ The AC surfaces to master if and only if at least one condition holds:
 1. *WO surface-up requires master input.* The WO has surfaced a question, blocker, or proposal that exceeds AC's adjudication authority and needs master coordination.
 2. *Phase transition.* The pair is transitioning between phases (e.g., Phase 1 to Phase 2 spawn, Phase 3 to Phase 4 PR cycle).
 3. *Tier-2 escalation.* The stream is ready for tier-2 elevation (push, draft PR creation).
-4. *WO replacement request.* The WO has invoked `/session-checkpoint` and AC is requesting master spawn a replacement.
+4. *WO replacement request.* The WO has invoked `session-checkpoint` and AC is requesting master spawn a replacement.
 5. *Genuine master-bound emergence.* AC has identified a strategic concern, scope expansion candidate, or cross-stream coordination need that only master can resolve.
 
 Routine status updates, internal WO-AC adjudication, and within-cycle critique iterations stay within the pair.
@@ -113,4 +113,4 @@ The map answers: "for stream-Y to proceed past transition T, what must stream-X 
 - *Resolve at delivery*: when a source stream delivers the named artifact, master marks the row delivered and surfaces availability to the target stream's AC.
 - *Replan on conflict*: if a dependency cannot be satisfied (source stream descopes the artifact, target stream changes requirements), master surfaces to user for re-decomposition rather than silently relaxing the dependency.
 
-The map is the canonical alternative to direct AC-to-AC cross-stream communication for the artifact-handoff failure mode. The non-communication invariant in `meta-orchestrator-initiate/SKILL.md` holds; the dependency map plus master-routed coordination is what replaces direct comm.
+The map is the canonical alternative to direct AC-to-AC cross-stream communication for the artifact-handoff failure mode. The non-communication invariant in `SKILL.md` holds; the dependency map plus master-routed coordination is what replaces direct comm.

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/03-operational-patterns.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/03-operational-patterns.md
@@ -59,7 +59,7 @@ Path convention:
 - *Fallback* (no `CLAUDE_JOB_DIR` set or no job context): `~/.claude/jobs/manual-handoff/observations/<role>.md`
 
 Logs are append-only running narrative: friction points, parameterization candidates, calibration data, decisions, unexpected state.
-Logs feed the per-role `/session-checkpoint` and the master's `/meta-orchestrator-checkpoint` synthesis.
+Logs feed the per-role `session-checkpoint` and the master's `meta-orchestrator-checkpoint` synthesis.
 
 ## Stream-completion plus main-advance handling
 

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/04-spawn-prompt-template.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/04-spawn-prompt-template.md
@@ -24,7 +24,7 @@ Minimum prompt length is approximately 150 lines; the structural template alone 
 2. *Working directory.* Absolute path to the target repo. Instruction to verify via `pwd` and `cd` if needed as first action.
 3. *Wrapper protocol both directions.* Verbatim canonical text (header / body / closing question / footer) with direction-specific closing question text. Single-external-position rule explicit. The pair will use this for all cross-layer messages.
 4. *Embedded proposal.* The mission frame, the stream's scope, the deliverable, the success criteria. For ACs: includes the push-back-likelihood note as a three-audience artifact (AC self-calibration, master expectation-setting, WO awareness via this same prompt).
-5. *First action.* What the role should do at session start. For ACs: `/session-orient` with master-supplied addendum. For WOs: `/session-orient` with AC-supplied addendum, then audit the target repo's state.
+5. *First action.* What the role should do at session start. For ACs: `session-orient` with master-supplied addendum. For WOs: `session-orient` with AC-supplied addendum, then audit the target repo's state.
 6. *Execution constraints.* What the role is and is not allowed to do. For ACs: critique posture, pullback discipline, no operational pre-cooking. For WOs: subagent-dispatch for in-repo writes, atomic commits, no direct user comm.
 7. *Surfacing protocol.* When and how to surface to the next layer up. For ACs: five-condition protocol. For WOs: group-boundary surfaces, exception surfaces, first-cycle calibration.
 8. *Observation logging.* Path convention for the role's observation log; what to record; append-only discipline.

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/05-exemplar-session.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/05-exemplar-session.md
@@ -1,7 +1,7 @@
 # Exemplar session
 
 Refined end-to-end exemplar of a mission run through the master-orchestrator pattern.
-Load when first invoking `/meta-orchestrator-initiate` and needing the multi-pair coordination shape concretely, or when reasoning about a particular phase transition or failure mode in context.
+Load when first invoking `meta-orchestrator-initiate` and needing the multi-pair coordination shape concretely, or when reasoning about a particular phase transition or failure mode in context.
 
 The exemplar uses an illustrative two-stream mission (parallel work in two repos) to show N greater than 1 behaviors. Single-stream missions are the degenerate case.
 
@@ -13,7 +13,7 @@ User issues a mission directive in conversation channel to the planning master o
 - Addendum: target repos, deliverable shape, success criteria, observation expectations
 - Optional: checkpoint payload path (resuming a prior mission)
 
-Master receives the directive and invokes `/meta-orchestrator-initiate`.
+Master receives the directive and invokes `meta-orchestrator-initiate`.
 
 ## Phase 1: strategic frame establishment and decomposition
 
@@ -56,10 +56,10 @@ For each stream, master spawns the AC↔WO pair using Agent tool with `team_name
 Stream-α (high-novelty path):
 
 1. Master spawns `repo-A-α-ac` via Agent tool
-2. AC bootstraps: `/session-orient` with master-supplied addendum; produces three-audience push-back-likelihood note
+2. AC bootstraps: `session-orient` with master-supplied addendum; produces three-audience push-back-likelihood note
 3. AC drafts structural template for WO spawn prompt
 4. Master inlines content into AC's template and spawns `repo-A-α-wo` via Agent tool
-5. WO bootstraps: `/session-orient` with AC-supplied addendum; audits target repo state; claims its jj chain
+5. WO bootstraps: `session-orient` with AC-supplied addendum; audits target repo state; claims its jj chain
 
 Stream-β (low-novelty path):
 
@@ -98,9 +98,9 @@ If, alternatively, stream-α could not produce the artifact (descope), master su
 
 Three checkpoint scopes operate at different layers:
 
-- *WO context fill.* WO invokes `/session-checkpoint` for its own session. AC requests master replace WO. Master spawns new WO with retired WO's checkpoint as `/session-orient` addendum.
-- *AC context fill.* AC invokes `/session-checkpoint` for its own session. AC surfaces handoff narrative to master via wrapper. Master spawns new AC with the AC's checkpoint payload as orient addendum. The new AC reorients on the stream and retains accumulated calibration.
-- *Master context fill.* Master invokes `/meta-orchestrator-checkpoint` (team-level scope, distinct from session-level checkpoints) and surfaces handoff narrative to user. Fresh master session invokes `/meta-orchestrator-initiate` with the checkpoint payload to resume.
+- *WO context fill.* WO invokes `session-checkpoint` for its own session. AC requests master replace WO. Master spawns new WO with retired WO's checkpoint as `session-orient` addendum.
+- *AC context fill.* AC invokes `session-checkpoint` for its own session. AC surfaces handoff narrative to master via wrapper. Master spawns new AC with the AC's checkpoint payload as orient addendum. The new AC reorients on the stream and retains accumulated calibration.
+- *Master context fill.* Master invokes `meta-orchestrator-checkpoint` (team-level scope, distinct from session-level checkpoints) and surfaces handoff narrative to user. Fresh master session invokes `meta-orchestrator-initiate` with the checkpoint payload to resume.
 
 Each layer's checkpoint feeds the next-layer-up's reorient at handoff time.
 
@@ -109,7 +109,7 @@ Each layer's checkpoint feeds the next-layer-up's reorient at handoff time.
 When a stream reaches integration-readiness:
 
 1. WO completes its chain; verification passes; commits are clean atomic units
-2. AC runs `/session-review` (System 3-star convergence audit)
+2. AC runs `session-review` (System 3-star convergence audit)
 3. AC compiles evidence against the six-point evidence rubric (D2 match / no orphans / reader path coherent / risk flags closed / AC concurrence / tier-1 chain intact for elevation)
 4. AC surfaces tier-2 elevation proposal to master under condition 3 of the five-condition protocol
 5. Master surfaces to user with: validation evidence, proposed PR title, bookmark name, body protocol variant (title-plus-comment default or title-only opt-out)
@@ -121,9 +121,9 @@ In our example: stream-β completes first; merges to main. Stream-α auto-rebase
 
 ## Phase 8: mission closure
 
-When all N streams have integrated, master invokes `/meta-orchestrator-checkpoint` in closure-variant mode.
+When all N streams have integrated, master invokes `meta-orchestrator-checkpoint` in closure-variant mode.
 
-Closure summary (subset of handoff schema; see `meta-orchestrator-checkpoint/01-handoff-payload-schema.md`):
+Closure summary (subset of handoff schema; see the `meta-orchestrator-checkpoint` skill's `01-handoff-payload-schema.md`):
 
 - Per-stream merged PR with URL
 - Accumulated goal-2 design notes (insights this mission surfaced about the orchestration pattern itself)

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-orchestrator-initiate/SKILL.md
@@ -5,24 +5,23 @@ description: Team-level orchestrator initialization for missions requiring multi
 
 # Meta-orchestrator initiate
 
-Symlink location: `~/.claude/skills/meta-orchestrator-initiate/SKILL.md`
-Slash command: `/meta-orchestrator-initiate`
+Invoke by name: `meta-orchestrator-initiate`
 
 Mission start protocol for a planning master orchestrator.
-Assembles the strategic frame from a user-supplied mission directive (or from a prior `/meta-orchestrator-checkpoint` handoff payload), establishes the authority hierarchy and wrapper canon the team will operate under, and produces a self-directing briefing that enables the master to begin proposing the team decomposition.
+Assembles the strategic frame from a user-supplied mission directive (or from a prior `meta-orchestrator-checkpoint` handoff payload), establishes the authority hierarchy and wrapper canon the team will operate under, and produces a self-directing briefing that enables the master to begin proposing the team decomposition.
 
-This skill is the team-level analog of `/session-orient`.
-Where `/session-orient` initializes one session, this initializes a team of sessions: a planning master orchestrator plus N repo-coupled AC↔WO pairs that execute parallel work streams in target repositories.
+This skill is the team-level analog of `session-orient`.
+Where `session-orient` initializes one session, this initializes a team of sessions: a planning master orchestrator plus N repo-coupled AC↔WO pairs that execute parallel work streams in target repositories.
 
 ## When to invoke
 
 Three triggers, all user-initiated:
 
 - User issues a mission directive in conversation channel with addendum (constraints, target repos, deliverable shape, success criteria, observation expectations)
-- User issues `/meta-orchestrator-initiate <checkpoint-payload-path>` to resume a mission from a prior `/meta-orchestrator-checkpoint` output
+- User issues `meta-orchestrator-initiate <checkpoint-payload-path>` to resume a mission from a prior `meta-orchestrator-checkpoint` output
 - User explicitly requests "start a new team for X" or equivalent framing
 
-If the mission scope is single-session-single-repo (no parallel streams, no multi-cycle coordination), use `/session-orient` directly instead — meta-orchestrator overhead is not warranted.
+If the mission scope is single-session-single-repo (no parallel streams, no multi-cycle coordination), use `session-orient` directly instead — meta-orchestrator overhead is not warranted.
 
 ## Composed skills
 
@@ -30,18 +29,18 @@ This skill orchestrates a higher-level protocol that uses the following as compo
 Do not duplicate their functionality; delegate to them.
 
 - `meta-agent-teams` provides teammate spawn conventions, issue-to-task-list mirroring, and the orient/work/checkpoint/shutdown/replace lifecycle for individual pairs
-- `/session-orient` provides the session-level orientation each AC and WO runs after spawn (with a master-supplied addendum)
-- `/session-checkpoint` provides the session-level checkpoint each AC and WO runs at cycle end
-- `/meta-orchestrator-checkpoint` provides the team-level state capture and handoff that this skill consumes when invoked with a checkpoint payload
-- `/nix-flake-pr-cycle` and `preferences-git-version-control` provide Phase-4 PR-cycle conventions invoked when streams complete
+- `session-orient` provides the session-level orientation each AC and WO runs after spawn (with a master-supplied addendum)
+- `session-checkpoint` provides the session-level checkpoint each AC and WO runs at cycle end
+- `meta-orchestrator-checkpoint` provides the team-level state capture and handoff that this skill consumes when invoked with a checkpoint payload
+- `nix-flake-pr-cycle` and `preferences-git-version-control` provide Phase-4 PR-cycle conventions invoked when streams complete
 
 ## Three-layer architecture
 
 | Layer | Identity | Owns | Does not |
 |---|---|---|---|
 | Master orchestrator | Planning AC; this skill's invoker | Strategic routing; spawn primitive; gates; cross-stream coordination; team-level checkpoint | Direct execution; bypassing AC to steer WO; cross-stream comm at AC↔AC or WO↔WO level |
-| Repo-coupled AC | Spawned by master per stream | Strategic frame for stream; critique via wrapper; `/session-review`; pair-internal lifecycle; surfacing to master under five-condition protocol | Pre-cooking operational detail; running audits inline; direct communication with other streams' ACs |
-| Repo-coupled WO | Spawned by master per stream after AC | Operational execution on assigned jj chain; subagent dispatch; atomic commits; `/session-checkpoint` at fill | Direct user comm; cross-WO comm; skipping first-cycle critique |
+| Repo-coupled AC | Spawned by master per stream | Strategic frame for stream; critique via wrapper; `session-review`; pair-internal lifecycle; surfacing to master under five-condition protocol | Pre-cooking operational detail; running audits inline; direct communication with other streams' ACs |
+| Repo-coupled WO | Spawned by master per stream after AC | Operational execution on assigned jj chain; subagent dispatch; atomic commits; `session-checkpoint` at fill | Direct user comm; cross-WO comm; skipping first-cycle critique |
 | Ephemeral subagents | Dispatched per-task by AC or WO | Single bounded task; return on completion | Persisting across turns |
 
 ## Authority hierarchy
@@ -122,8 +121,8 @@ Execute on invocation, in order.
 
 ### Step 1: parse input
 
-If a checkpoint payload path was supplied, read and parse it per the schema in `meta-orchestrator-checkpoint/01-handoff-payload-schema.md`.
-Restore: mission frame summary, retired-AC enumeration with pointers to per-AC `/session-checkpoint` outputs, accumulated design decisions, parameterization-calibration data, master's observation log path, open threads, in-flight work, next-spawn recommendations.
+If a checkpoint payload path was supplied, read and parse it per the schema in the `meta-orchestrator-checkpoint` skill's `01-handoff-payload-schema.md`.
+Restore: mission frame summary, retired-AC enumeration with pointers to per-AC `session-checkpoint` outputs, accumulated design decisions, parameterization-calibration data, master's observation log path, open threads, in-flight work, next-spawn recommendations.
 Resume from the appropriate protocol step based on captured state: step 4 (decomposition refinement) if the payload signals open decomposition issues or mission-frame shifts; step 5 (spawn pairs) if decomposition is ratified but pairs are not yet spawned; step 6 (monitor cycle dynamics) if pairs are active mid-execution.
 Default is step 4 when in doubt; the payload's open-threads-and-in-flight-work section is the operative resumption signal.
 
@@ -169,7 +168,7 @@ At each stream's completion, follow the stream-completion plus main-advance hand
 
 ### Step 7: monitor own context fill
 
-When approaching ~50% context, invoke `/meta-orchestrator-checkpoint` to capture team-level state and hand off to a fresh master session.
+When approaching ~50% context, invoke `meta-orchestrator-checkpoint` to capture team-level state and hand off to a fresh master session.
 Earlier triggers: AC surfaces "we should checkpoint and hand off"; user directive to wrap up.
 
 ## Output
@@ -182,7 +181,7 @@ The briefing this skill produces is for the master's own consumption:
 - Observation log path established
 - Readiness to surface decomposition to user
 
-## Composition with `/meta-orchestrator-checkpoint`
+## Composition with `meta-orchestrator-checkpoint`
 
 This skill's invocation accepts the checkpoint skill's output as input (step 1 path).
 The checkpoint skill produces a payload formatted such that this skill can resume from documented state without re-deriving from a fresh mission frame.
@@ -205,8 +204,8 @@ An exemplar session covering user→master entry, N-stream decomposition with ra
 *Related skills:*
 - `meta-agent-teams` — teammate isolation, issue-to-task-list mirroring, orient/checkpoint lifecycle
 - `meta-orchestrator-checkpoint` — team-level state capture and handoff
-- `/session-orient` — session-level orientation each AC and WO runs with a master addendum
-- `/session-checkpoint` — session-level checkpoint each AC and WO runs at fill
+- `session-orient` — session-level orientation each AC and WO runs with a master addendum
+- `session-checkpoint` — session-level checkpoint each AC and WO runs at fill
 - `nix-flake-pr-cycle` — Phase-4 PR cycle for stream completion
 - `preferences-git-version-control` — jj-mode tiered-ceremony for tier transitions
 

--- a/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-session-resume/SKILL.md
+++ b/modules/home/ai/plugins/agent-orchestration-and-meta-tooling/.apm/skills/meta-session-resume/SKILL.md
@@ -79,10 +79,10 @@ The command prints exactly one line; map its sentinel to an action.
 
 Examples:
 
-- `/meta-session-resume` - Auto-detects UUID, generates command, adds to atuin history
-- `/meta-session-resume abc123` - Uses provided UUID, generates command, adds to atuin history
-- `/meta-session-resume nohist` - Auto-detects UUID, generates command, skips atuin history
-- `/meta-session-resume abc123 nohist` - Uses provided UUID, generates command, skips atuin history
-- "Prepare this session for resumption" - Natural language trigger, same as `/meta-session-resume`
+- `meta-session-resume` - Auto-detects UUID, generates command, adds to atuin history
+- `meta-session-resume abc123` - Uses provided UUID, generates command, adds to atuin history
+- `meta-session-resume nohist` - Auto-detects UUID, generates command, skips atuin history
+- `meta-session-resume abc123 nohist` - Uses provided UUID, generates command, skips atuin history
+- "Prepare this session for resumption" - Natural language trigger, same as `meta-session-resume`
 
 IMPORTANT: never run `ccds -r` yourself — the command only records or displays the resume string; executing it would spawn a recursive Claude session.

--- a/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-checkpoint/SKILL.md
+++ b/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-checkpoint/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: session-checkpoint
-description: All-horizons session skill that captures session state, evaluates surprise, propagates context downstream, assesses documentation impact, and produces a handoff narrative sufficient for the next session's /session-orient.
+description: All-horizons session skill that captures session state, evaluates surprise, propagates context downstream, assesses documentation impact, and produces a handoff narrative sufficient for the next session's `session-orient`.
 ---
 # Session checkpoint
 
-Symlink location: `~/.claude/skills/session-checkpoint/SKILL.md`
-Slash command: `/session-checkpoint`
+Invoke by name: `session-checkpoint`
 
-Session wind-down protocol that captures state across all planning horizons, evaluates accumulated surprise, propagates discoveries to downstream issues, assesses documentation impact, and produces a self-contained handoff narrative sufficient for the next session to self-direct via `/session-orient`.
+Session wind-down protocol that captures state across all planning horizons, evaluates accumulated surprise, propagates discoveries to downstream issues, assesses documentation impact, and produces a self-contained handoff narrative sufficient for the next session to self-direct via `session-orient`.
 This skill operates across all horizons simultaneously: it updates operational state (signal tables, checkpoint context), evaluates tactical feedback (surprise accumulation, replanning thresholds), and captures strategic observations (documentation impact, Cynefin reclassification).
 
 This is the default session wind-down command for repositories with the full stigmergic workflow installed.
@@ -25,7 +24,7 @@ Stigmergic coordination binds it together — agents orient by reading structure
 Queue economics calibrates the pipeline: buffer sizing via Little's Law, agent utilization at 70-85% (not 100%, due to queueing instability), and batch sizing via the U-curve between planning overhead and plan staleness.
 
 This skill operates across all VSM systems simultaneously: capturing operational state (signal tables, checkpoint context), evaluating tactical feedback (surprise accumulation against the replanning threshold theta), and recording strategic observations (Cynefin reclassifications, documentation impact assessments).
-It produces the handoff narrative that enables the next session to self-direct via `/session-orient`, completing the MPC receding-horizon cycle.
+It produces the handoff narrative that enables the next session to self-direct via `session-orient`, completing the MPC receding-horizon cycle.
 The quality of the handoff directly determines the next session's planning accuracy — a poor checkpoint degrades the entire pipeline.
 
 This skill operates under the reflexive severity mandate: when patterns suggest the framework itself is producing poor outcomes, the agent's obligation is to pause and surface the observation rather than pressing on.
@@ -40,7 +39,7 @@ Do not duplicate their functionality; delegate to them.
 
 - `issues-beads-checkpoint` (retired, pending re-base onto Linear/OpenSpec) provided the per-issue signal table update, checkpoint-context write, escalation handling, proactive pheromone propagation, buffer depletion checks, graph health verification, and beads commit; per-issue checkpoint mechanics await re-implementation via that re-base.
 - `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) provided graph restructuring when checkpoint reveals structural issues (splitting, merging, re-parenting, dependency rewiring); graph restructuring when step 2 or step 5 reveals the need awaits re-implementation via that re-base.
-- `/stigmergic-convention` provides the signal table schema, field definitions, read-modify-write protocol, and checkpoint-context format.
+- `stigmergic-convention` provides the signal table schema, field definitions, read-modify-write protocol, and checkpoint-context format.
   Reference this skill for signal table semantics; do not redefine them here.
 
 `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) previously provided core beads conventions and a command quick reference to load before running checkpoint commands.
@@ -145,7 +144,7 @@ Compare the accumulated surprise against the replanning threshold theta.
 The replanning threshold is context-dependent.
 Complex-domain issues have a lower per-issue threshold because surprise in complex domains has higher downstream impact: a small deviation in a complex subsystem can cascade unpredictably.
 
-Per-issue theta heuristics (consistent with `/session-review`):
+Per-issue theta heuristics (consistent with `session-review`):
 - *Clear* domain: theta = 0.5 per issue (high tolerance; clear-domain surprise is usually bounded).
 - *Complicated* domain: theta = 0.3 per issue (moderate tolerance).
 - *Complex* domain: theta = 0.2 per issue (low tolerance; complex-domain surprise cascades).
@@ -230,13 +229,13 @@ When surprise exceeds 0.5 and reveals fundamental spec inaccuracy that drops und
 1. Create a working note in `docs/notes/` capturing the revised understanding and what probes are needed.
 2. Mark the spec with `superseded-by:` frontmatter pointing to the working note.
 3. The superseded spec remains as historical record until a replacement is promoted.
-4. Flag affected beads issues for replanning in the next `/session-plan`.
+4. Flag affected beads issues for replanning in the next `session-plan`.
 
 #### Diagram staleness
 
 Check whether the session's implementation changes affect areas depicted by existing diagrams.
 When code or configuration changes fall within the scope of an existing diagram (deployment topology, component structure, bounded context boundaries), flag that diagram for update.
-Reference diagram categories from `preferences-architecture-diagramming/04-diagram-compendium.md` when identifying which C4 level is affected.
+Reference diagram categories from the `preferences-architecture-diagramming` skill's `04-diagram-compendium.md` when identifying which C4 level is affected.
 Include flagged diagrams in the handoff narrative's documentation impact section so the next session can prioritize updates.
 
 #### Sunset flagging
@@ -249,7 +248,7 @@ If the doc has `superseded-by` frontmatter older than 30 days, recommend deletio
 
 When closing an issue whose results affect an external repo issue, include the cross-reference in the closure reason.
 Format: "Implemented; results consumed by {prefix}-{id} in {repo}."
-This ensures the next `/session-orient` in the external repo detects the upstream completion via the closure-reason signaling mechanism.
+This ensures the next `session-orient` in the external repo detects the upstream completion via the closure-reason signaling mechanism.
 
 #### Cross-doc consistency check
 
@@ -260,7 +259,7 @@ Flag inconsistencies in the checkpoint context for the next session.
 #### Last-validated frontmatter
 
 For docs that were reviewed and confirmed accurate during this session (even if not modified), update or add `last-validated: YYYY-MM-DD` frontmatter.
-This feeds the staleness scan in the next `/session-orient` step 3.
+This feeds the staleness scan in the next `session-orient` step 3.
 
 ### Step 6: propagate discoveries to downstream issues
 
@@ -336,7 +335,7 @@ These checks are performed inline rather than delegating to `issues-beads-audit`
 
 ### Step 8: produce handoff narrative
 
-Synthesize a self-contained handoff narrative sufficient for the next session to self-direct via `/session-orient`.
+Synthesize a self-contained handoff narrative sufficient for the next session to self-direct via `session-orient`.
 The narrative captures what happened, what was surprising, what the next session should focus on, and what alerts require attention.
 
 The handoff narrative has the following sections.
@@ -353,7 +352,7 @@ Group by impact: local surprises (affecting only the issue itself), propagated s
 Organize by response type: minor inaccuracies (revise in place), major inaccuracies (revise or demote), and promotion candidates (working notes that reached tactical resolution).
 For demotions, note the Cynefin reclassification that motivated the demotion.
 
-*Replanning alerts*: conditions that warrant re-invocation of `/session-plan`.
+*Replanning alerts*: conditions that warrant re-invocation of `session-plan`.
 Include alerts when accumulated surprise exceeds theta (from step 4), when documentation was demoted (from step 5), or when any other replanning trigger fired during the session.
 
 *Confidence status*: for each touched issue, state the current confidence level and whether it advanced during this session.
@@ -369,7 +368,7 @@ For pending propagations, include enough detail for the next session to complete
 
 *Next session focus*: recommended starting point for the next session.
 Identify the highest-priority ready issue or the most impactful unblocking action.
-When replanning was triggered, recommend starting the next session with `/session-plan` rather than jumping to implementation.
+When replanning was triggered, recommend starting the next session with `session-plan` rather than jumping to implementation.
 
 ```
 Session summary:
@@ -406,7 +405,7 @@ Cross-repo propagation:
 Next session:
 - Recommended: <issue-id> (<rationale>)
 - Alternative entry points: <issue-id>, <issue-id>
-- Phase recommendation: {/session-plan | implement | /session-orient discovery mode}
+- Phase recommendation: {session-plan | implement | session-orient discovery mode}
 ```
 
 ### Step 9: push beads state
@@ -425,7 +424,7 @@ For multi-issue sessions, summarize by category rather than listing every issue.
 
 ### Step 10: generate session resume command
 
-Invoke `/meta-session-resume` to produce the `ccds -r` command and add it to atuin history.
+Invoke `meta-session-resume` to produce the `ccds -r` command and add it to atuin history.
 No arguments are needed — the skill auto-detects the session UUID via `$PPID`.
 
 ## Cynefin modulation within checkpoint
@@ -442,21 +441,21 @@ Cynefin classification modulates how deeply this skill executes, not whether the
 ## Typical next steps
 
 After checkpoint completes, the session ends.
-The next session starts with `/session-orient`, which reads the handoff narrative, signal tables, and checkpoint contexts produced by this skill.
+The next session starts with `session-orient`, which reads the handoff narrative, signal tables, and checkpoint contexts produced by this skill.
 
-When replanning was triggered (surprise exceeded theta or documentation was demoted), the handoff narrative recommends that the next session begin with `/session-orient` followed by `/session-plan` before resuming implementation.
+When replanning was triggered (surprise exceeded theta or documentation was demoted), the handoff narrative recommends that the next session begin with `session-orient` followed by `session-plan` before resuming implementation.
 
 ---
 
 *Composed skills (delegate, do not duplicate):*
 - `issues-beads-checkpoint` (retired, pending re-base onto Linear/OpenSpec) -- per-issue signal table update, checkpoint-context write, escalation handling, pheromone propagation, buffer depletion check, graph health verification, beads commit
 - `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) -- graph restructuring when checkpoint reveals structural issues
-- `/stigmergic-convention` -- signal table schema, field definitions, read-modify-write protocol
+- `stigmergic-convention` -- signal table schema, field definitions, read-modify-write protocol
 
 *Related skills:*
-- `/session-orient` -- strategic horizon session start, consumes the handoff narrative produced here
-- `/session-plan` -- tactical-to-operational decomposition, invoked when replanning is triggered
-- `/session-review` -- convergence-point validation, uses compatible theta heuristics
+- `session-orient` -- strategic horizon session start, consumes the handoff narrative produced here
+- `session-plan` -- tactical-to-operational decomposition, invoked when replanning is triggered
+- `session-review` -- convergence-point validation, uses compatible theta heuristics
 - `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) -- core beads conventions and command quick reference
 
 *Theoretical foundations:*

--- a/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-orient/SKILL.md
+++ b/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-orient/SKILL.md
@@ -4,8 +4,7 @@ description: Strategic horizon session skill that assembles complete session con
 ---
 # Session orientation
 
-Symlink location: `~/.claude/skills/session-orient/SKILL.md`
-Slash command: `/session-orient`
+Invoke by name: `session-orient`
 
 Session start protocol that assembles context from all available sources, calibrates work selection by Cynefin domain and planning-depth, and produces a briefing that enables the worker to self-direct.
 This skill operates at the strategic planning horizon, reading the full remaining scope at low resolution.
@@ -39,7 +38,7 @@ This skill orchestrates a higher-level protocol that uses the following skills a
 Do not duplicate their functionality; delegate to them.
 
 - `issues-beads-orient` (retired, pending re-base onto Linear/OpenSpec) provided DAG diagnostics and work selection (phase 1 graph-wide scan, phase 2 signal-table-driven briefing).
-- `/stigmergic-convention` provides the signal table schema, field definitions, and read-modify-write protocol for parsing and interpreting signal tables on candidate issues.
+- `stigmergic-convention` provides the signal table schema, field definitions, and read-modify-write protocol for parsing and interpreting signal tables on candidate issues.
 
 `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) previously provided core beads conventions and a command quick reference to load before running orientation commands.
 
@@ -144,7 +143,7 @@ The `preferences-architecture-diagramming` skill defines the diagram categories 
 fd -e d2 -e tex -e mmd . docs/ 2>/dev/null
 ```
 
-Cross-reference flagged diagrams against the compendium categories in `preferences-architecture-diagramming/04-diagram-compendium.md` to assess coverage gaps.
+Cross-reference flagged diagrams against the compendium categories in the `preferences-architecture-diagramming` skill's `04-diagram-compendium.md` to assess coverage gaps.
 Report missing C4 levels alongside stale diagrams so the worker can prioritize updates and new diagram creation together.
 
 Staleness thresholds vary by Cynefin domain, consistent with the adaptive planning calibration in `preferences-adaptive-planning`.
@@ -163,7 +162,7 @@ fd -t l --broken . contexts/ 2>/dev/null
 
 ### Step 4: parse signal tables on candidate issues
 
-For each candidate issue, extract the signal table from the issue's notes field using the delimiter-based parsing protocol from `/stigmergic-convention`.
+For each candidate issue, extract the signal table from the issue's notes field using the delimiter-based parsing protocol from `stigmergic-convention`.
 
 ```bash
 bd show <id> --json | jq -r '.[0].notes // ""'
@@ -207,7 +206,7 @@ Omit dependency context unless a closed dependency changed an interface the work
 
 At *standard* depth (complicated domain): emit full context including the issue description, all closed dependency closure context in topological order, resolved escalations, and complete acceptance criteria with verification commands.
 If the surprise score from a prior worker exceeds 0.3, highlight the divergence and include checkpoint context that explains what was unexpected.
-When the planning-depth signal indicates multiple independent issues that can proceed in parallel, the diamond workflow (`~/.claude/skills/jj-version-control/diamond-workflow.md` and `~/.claude/skills/jj-version-control/tiered-ceremony.md` tier 3) is the default decomposition pattern in jj mode.
+When the planning-depth signal indicates multiple independent issues that can proceed in parallel, the diamond workflow (the `jj-version-control` skill's `diamond-workflow.md` and the `jj-version-control` skill's `tiered-ceremony.md` tier 3) is the default decomposition pattern in jj mode.
 
 At *deep* depth (complex domain): emit everything from standard plus explicit exploration phase directives.
 Separate "what we know" (from dependency context and prior checkpoint context) from "what we need to discover" (from the issue description's open questions or areas where surprise was high).
@@ -258,7 +257,7 @@ The synthesis includes:
 *Calibrated briefing*: the depth-appropriate briefing assembled in step 5, with exploration directives from step 6 when applicable.
 
 *Work plan with phase recommendation*:
-- Recommend `/session-plan` if the operational buffer is depleted (few ready issues relative to work capacity) or if decomposition is needed before implementation can begin.
+- Recommend `session-plan` if the operational buffer is depleted (few ready issues relative to work capacity) or if decomposition is needed before implementation can begin.
 - Recommend proceeding to implementation if the operational buffer is full and selected issues are ready with clear acceptance criteria.
 - Recommend discovery mode (within this orient session) if planning-depth is deep or probe, before either planning or implementing.
 - Recommend validation or regression-protection work when a candidate's implementation is ahead of its evidence: code exists and tests pass but confidence is still `prototype` or `undemonstrated`, indicating the evidence hasn't been assessed for severity.
@@ -340,19 +339,19 @@ At *probe* depth: include only cross-project context that directly informs the h
 
 After orientation completes, the worker proceeds to one of:
 
-- `/session-plan` if decomposition is needed (operational buffer depleted, scope unclear, or new epic requiring breakdown).
+- `session-plan` if decomposition is needed (operational buffer depleted, scope unclear, or new epic requiring breakdown).
 - Implementation if the operational buffer is full and the selected issue has clear acceptance criteria and verification commands.
-- Discovery mode within this orient session if planning-depth is deep or probe, followed by `/session-checkpoint` after exploration and then either `/session-plan` or implementation.
+- Discovery mode within this orient session if planning-depth is deep or probe, followed by `session-checkpoint` after exploration and then either `session-plan` or implementation.
 
 ---
 
 *Composed skills (delegate, do not duplicate):*
 - `issues-beads-orient` (retired, pending re-base onto Linear/OpenSpec) -- DAG diagnostics, graph-wide scan, signal-table-driven briefing
-- `/stigmergic-convention` -- signal table schema and parsing protocol
+- `stigmergic-convention` -- signal table schema and parsing protocol
 
 *Related skills:*
-- `/session-plan` -- tactical-to-operational decomposition
-- `/session-checkpoint` -- all-horizon state capture and handoff
+- `session-plan` -- tactical-to-operational decomposition
+- `session-checkpoint` -- all-horizon state capture and handoff
 - `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) -- core beads conventions and command quick reference
 - `preferences-validation-assurance` for the confidence promotion chain and evidence quality dimensions used to interpret candidate issue readiness
 - `preferences-compositional-continuous-verification` for the theoretical anchor behind the standing traceability-audit habit on `.#checks` and the structural commitment behind the validate-to-merge workflow

--- a/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-plan/SKILL.md
+++ b/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-plan/SKILL.md
@@ -4,8 +4,7 @@ description: Tactical-to-operational transition skill that transforms scope unde
 ---
 # Session planning
 
-Symlink location: `~/.claude/skills/session-plan/SKILL.md`
-Slash command: `/session-plan`
+Invoke by name: `session-plan`
 
 Session planning protocol that transforms tactical-level understanding into an operational execution buffer of atomic issues with explicit dependencies, acceptance criteria, and Cynefin classification.
 This skill operates at the tactical-to-operational planning horizon, decomposing scope into an implementation buffer at high resolution.
@@ -41,7 +40,7 @@ Do not duplicate their functionality; delegate to them.
 
 - `issues-beads-seed` (retired, pending re-base onto Linear/OpenSpec) created an issue graph from architecture and specification documents; new issue creation from `docs/development/` artifacts awaits re-implementation via that re-base.
 - `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) refined issue graph structure; restructuring existing graph topology (splitting, merging, re-parenting, dependency rewiring) awaits re-implementation via that re-base.
-- `/stigmergic-convention` provides the signal table schema, field definitions, and read-modify-write protocol for writing signal tables on new and updated issues.
+- `stigmergic-convention` provides the signal table schema, field definitions, and read-modify-write protocol for writing signal tables on new and updated issues.
 
 `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) previously provided core beads conventions and a command quick reference to load before running planning commands.
 
@@ -251,7 +250,7 @@ bd show <epic-id> --json | jq -r '.[0].notes // ""' | grep -q 'audit-findings'
 Treat each item in the "Content remediation needed" section as planning scope alongside new work from docs.
 Acceptance criteria rewrites and scope updates went through `issues-beads-evolve` in step 4; that skill is retired and pending re-base onto Linear/OpenSpec.
 Missing regression-protection issues became new issues created via `issues-beads-seed` in step 4; that skill is retired and pending re-base onto Linear/OpenSpec.
-Confidence gaps on closed work are routed to `/session-review` rather than handled during planning.
+Confidence gaps on closed work are routed to `session-review` rather than handled during planning.
 
 After consuming the audit findings, clear the `<!-- audit-findings -->` block from the epic notes to prevent re-processing in future planning sessions.
 Record what was consumed in the planning session's handoff narrative so the audit trail is preserved.
@@ -363,7 +362,7 @@ The containment-versus-sequencing discipline and the "Dependency type discipline
 
 ### Step 6: set signal tables on new issues
 
-Each new issue receives a signal table following the schema from `/stigmergic-convention`.
+Each new issue receives a signal table following the schema from `stigmergic-convention`.
 
 ```
 <!-- stigmergic-signals -->
@@ -383,7 +382,7 @@ Set `confidence` to `undemonstrated`, `evidence-freshness` to `—`, and `regres
 These are starting values — promotion happens when evidence is produced during implementation and review, not during planning.
 The confidence target from step 4 is not recorded in the signal table (it would duplicate what the issue's role in the DAG already expresses); it serves as planning guidance for the worker who implements the issue.
 
-Write signal tables using the read-modify-write protocol from `/stigmergic-convention`.
+Write signal tables using the read-modify-write protocol from `stigmergic-convention`.
 The cynefin and planning-depth values come from the readiness gate's signal derivation (step 1) or from explicit per-issue classification during decomposition (step 4).
 
 ### Step 7: verify graph health
@@ -424,7 +423,7 @@ Identify which issues can be worked in parallel at each stage of the execution o
 
 The execution plan serves as the handoff to implementation.
 A worker reading this plan should understand what to work on first, what can proceed concurrently, and where the bottlenecks are.
-The diamond workflow (`~/.claude/skills/jj-version-control/diamond-workflow.md`) provides the canonical four-phase mapping from beads issue antichains to parallel jj chains: diverge (decompose), develop (multi-parent `@` development join), converge (validate the integrated state), serialize (sequential rebase to main).
+The diamond workflow (the `jj-version-control` skill's `diamond-workflow.md`) provides the canonical four-phase mapping from beads issue antichains to parallel jj chains: diverge (decompose), develop (multi-parent `@` development join), converge (validate the integrated state), serialize (sequential rebase to main).
 
 ```bash
 # Identify all unblocked work as parallel execution candidates
@@ -439,23 +438,23 @@ bd list --pretty
 
 ## Replanning triggers
 
-Four conditions trigger re-invocation of `/session-plan` to restock the operational buffer.
+Four conditions trigger re-invocation of `session-plan` to restock the operational buffer.
 
 *Surprise accumulation exceeds replanning threshold.*
-The `/session-checkpoint` skill detects this condition by computing the sum of surprise scores across session nodes and comparing against threshold theta.
+The `session-checkpoint` skill detects this condition by computing the sum of surprise scores across session nodes and comparing against threshold theta.
 When surprise is high, the existing plan has diverged from reality and requires revision.
 
 *Validation gate completion.*
-When `/session-review` completes integration verification at a DAG convergence point, findings may invalidate planning assumptions.
-The worker detects this condition and invokes `/session-plan` if the review reveals structural issues.
+When `session-review` completes integration verification at a DAG convergence point, findings may invalidate planning assumptions.
+The worker detects this condition and invokes `session-plan` if the review reveals structural issues.
 
 *Specification change.*
 When architecture or requirements documents are revised, the planning assumptions that produced the current buffer may be stale.
-The worker detects this condition and invokes `/session-plan` to reconcile the buffer with the updated specifications.
+The worker detects this condition and invokes `session-plan` to reconcile the buffer with the updated specifications.
 
 *Buffer depletion.*
 When the ready issue count drops below B*, the buffer can no longer sustain continuous implementation.
-The `/session-checkpoint` skill detects this condition via buffer depletion alerts in the handoff narrative.
+The `session-checkpoint` skill detects this condition via buffer depletion alerts in the handoff narrative.
 
 In all cases, begin with step 1 (readiness gate) to validate that the input artifacts remain sufficient, then proceed through the remaining steps to restock the buffer.
 
@@ -475,20 +474,20 @@ Cynefin classification modulates how deeply this skill executes, not whether the
 After planning completes, the worker proceeds to one of:
 
 - Implementation if the operational buffer is now full and issues are ready with clear acceptance criteria and verification commands.
-- `/session-orient` if scope changed during planning and re-calibration is needed before selecting work.
-- Further `/session-plan` if the buffer is still depleted after the current planning pass (rare; usually indicates the scope is too large for a single planning session and should be narrowed).
+- `session-orient` if scope changed during planning and re-calibration is needed before selecting work.
+- Further `session-plan` if the buffer is still depleted after the current planning pass (rare; usually indicates the scope is too large for a single planning session and should be narrowed).
 
 ---
 
 *Composed skills (delegate, do not duplicate):*
 - `issues-beads-seed` (retired, pending re-base onto Linear/OpenSpec) -- issue graph creation from `docs/development/` artifacts
 - `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) -- graph structure refinement (splitting, merging, re-parenting, rewiring)
-- `/stigmergic-convention` -- signal table schema and write protocol
+- `stigmergic-convention` -- signal table schema and write protocol
 
 *Related skills:*
-- `/session-orient` -- strategic horizon session start, provides discovery findings as input
-- `/session-checkpoint` -- all-horizon state capture, detects replanning triggers
-- `/session-review` -- convergence-point validation, may trigger replanning
+- `session-orient` -- strategic horizon session start, provides discovery findings as input
+- `session-checkpoint` -- all-horizon state capture, detects replanning triggers
+- `session-review` -- convergence-point validation, may trigger replanning
 - `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) -- core beads conventions and command quick reference
 
 *Theoretical foundations:*

--- a/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-review/SKILL.md
+++ b/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/session-review/SKILL.md
@@ -4,20 +4,19 @@ description: Operational-to-tactical feedback skill that verifies assembled subs
 ---
 # Session review
 
-Symlink location: `~/.claude/skills/session-review/SKILL.md`
-Slash command: `/session-review`
+Invoke by name: `session-review`
 
 Session review protocol that verifies assembled subsystems at topological convergence points in the issue DAG, where multiple independent implementation chains merge.
 This skill operates at the operational-to-tactical feedback boundary, validating that independently completed work integrates correctly and measuring accumulated surprise to determine whether replanning is needed.
 It implements the System 3* audit function from the Viable System Model.
 
-This skill is distinct from the per-issue self-verification gate defined in `/stigmergic-convention`.
+This skill is distinct from the per-issue self-verification gate defined in `stigmergic-convention`.
 The self-verification gate runs at issue granularity as part of `bd close`, verifying that a single issue's acceptance criteria are met.
 Session review runs at convergence-point granularity, verifying that multiple closed issues integrate correctly as a subsystem.
-Workers do not invoke `/session-review` for every issue close; they invoke it when a convergence node becomes ready because all its blocking dependencies are closed.
+Workers do not invoke `session-review` for every issue close; they invoke it when a convergence node becomes ready because all its blocking dependencies are closed.
 
 This is the default review command for repositories with the full stigmergic workflow installed.
-For repositories without the full workflow (no session-layer skills, small utility repos, quick fixes), the self-verification gate in `/stigmergic-convention` provides the only review mechanism.
+For repositories without the full workflow (no session-layer skills, small utility repos, quick fixes), the self-verification gate in `stigmergic-convention` provides the only review mechanism.
 
 ## Theoretical grounding
 
@@ -45,7 +44,7 @@ For the full theoretical derivation including the R_plan(d) formulation, buffer 
 This skill orchestrates a higher-level protocol that uses the following skills as components.
 Do not duplicate their functionality; delegate to them.
 
-- `/stigmergic-convention` provides the self-verification gate protocol, signal table schema, field definitions, and the read-modify-write protocol for reading surprise scores from closed dependencies and writing updated signals on the convergence node.
+- `stigmergic-convention` provides the self-verification gate protocol, signal table schema, field definitions, and the read-modify-write protocol for reading surprise scores from closed dependencies and writing updated signals on the convergence node.
 - `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) created rework issues when integration verification fails or accumulated surprise exceeds the replanning threshold.
 
 `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) previously provided core beads conventions and a command quick reference to load before running review commands.
@@ -69,7 +68,7 @@ Execute the following steps in order.
 
 A convergence point is a node in the issue DAG whose blocking dependencies are all closed.
 Nodes with high in-degree (many blocking dependencies) are the primary targets for review because they represent integration points where multiple independent work streams merge.
-The jj diamond workflow's *converge* phase (see `~/.claude/skills/jj-version-control/diamond-workflow.md`) is the VCS-level expression of arriving at such a convergence point — the diamond's converge phase and a planning-DAG convergence node refer to the same node-shape from different perspectives.
+The jj diamond workflow's *converge* phase (see the `jj-version-control` skill's `diamond-workflow.md`) is the VCS-level expression of arriving at such a convergence point — the diamond's converge phase and a planning-DAG convergence node refer to the same node-shape from different perspectives.
 
 Identify candidate convergence points:
 
@@ -177,7 +176,7 @@ Produce a verification report summarizing:
 - What integration verification was performed and its results
 - The accumulated surprise score and its relationship to theta
 
-Update the convergence node's signal table via the read-modify-write protocol from `/stigmergic-convention`:
+Update the convergence node's signal table via the read-modify-write protocol from `stigmergic-convention`:
 - Set progress to *verifying* during review, then to *implementing* or the appropriate next state after review completes.
 - Record the accumulated surprise on the convergence node itself (as a synthesized value reflecting its children's experience).
 
@@ -202,17 +201,17 @@ When integration verification fails or accumulated surprise exceeds theta, the e
 Rework issues previously went through `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) to address integration failures.
 Each rework issue should describe the specific failure, reference the convergence node and the relevant closed dependencies, and include acceptance criteria that would resolve the failure.
 
-Update signal tables on affected issues via the read-modify-write protocol from `/stigmergic-convention`:
+Update signal tables on affected issues via the read-modify-write protocol from `stigmergic-convention`:
 - Set escalation to *pending* on the convergence node if the failure requires human judgment about how to proceed.
 - Increase surprise scores on the convergence node to reflect the integration divergence.
 
-Flag the need for replanning via `/session-plan`.
+Flag the need for replanning via `session-plan`.
 The handoff to session-plan should include the rework issues created, the accumulated surprise score, and the specific integration failures that motivated replanning.
 
 If the convergence node previously had a higher confidence level, demote `confidence` to `regressed` to reflect that a previously supported claim no longer holds.
 Record what evidence failed in the checkpoint context so the next worker understands the regression.
 
-When deciding between rework and escalation, apply the self-verification gate's principle from `/stigmergic-convention`: if the failure can be fixed and retried, create rework issues; if the failure reveals an ambiguity that the DAG does not contain enough information to resolve, escalate with a precise question.
+When deciding between rework and escalation, apply the self-verification gate's principle from `stigmergic-convention`: if the failure can be fixed and retried, create rework issues; if the failure reveals an ambiguity that the DAG does not contain enough information to resolve, escalate with a precise question.
 
 ### Step 6: documentation and convention health at convergence
 
@@ -232,7 +231,7 @@ If issue A's work changed an assumption that issue B's spec relies on, flag the 
 #### Diagram coverage at convergence
 
 Check whether the converging work introduced or modified architectural boundaries that the existing diagram set does not cover.
-Compare the C4 levels touched by the converging issues against the diagram categories in `preferences-architecture-diagramming/04-diagram-compendium.md`.
+Compare the C4 levels touched by the converging issues against the diagram categories in the `preferences-architecture-diagramming` skill's `04-diagram-compendium.md`.
 When a convergence point assembles a new subsystem boundary or changes deployment topology and no corresponding diagram exists, flag the gap.
 When existing diagrams depict structures that the converging implementation changed, flag those diagrams as stale.
 
@@ -253,20 +252,20 @@ Record observations via `bd update <epic-id> --append-notes "Review gate [N]: ..
 After review completes, the worker proceeds to one of:
 
 - Implementation if verification passed and the operational buffer still contains ready issues.
-- `/session-plan` if replanning was triggered by high surprise or failed verification.
-- `/session-checkpoint` if the session is ending, to capture the review results in the handoff narrative.
-- `/session-plan` to decompose validation or regression-protection work when review reveals a severity gap — the implementation exists but confidence cannot advance without stronger evidence.
+- `session-plan` if replanning was triggered by high surprise or failed verification.
+- `session-checkpoint` if the session is ending, to capture the review results in the handoff narrative.
+- `session-plan` to decompose validation or regression-protection work when review reveals a severity gap — the implementation exists but confidence cannot advance without stronger evidence.
 
 ---
 
 *Composed skills (delegate, do not duplicate):*
-- `/stigmergic-convention` -- signal table schema, self-verification gate, read-modify-write protocol
+- `stigmergic-convention` -- signal table schema, self-verification gate, read-modify-write protocol
 - `issues-beads-evolve` (retired, pending re-base onto Linear/OpenSpec) -- rework issue creation when integration verification fails
 
 *Related skills:*
-- `/session-orient` -- strategic horizon session start, provides initial context for work selection
-- `/session-plan` -- tactical-to-operational decomposition, invoked when replanning is triggered
-- `/session-checkpoint` -- all-horizon state capture and handoff
+- `session-orient` -- strategic horizon session start, provides initial context for work selection
+- `session-plan` -- tactical-to-operational decomposition, invoked when replanning is triggered
+- `session-checkpoint` -- all-horizon state capture and handoff
 - `issues-beads-prime` (retired, pending re-base onto Linear/OpenSpec) -- core beads conventions and command quick reference
 
 *Theoretical foundations:*

--- a/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/stigmergic-convention/SKILL.md
+++ b/modules/home/ai/plugins/beads-issue-tracking-and-session-workflow/.apm/skills/stigmergic-convention/SKILL.md
@@ -4,8 +4,7 @@ description: Signal table schema, field definitions, update protocol, and CUE va
 ---
 # Stigmergic convention reference
 
-Symlink location: `~/.claude/skills/stigmergic-convention/SKILL.md`
-Slash command: `/stigmergic-convention`
+Invoke by name: `stigmergic-convention`
 
 Protocol reference for stigmergic workflow coordination via structured signal tables on beads issues.
 Workers orient by reading the DAG rather than receiving briefings.
@@ -226,7 +225,7 @@ bd lint          # check for missing template sections
 - `preferences-validation-assurance` for the evidence quality dimensions, confidence promotion chain, and regression harness design underlying the confidence, evidence-freshness, and regression-guard signals
 
 *Composed by:*
-- `/session-orient` -- reads signal tables during orientation briefing assembly
-- `/session-plan` -- sets signal tables on newly created issues
-- `/session-review` -- reads signal tables for surprise accumulation at convergence points
-- `/session-checkpoint` -- updates signal tables during session wind-down
+- `session-orient` -- reads signal tables during orientation briefing assembly
+- `session-plan` -- sets signal tables on newly created issues
+- `session-review` -- reads signal tables for surprise accumulation at convergence points
+- `session-checkpoint` -- updates signal tables during session wind-down

--- a/modules/home/ai/plugins/document-authoring-and-visualization/.apm/skills/knowledge-graph/references/ingestion-workflow.md
+++ b/modules/home/ai/plugins/document-authoring-and-visualization/.apm/skills/knowledge-graph/references/ingestion-workflow.md
@@ -6,7 +6,7 @@ description: Worked-example runbook for populating reference corpora into cognee
 # ingestion workflow
 
 This runbook walks two real corpora from empty to queryable and shows how to use the resulting graphs as grounding context while writing or reviewing a technical manuscript.
-The targets are `engineering-references-v2` (writing and architecture craft) and `modeling-references` (the scientific subject matter), and the intended consumer is `/Users/crs58/projects/hodosome-workspace/hodosome/docs/manuscript/manuscript.qmd`, a paper on stochastic dynamical modeling and inference of gene-regulatory network architecture.
+The targets are `engineering-references-v2` (writing and architecture craft) and `modeling-references` (the scientific subject matter), and the intended consumer is `docs/manuscript/manuscript.qmd` in the private `sciexp/hodosome` tree, a paper on stochastic dynamical modeling and inference of gene-regulatory network architecture.
 
 Throughout, ingestion means indexing curated reference documents, not capturing session state.
 The verbs are named for memory but used for reference-corpus indexing; the discipline is in what you ingest and why you query.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/nucleus-platform/SKILL.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/nucleus-platform/SKILL.md
@@ -81,7 +81,7 @@ This is a demotion of LinkML from the domain spine, not its removal from the str
 Semantic identity is data that no type system carries.
 Whether a slot's range is CL:0000540, which CURIE an enum value binds, how a local term maps to an external vocabulary: none of this is a projection of anything in Lean, so it is curated and joined in at the LinkML layer.
 The semantic and provenance overlay is one framework, LinkML, at full strength: ontology binding via class_uri, slot_uri, and CURIE-bound enums; OWL, SHACL, and RDF emission; and a curator- and biologist-editable surface.
-LinkML's broader ontology and semantic facilities, including cross-ontology mapping provenance, are realized per-schema rather than as separate tools, grounded in the linkml and linkml-biolink-model reference repos under /Users/crs58/projects/omicslake-workspace.
+LinkML's broader ontology and semantic facilities, including cross-ontology mapping provenance, are realized per-schema rather than as separate tools, grounded in the linkml and linkml-biolink-model reference repos in the local `omicslake-workspace` repository.
 
 The join of the axes is projection-plus-overlay: the [build] projection emits a LinkML skeleton from the Lean data model, and curator-authored ontology bindings are merged onto it as a mixin.
 A property-based conformance test closes the join: the published LinkML schema must accept exactly the serializations the algebraic model emits and round-trip them.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/nucleus-platform/references/linkml-data-model.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/nucleus-platform/references/linkml-data-model.md
@@ -30,14 +30,14 @@ This does not make LinkML a structural source.
 
 ## Grounding instances
 
-The flow is grounded in a real instance and its template, both under /Users/crs58/projects/omicslake-workspace.
+The flow is grounded in a real instance and its template, both in the local `omicslake-workspace` repository.
 
 - test-linkml — the concrete reference instance, a copier-instantiated LinkML project; its src/test_linkml/schema/test_linkml.yaml generates src/test_linkml/datamodel/{test_linkml_pydantic.py, test_linkml.py}, and its project/ tree holds the other twelve generated bindings. We author our schema manually following its inferred practices, not through the copier.
 - linkml-project-copier — the copier template whose template/justfile defines the gen-* recipes (gen-python, gen-project, gen-pydantic, gen-doc, and the per-binding recipes) that drive schema-to-datamodel generation.
 
 ## Reference repositories
 
-All under /Users/crs58/projects/omicslake-workspace, verified present.
+All in the local `omicslake-workspace` repository, verified present.
 Near the contracts discussion:
 
 - open-data-product-standard — the ODPS specification source.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/check-translation-validation.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/check-translation-validation.md
@@ -29,14 +29,14 @@ It is not a requirement, and its absence is not a failure of the loop.
 An undischarged correspondence is an open obligation, not a defect: it is precisely the thing the next refine iteration can target, or that a lower tier can cover with empirical evidence in the meantime.
 
 The reference corpus treats unproven obligations exactly this way.
-Tutorial theorems ship as `axiom` declarations — honest, non-failing placeholders that Lean accepts while verifying nothing — with a documented roadmap to discharge them later with real Aeneas tactics (`~/projects/functional-programming-workspace/rust-lean-aeneas`, `GAP_ANALYSIS.md`, `STATUS.md`).
+Tutorial theorems ship as `axiom` declarations — honest, non-failing placeholders that Lean accepts while verifying nothing — with a documented roadmap to discharge them later with real Aeneas tactics (`rust-lean-aeneas`, `GAP_ANALYSIS.md`, `STATUS.md`).
 The trusted-kernel completion criterion is stated alongside this openly: if `lake build` succeeds on a real proof, the Lean kernel has verified it; if a theorem is still an `axiom`, that is simply recorded as an open item rather than masked.
 
 The kernel-recheck guarantee is what makes the whole ladder safe, and especially what makes AI-assisted proof safe.
 An ordinary Lean proof term is re-checked by the small trusted kernel regardless of how it was produced.
 A human-written proof, an Aeneas-tactic-generated proof, and an LLM-generated proof are all just proof terms, and the kernel re-checks every one of them.
 Provenance is therefore irrelevant to soundness: a mis-generated proof simply fails to typecheck.
-The sharp in-corpus contrast is between `decide` and `native_decide`: `decide` (and any normal tactic-produced proof) yields a kernel-checked term that adds no axiom, whereas `native_decide` is documented as adding the entire Lean compiler to the trusted base and surfacing a new axiom in `#print axioms` for anything that transitively depends on it (`~/projects/functional-programming-workspace/lean4`, `src/Init/Tactics.lean`).
+The sharp in-corpus contrast is between `decide` and `native_decide`: `decide` (and any normal tactic-produced proof) yields a kernel-checked term that adds no axiom, whereas `native_decide` is documented as adding the entire Lean compiler to the trusted base and surfacing a new axiom in `#print axioms` for anything that transitively depends on it (`lean4`, `src/Init/Tactics.lean`).
 The corollary is that you may let automation, including an LLM, propose proofs aggressively at tier 1, because nothing it proposes can corrupt soundness — at worst it fails to compile.
 
 ## Three notions of agreement
@@ -47,12 +47,12 @@ Each tier targets one or more of them, and naming which one you are after disamb
 *Definitional (judgmental) equality* holds when two expressions reduce to the same normal form purely by computation.
 The kernel checks it automatically with no reasoning step: `example : 2 + 3 = 5 := rfl` succeeds because both sides compute to 5.
 Definitional equality is strong but brittle.
-For a variable `n`, the equation `n + 0 = n` is *not* definitional, because `Nat.add` recurses on its second argument so `n + 0` does not reduce, and proving it needs `induction` (`~/projects/functional-programming-workspace/rust-lean-aeneas`, `LEAN.md`).
+For a variable `n`, the equation `n + 0 = n` is *not* definitional, because `Nat.add` recurses on its second argument so `n + 0` does not reduce, and proving it needs `induction` (`rust-lean-aeneas`, `LEAN.md`).
 Definitional equality is the rare, lucky case where the lifted model and the spec are literally the same function up to computation; do not expect it across a refine/lower boundary.
 
 *Functional / observational equivalence* holds when two differently-implemented functions compute the same input-to-output relation — the same mathematical function — even with different internal strategies.
 This is a *propositional* equality, proved by induction or case analysis rather than by reduction.
-The canonical worked instance in the corpus is the infix-versus-RPN evaluator equivalence: tree recursion and a stack machine are completely different evaluation strategies that nonetheless compute the same function, and the bridging theorem states exactly that (`~/projects/functional-programming-workspace/rust-lean-aeneas`, `tutorials/03-infix-calculator/.../Equivalence.lean`).
+The canonical worked instance in the corpus is the infix-versus-RPN evaluator equivalence: tree recursion and a stack machine are completely different evaluation strategies that nonetheless compute the same function, and the bridging theorem states exactly that (`rust-lean-aeneas`, `tutorials/03-infix-calculator/.../Equivalence.lean`).
 A roundtrip/inverse property such as decrypt(encrypt(p, key), key) = p is another observational identity.
 Across a refine/lower boundary, equivalence is the usual aspiration: the Rust you wrote should compute the same function as the Lean spec it was lowered from.
 
@@ -74,7 +74,7 @@ theorem mul2_add1_spec (x : U32)
     mul2_add1 x ⦃ y => ↑ y = 2 * ↑x + (1 : Nat) ⦄   -- success ∧ postcondition
 ```
 
-The `⦃ y => P y ⦄` notation is Aeneas' postcondition / success-monad-spec syntax, written in the Hoare-logic style the tutorial advises — preconditions as hypotheses, postcondition inside the brace (`~/projects/functional-programming-workspace/aeneas`, `tests/lean/BaseTutorial.lean`).
+The `⦃ y => P y ⦄` notation is Aeneas' postcondition / success-monad-spec syntax, written in the Hoare-logic style the tutorial advises — preconditions as hypotheses, postcondition inside the brace (`aeneas`, `tests/lean/BaseTutorial.lean`).
 Read against the three notions: the theorem asserts the lifted `mul2_add1` *refines* a spec that says "given no overflow, return twice the input plus one", and because the postcondition pins the result exactly, this particular instance also witnesses functional equivalence on the precondition's domain.
 
 ## Tier 1 — mechanical: kernel-checked refinement proof
@@ -88,13 +88,13 @@ Hammer-class automation — `aesop`, `duper`, LeanHammer — sits at the *extern
 
 Aeneas' own tactics are the engine for discharging refinement obligations over the lifted model.
 The principal tactic is `step`, with spec theorems registered via the `@[step]` attribute.
-`step` looks for a suitable theorem — supplied by the user or found in the `@[step]` database — describing the behaviour of a monadic function, applies it to the current goal, introduces the existentially quantified result variables, splits the postcondition conjunctions, and tries to discharge the preconditions automatically, leaving any it cannot prove as subgoals (`~/projects/functional-programming-workspace/aeneas`, `backends/lean/Aeneas/Tactic/Step/Step.lean`, `tests/lean/BaseTutorial.lean`).
+`step` looks for a suitable theorem — supplied by the user or found in the `@[step]` database — describing the behaviour of a monadic function, applies it to the current goal, introduces the existentially quantified result variables, splits the postcondition conjunctions, and tries to discharge the preconditions automatically, leaving any it cannot prove as subgoals (`aeneas`, `backends/lean/Aeneas/Tactic/Step/Step.lean`, `tests/lean/BaseTutorial.lean`).
 Precondition discharge internally threads a `grind` state across successive `step` calls, so `step` is itself a composite that delegates to lean4's `grind`.
-The names `progress` and the `@[pspec]` / `@[progress]` attributes are deprecated aliases retained only for backward compatibility — they emit a deprecation warning and delegate to `step` / `@[step]` (`~/projects/functional-programming-workspace/aeneas`, `backends/lean/Aeneas/Tactic/Step/Deprecated.lean`).
+The names `progress` and the `@[pspec]` / `@[progress]` attributes are deprecated aliases retained only for backward compatibility — they emit a deprecation warning and delegate to `step` / `@[step]` (`aeneas`, `backends/lean/Aeneas/Tactic/Step/Deprecated.lean`).
 Use `step` and `@[step]` in all new proofs; mention `progress` and `@[pspec]` only to note that they are deprecated.
 
 Arithmetic obligations inside a refinement proof are discharged with `scalar_tac`, not bare `omega`.
-`scalar_tac` is Aeneas' arithmetic solver, aware of machine-integer bounds (`U32`, `Usize`, and so on); it heavily preprocesses the goal and then calls `omega` under the hood, and with `scalar_tac +nonLin` it reaches some non-linear goals as well (`~/projects/functional-programming-workspace/aeneas`, `backends/lean/Aeneas/Tactic/Solver/ScalarTac/ScalarTac.lean`).
+`scalar_tac` is Aeneas' arithmetic solver, aware of machine-integer bounds (`U32`, `Usize`, and so on); it heavily preprocesses the goal and then calls `omega` under the hood, and with `scalar_tac +nonLin` it reaches some non-linear goals as well (`aeneas`, `backends/lean/Aeneas/Tactic/Solver/ScalarTac/ScalarTac.lean`).
 This is the load-bearing scope rule for the check leg: `omega` is forbidden *inside* Aeneas refinement proofs over the lifted model, because those goals manipulate machine-integer scalars whose bounds bare `omega` does not know; `scalar_tac` supplies the bounds preprocessing before delegating to `omega`.
 Hand-authored, spec-side Lean over plain `Nat` or `Int` may use `omega` directly — that restriction applies only within the Aeneas-lifted refinement proofs.
 Keep this distinction explicit wherever `omega` appears.
@@ -120,7 +120,7 @@ theorem clamp_in_bounds (x lo hi : Std.I32) (h : lo ≤ hi) :
   split <;> split <;> simp_all <;> constructor <;> scalar_tac
 ```
 
-Both of these are genuine kernel-checked proofs, not `axiom` placeholders, and the corpus also carries real ones — for example an invariant-preservation theorem and a reachability induction over an Aeneas-lifted traffic-light state machine, finished with `simp`, `cases`, `simp_all`, and `induction` (`~/projects/functional-programming-workspace/rust-lean-aeneas`, `tutorials/04-state-machines/.../TrafficLightProofs.lean`).
+Both of these are genuine kernel-checked proofs, not `axiom` placeholders, and the corpus also carries real ones — for example an invariant-preservation theorem and a reachability induction over an Aeneas-lifted traffic-light state machine, finished with `simp`, `cases`, `simp_all`, and `induction` (`rust-lean-aeneas`, `tutorials/04-state-machines/.../TrafficLightProofs.lean`).
 
 Aeneas' `Result` model is what these proofs reason over.
 The current `Result` type has three constructors — `ok`, `fail`, and `div` — paired with a seven-constructor `Error`.
@@ -133,16 +133,16 @@ When a tier-1 proof is not yet available, or as a fast preliminary sanity check 
 The hand-authored Lean spec is ordinary executable Lean, and the Aeneas-lifted model is also executable Lean over the `Result` monad, so the two can be tested against each other directly: generate many random inputs and check that the spec's output agrees with the lifted model's output (the ≈ relation), collecting statistical evidence for the ≈-identity short of a proof.
 
 The framework is Plausible, Lean's QuickCheck-style property-based testing library (upstream `leanprover-community/plausible`).
-Plausible is a standalone package, not part of lean4 core; Mathlib re-exports it and adds instances under (`~/projects/functional-programming-workspace/mathlib4`, `Mathlib/Testing/Plausible/`).
+Plausible is a standalone package, not part of lean4 core; Mathlib re-exports it and adds instances under (`mathlib4`, `Mathlib/Testing/Plausible/`).
 Its confirmed API surface is the `Plausible.Testable` type class (a testable proposition, run under a `Configuration`), `Plausible.SampleableExt` (random sample generation for a type so it can appear in a tested ∀-quantifier), `Plausible.Shrinkable` (counterexample shrinking), `Plausible.Gen` (the random-generation monad), and `Plausible.TestResult` / `Plausible.PrintableProp` (counterexample reporting).
 State the agreement between the two executable Lean artifacts as a universally-quantified decidable proposition, then exercise it through one of two front-ends that both call the same runner.
-The `#test <prop>` command tests the property at elaboration time; it is a macro that desugars to `#eval Plausible.Testable.check <prop>` (`~/projects/functional-programming-workspace/plausible`, `Plausible/Testable.lean:625`).
-The `plausible` tactic (the confirmed successor to Mathlib's older `slim_check`) attacks a goal of that same shape (`~/projects/functional-programming-workspace/plausible`, `Plausible/Tactic.lean:158`).
-Both route to `Plausible.Testable.check`, which runs `numInst` (default 100) randomized trials and reports a shrunk counterexample as `TestResult.failure` (`~/projects/functional-programming-workspace/plausible`, `Plausible/Testable.lean:80-102`), or reports success when no counterexample is found.
-`Testable.run` is *not* a runner entry point: it is the `Testable` class method returning `Gen (TestResult p)` (`~/projects/functional-programming-workspace/plausible`, `Plausible/Testable.lean:174-176`); the runners proper are `Testable.check` (`Plausible/Testable.lean:603`) and `Testable.checkIO` (`Plausible/Testable.lean:549`).
+The `#test <prop>` command tests the property at elaboration time; it is a macro that desugars to `#eval Plausible.Testable.check <prop>` (`plausible`, `Plausible/Testable.lean:625`).
+The `plausible` tactic (the confirmed successor to Mathlib's older `slim_check`) attacks a goal of that same shape (`plausible`, `Plausible/Tactic.lean:158`).
+Both route to `Plausible.Testable.check`, which runs `numInst` (default 100) randomized trials and reports a shrunk counterexample as `TestResult.failure` (`plausible`, `Plausible/Testable.lean:80-102`), or reports success when no counterexample is found.
+`Testable.run` is *not* a runner entry point: it is the `Testable` class method returning `Gen (TestResult p)` (`plausible`, `Plausible/Testable.lean:174-176`); the runners proper are `Testable.check` (`Plausible/Testable.lean:603`) and `Testable.checkIO` (`Plausible/Testable.lean:549`).
 
 Tier 2 establishes only empirical, approximate identity — not a proof — and that is its honest role: it is evidence that the spec and lifted model agree on the sampled inputs, strong enough to catch a divergence early and cheap enough to run constantly, but it never closes a refinement obligation on its own.
-The load-bearing reason is mechanical, not merely a matter of statistical coverage: the `plausible` tactic is a test aid, not a proof tactic, and when it finds no counterexample it *admits* the goal via `admitGoal` (`~/projects/functional-programming-workspace/plausible`, `Plausible/Tactic.lean:206`) rather than discharging the theorem.
+The load-bearing reason is mechanical, not merely a matter of statistical coverage: the `plausible` tactic is a test aid, not a proof tactic, and when it finds no counterexample it *admits* the goal via `admitGoal` (`plausible`, `Plausible/Tactic.lean:206`) rather than discharging the theorem.
 A passing `plausible` or `#test` run therefore raises confidence that Φ(S) ≈ S but does not establish it — producing a machine-checked refinement or equivalence is exactly tier 1's job, and that is precisely why tier 2 yields ≈-evidence while tier 1 yields a kernel-checked ⊑ or equivalence.
 A passing tier-2 campaign over a function is a good reason to attempt tier 1 on it; a failing one is a counterexample that bounces straight back into the next refine iteration.
 Note that this Lean-side spec-versus-lifted-model testing is the *prescribed* design for the loop, not something already wired in the corpus — the existing tutorials run Rust-side `proptest` / `quickcheck` on the Rust core as a tier-2 analog rather than testing the two Lean artifacts against each other.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/diagramming.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/diagramming.md
@@ -21,7 +21,7 @@ The real emitters are future work and are not built in v1.
 
 The three emitters traverse three different intermediate representations, but they describe the same nominal type system.
 Rather than three bespoke JSON shapes, this skill specifies *one* node/edge vocabulary that all three populate, so that two graphs can be diffed as data rather than compared as pictures.
-The schema is versioned by a single integer `schemaVersion` field at the document root; a consumer asserts the version it understands and refuses unknown ones, exactly as the rustdoc `FORMAT_VERSION` contract instructs (`src/lib.rs:104-117` in `~/projects/rust-workspace/rustdoc-types`).
+The schema is versioned by a single integer `schemaVersion` field at the document root; a consumer asserts the version it understands and refuses unknown ones, exactly as the rustdoc `FORMAT_VERSION` contract instructs (`src/lib.rs:104-117` in `rustdoc-types`).
 The v1 schema is `schemaVersion = 1`.
 
 A document is a set of nodes plus a set of edges, tagged with the emitter that produced it and which IR stage the emitter read.
@@ -78,7 +78,7 @@ The spec side is ground truth because the Lean 4 declarations *are* the specific
 The emitter is a `lake exe` metaprogram that walks the elaborated `Lean.Environment` and emits one node per relevant declaration plus the edges its type and constructors imply.
 It is not part of the refine/lower, Charon, or Aeneas stages; it consumes the same `Environment` those stages elaborate against, and produces the artifact translation validation later checks against (see `references/check-translation-validation.md`).
 
-The environment is obtained outside elaboration via `importModules ... (leakEnv := true) (loadExts := true)` after `initSearchPath (← findSysroot)`, the recipe doc-gen4 uses (`DocGen4/Load.lean:12-15` and `:21-38` in `~/projects/functional-programming-workspace/lean-doc-gen4`); `loadExts := true` is required because the structure and instance extensions are read below.
+The environment is obtained outside elaboration via `importModules ... (leakEnv := true) (loadExts := true)` after `initSearchPath (← findSysroot)`, the recipe doc-gen4 uses (`DocGen4/Load.lean:12-15` and `:21-38` in `lean-doc-gen4`); `loadExts := true` is required because the structure and instance extensions are read below.
 The walk iterates `env.constants` (an `SMap` with a `ForIn` instance over `(Name × ConstantInfo)` pairs) inside `MetaM`, run via `Meta.MetaM.toIO`.
 The `Environment` structure has changed shape across recent Lean versions, so the emitter goes through the public accessors (`constants`, `find?`, `header`, `getModuleIdxFor?`) and never pattern-matches the structure directly, exactly as doc-gen4 does; a consumer building against an arbitrary toolchain re-confirms these signatures against that toolchain rather than assuming them.
 
@@ -100,7 +100,7 @@ An `Option` field whose name ends in `?` is omitted from the JSON when `none` (t
 
 The impl side is the second authority, faithful not to the Rust source but to the LLBC that Aeneas actually verifies against.
 LLBC is the lowered, monomorphization-aware, body-bearing IR; it is the object the functional translation consumes, so a type graph read from it describes exactly the type system the lifted Lean model will reflect.
-The emitter is an OCaml consumer of charon-ml (`~/projects/functional-programming-workspace/charon/charon-ml`), version-locked to the Charon checkout (`0.1.216` at this clone, `charon-ml/src/CharonVersion.ml:3`); the deserializer rejects any LLBC whose version differs (`OfJson.ml:27-34`), so the impl-side graph cannot silently drift from the IR it claims to describe.
+The emitter is an OCaml consumer of charon-ml (the `charon-ml/` tree of the `charon` repository), version-locked to the Charon checkout (`0.1.216` at this clone, `charon-ml/src/CharonVersion.ml:3`); the deserializer rejects any LLBC whose version differs (`OfJson.ml:27-34`), so the impl-side graph cannot silently drift from the IR it claims to describe.
 
 The crate is loaded with `OfJson.crate_of_json_file`, yielding a `crate` record whose `type_decls : type_decl TypeDeclId.Map.t` is the node table (`charon-ml/src/GAst.ml:33-47`).
 Each `type_decl.kind` is a `type_decl_kind` (`Generated_Types.ml:1234-1247`): `Struct of field list` becomes a `struct` node, `Enum of variant list` becomes an `enum` node, `Union of field list` becomes a `struct` node (with a `union` flag in `attrs`), and `Opaque`/`Alias`/`TDeclError` produce nodes flagged accordingly but with no field edges.
@@ -120,7 +120,7 @@ The Charon invocation that produces an LLBC the emitter then reads is the Aeneas
 ## Emitter (iii): rustdoc-types over rustdoc JSON (independent cross-check)
 
 The third emitter is deliberately *not* an authority.
-It reads the rustdoc JSON produced by `cargo +nightly rustdoc -- --output-format json -Z unstable-options` (`README.md:5-7` in `~/projects/rust-workspace/rustdoc-types`), parsed into a `rustdoc_types::Crate` and gated on `format_version == FORMAT_VERSION` (`57` at this pin).
+It reads the rustdoc JSON produced by `cargo +nightly rustdoc -- --output-format json -Z unstable-options` (`README.md:5-7` in `rustdoc-types`), parsed into a `rustdoc_types::Crate` and gated on `format_version == FORMAT_VERSION` (`57` at this pin).
 It exists to provide an independent third witness along a different tool path (rustc's rustdoc) than either authority, so that agreement at the public-API boundary cross-validates the spec and impl emitters without pretending to be verification-faithful ground truth.
 
 Node population reads `Crate::index : HashMap<Id, Item>`; each `Item.inner` is an `ItemEnum` whose snake-cased tag selects the kind (`src/lib.rs:713-830`): `Struct` becomes `struct`, `Enum` becomes `enum`, `Function` becomes `function`, `Trait` becomes the rustdoc analogue of a class.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/lean-spec-patterns.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/lean-spec-patterns.md
@@ -196,9 +196,9 @@ The spec's lakefile must pin its `lean-toolchain` to the exact string in the Aen
 The Aeneas Lean library is itself a `require` only in the round-trip and differential-testing context, where you compare the spec against the lifted model inside Lean; a standalone Lean spec needs only its own dependencies (mathlib and Plausible) and not the Aeneas library, and that standalone case — a Lean spec kept beside a non-Rust implementation such as Python — is owned by `preferences-theoretical-foundations`.
 Property testing is the fast-falsification half of the development loop: state the spec-versus-model correspondence as a `∀`-quantified decidable proposition, throw random inputs at it to find a counter-example quickly, then prove it (or `decide` / `native_decide` the finite instances) for the final check.
 
-The package is the standalone Lake package `plausible`, imported with `import Plausible`; mathlib4 re-exposes it transitively through `Mathlib.Tactic.Common` (`~/projects/functional-programming-workspace/plausible`, `Mathlib/Tactic/Common.lean:12`).
-There are three equivalent ways to run a property, all of which synthesize a `Testable` instance and call the same `Testable.check`: the `#test <prop>` command, a direct `#eval Testable.check <prop>`, or the `plausible` tactic applied to a goal of that shape (`~/projects/functional-programming-workspace/plausible`, `Plausible/Tactic.lean:158`).
-The `#test` command is itself a macro that desugars to `#eval Plausible.Testable.check <prop>` (`~/projects/functional-programming-workspace/plausible`, `Plausible/Testable.lean:625`).
+The package is the standalone Lake package `plausible`, imported with `import Plausible`; mathlib4 re-exposes it transitively through `Mathlib.Tactic.Common` (`plausible`, `Mathlib/Tactic/Common.lean:12`).
+There are three equivalent ways to run a property, all of which synthesize a `Testable` instance and call the same `Testable.check`: the `#test <prop>` command, a direct `#eval Testable.check <prop>`, or the `plausible` tactic applied to a goal of that shape (`plausible`, `Plausible/Tactic.lean:158`).
+The `#test` command is itself a macro that desugars to `#eval Plausible.Testable.check <prop>` (`plausible`, `Plausible/Testable.lean:625`).
 
 ```lean
 import Plausible
@@ -224,12 +224,12 @@ A bare `by plausible` uses the default config.
 Property testing requires `SampleableExt` (built from `Arbitrary`, which supplies the `Gen α` generator, and `Shrinkable`) plus `Repr` instances for the quantified types; `SampleableExt` is usually inferable for closed types via `:= by infer_instance`, while `Arbitrary` and `Shrinkable` are hand-written for the non-derivable ones.
 This dependency is the reason a *runnable, decidable* spec is the prerequisite for property-testing it: the same constructive instances that make the spec `#eval`-able are the ones the generators and the `Testable` mechanism consume.
 
-The underlying class is `Testable`, declared `class Testable (p : Prop) where run (cfg : Configuration) (minimize : Bool) : Gen (TestResult p)` (`~/projects/functional-programming-workspace/plausible`, `Plausible/Testable.lean:174-176`).
+The underlying class is `Testable`, declared `class Testable (p : Prop) where run (cfg : Configuration) (minimize : Bool) : Gen (TestResult p)` (`plausible`, `Plausible/Testable.lean:174-176`).
 `Testable.run` is the class *method* that produces a `Gen (TestResult p)`; it is not a run-and-get-result entry point, so reach for the runners instead — `Testable.check : CoreM PUnit` (`Plausible/Testable.lean:603`), which `#test` and the tactic call, and `Testable.checkIO : IO (TestResult p)` (`Plausible/Testable.lean:549`) for programmatic use.
 A `TestResult` is one of `success`, `gaveUp`, or `failure`, the last carrying the shrunk counter-example (`Plausible/Testable.lean:80-102`).
 The default trial count is `numInst = 100`, raised or lowered through the configuration record as `(config := { numInst := N })`.
 
-Custom quantified types supply their own generation: derive or instance `Repr`, `Plausible.Shrinkable` (its `shrink : α → List α` drives counter-example minimization), and `Plausible.Arbitrary` (a `Gen α`), and `Plausible.SampleableExt` then follows automatically via the `selfContained` default instance (`~/projects/functional-programming-workspace/plausible`, `Plausible/Sampleable.lean:123-129`).
+Custom quantified types supply their own generation: derive or instance `Repr`, `Plausible.Shrinkable` (its `shrink : α → List α` drives counter-example minimization), and `Plausible.Arbitrary` (a `Gen α`), and `Plausible.SampleableExt` then follows automatically via the `selfContained` default instance (`plausible`, `Plausible/Sampleable.lean:123-129`).
 The older `SampleableExt.mkSelfContained` route is deprecated as of 2025-10-22 (`Plausible/Sampleable.lean:132`).
 These signatures were read at toolchain v4.32.0-rc1; `Arbitrary` in particular has seen churn across versions, so confirm it against the toolchain the spec's lakefile actually pins.
 

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/prior-art-idris2.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/prior-art-idris2.md
@@ -1,7 +1,7 @@
 # Prior art: ironstar's Idris2 spec and Rust crates
 
 The ironstar template is the closest existing prior art for this skill's loop, and it is the substrate for the later full-loop test exercise.
-It already practices the spec-leads-implementation half of refinement-driven development by hand: a dependently-typed Idris2 specification at `~/projects/rust-workspace/ironstar/spec` defines the domain model, algebraic laws, and proof terms, and a Rust workspace at `~/projects/rust-workspace/ironstar/crates` realizes those specifications as concrete types and trait implementations.
+It already practices the spec-leads-implementation half of refinement-driven development by hand: a dependently-typed Idris2 specification in the local `ironstar` checkout's `spec/` defines the domain model, algebraic laws, and proof terms, and a Rust workspace in its `crates/` realizes those specifications as concrete types and trait implementations.
 What ironstar does *not* yet have is the mechanized lift: no Charon, Aeneas, LLBC, or Lean material exists in the repository today, so its spec-to-code relationship is maintained entirely by hand and by tests.
 That missing half is exactly what the later exercise targets, and this reference mines ironstar read-only to prepare for it; the actual Idris2 to Lean 4 re-modeling is the user's test of the finished skill, not work performed now.
 
@@ -17,7 +17,7 @@ That missing half is exactly what the later exercise targets, and this reference
 ## How the spec and crates mirror each other
 
 The Idris2 spec is organized as five `Core.*` abstraction modules (Decider, View, Saga, Effect, Event), a `SharedKernel.UserId` module, and four bounded contexts (Analytics as the core domain, Session and Workspace as supporting, Todo as a generic example), with `%default total` set in every module.
-The whole pattern family descends from Jérémie Chassaing's Decider, realized in Rust via the `fmodel-rust` dependency (a local clone lives at `~/projects/rust-workspace/fmodel-rust`).
+The whole pattern family descends from Jérémie Chassaing's Decider, realized in Rust via the `fmodel-rust` dependency (a local clone of the upstream repository).
 The central abstraction is a record of three function fields: `decide :: c -> s -> Either err (List e)` (the coalgebra unfolding commands into events), `evolve :: s -> e -> s` (the algebra folding events into state, deliberately total), and `initialState :: s`.
 The totality of `evolve` is itself the encoding of the domain fact that events are historical and cannot fail.
 
@@ -115,6 +115,6 @@ These are the manual translation-validation that the mechanized check is meant t
 
 A few claims here are sketched in ironstar itself and should be confirmed against source before the exercise leans on them.
 It is not settled whether real property tests (`proptest!` macro bodies) exist versus only example-based `DeciderTestSpecification` Given/When/Then; the Todo decider tests inspected were example-based, and the `proptest` mentions matched mostly README and re-export lines, so treat the laws as verified by example primarily.
-The exact `fmodel-rust` 0.9 surface for `View`/`Saga`/`Aggregate` was read through ironstar's re-exports and usage rather than upstream source; consult `~/projects/rust-workspace/fmodel-rust` directly for the `Decider`/`Sum` definitions when assessing lift translatability.
+The exact `fmodel-rust` 0.9 surface for `View`/`Saga`/`Aggregate` was read through ironstar's re-exports and usage rather than upstream source; consult the local `fmodel-rust` clone directly for the `Decider`/`Sum` definitions when assessing lift translatability.
 The `MonotonicIds` `MonoCons` constructor as written appears to be a sketch that does not thread the ordering proof, so treat `MonotonicIds` as aspirational, not load-bearing, when porting (the `List.Chain'`/`List.Sorted` substitution in the table is the cleaner target anyway).
 Finally, the Analytics and Workspace per-aggregate modules were not exhaustively line-cited; they follow the same Decider-plus-sum-state-plus-`Either`-error shape, but specific command and event names should be read from source per aggregate when porting them.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/refine-and-lower.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/refine-and-lower.md
@@ -25,7 +25,7 @@ Errors caught at this stage — choosing a construct that does not lift — are 
 
 ## The Aeneas/Charon-safe Rust subset
 
-Aeneas functionalizes a subset of *safe* Rust (`~/projects/functional-programming-workspace/aeneas`, `README.md:121-139`).
+Aeneas functionalizes a subset of *safe* Rust (`aeneas`, `README.md:121-139`).
 The soundness premise is Rust's borrow checker: because `&mut T` guarantees exclusive access, a mutable borrow can be modeled purely as "take a value in, return the (possibly modified) value out."
 Anything that breaks that exclusive-aliasing guarantee falls outside the model.
 That single principle explains every inclusion and exclusion that follows.

--- a/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/vocabulary.md
+++ b/modules/home/ai/plugins/formal-specification-and-refinement/.apm/skills/refinement-driven-development/references/vocabulary.md
@@ -107,8 +107,8 @@ Read the direction column as the arrow within the pipeline composition above.
 
 ## Source anchors
 
-Eurydice as a Rust-to-C transpiler and its shared Charon front-end are grounded in `~/projects/functional-programming-workspace/eurydice` (README and `bin/main.ml`).
-Aeneas as a verification toolchain translating to a pure lambda calculus, its four backends, and the backward-function model are grounded in `~/projects/functional-programming-workspace/aeneas` (README, `src/Config.ml`, `src/Main.ml`, `backends/lean`).
-Charon's LLBC/ULLBC distinction, the Aeneas preset, and the JSON surface are grounded in `~/projects/functional-programming-workspace/charon` (`docs/usage.md`, `src/options.rs`, `charon-ml`).
+Eurydice as a Rust-to-C transpiler and its shared Charon front-end are grounded in `eurydice` (README and `bin/main.ml`).
+Aeneas as a verification toolchain translating to a pure lambda calculus, its four backends, and the backward-function model are grounded in `aeneas` (README, `src/Config.ml`, `src/Main.ml`, `backends/lean`).
+Charon's LLBC/ULLBC distinction, the Aeneas preset, and the JSON surface are grounded in `charon` (`docs/usage.md`, `src/options.rs`, `charon-ml`).
 The disciplined-term contrast and the extraction hazard are developed in `references/lift-charon-aeneas.md` and `references/check-translation-validation.md`; the name anchor in refinement calculus is developed in `references/mathematics.md`.
 For the spec-side authoring conventions this vocabulary serves, see `preferences-domain-modeling`.

--- a/modules/home/ai/plugins/nix-build-operations/.apm/skills/nix-flake-pr-cycle/SKILL.md
+++ b/modules/home/ai/plugins/nix-build-operations/.apm/skills/nix-flake-pr-cycle/SKILL.md
@@ -123,7 +123,7 @@ gh pr comment <N> --body "<markdown description>"
 Title and description in the immutable fields cannot be edited after creation, so the discipline is generic-at-creation, detailed-in-comment.
 The conventional-commits title is the one mutable surface that survives into the merged-commit subject when Mergify uses `fast-forward` merge, so it is worth getting right at creation time even though `gh pr edit --title` remains available until merge.
 
-For multi-chain epic integrations (a development join with two or more active chains), Phase 4 expands into the N+1 stacked-base submission pattern documented in `~/.claude/skills/jj-version-control/diamond-workflow.md` §"Phase 4: serialize (integrate)".
+For multi-chain epic integrations (a development join with two or more active chains), Phase 4 expands into the N+1 stacked-base submission pattern documented in the `jj-version-control` skill's `diamond-workflow.md` §"Phase 4: serialize (integrate)".
 The `jj-linearize-join` sibling tool performs the diamond-workflow → linearized-chain transformation; the `jj-stack-submit` sibling tool performs the Phase A submission (push N+1 bookmarks, create N stacked-base chain PRs + 1 aggregate PR, optionally backlink and mark ready).
 The aggregate PR is the merge gate, and Phases 5–7 of this skill apply to the aggregate PR; the chain PRs render the dependency structure on the forge and auto-close when GitHub observes their head commits reachable from `main`.
 

--- a/modules/home/ai/plugins/nix-build-operations/.apm/skills/process-compose-init/SKILL.md
+++ b/modules/home/ai/plugins/nix-build-operations/.apm/skills/process-compose-init/SKILL.md
@@ -6,10 +6,9 @@ disable-model-invocation: true
 Add process-compose integration for local development with dual Nix/non-Nix support.
 
 Read the CLAUDE.md files in these ecosystem repos for context and patterns:
-- ~/projects/nix-workspace/process-compose (upstream Go tool, YAML format)
-- ~/projects/nix-workspace/process-compose-flake (Nix module layer)
-- ~/projects/nix-workspace/services-flake (pre-built service modules)
-- ~/projects/nix-workspace/process-compose-flake-shell (devShell integration)
+- `F1bonacc1/process-compose` (upstream Go tool, YAML format)
+- `Platonic-Systems/process-compose-flake` (Nix module layer, includes devShell integration)
+- `juspay/services-flake` (pre-built service modules)
 
 First analyze this project to identify needed services (database, cache, queue, dev server, etc.) based on existing dependencies and configuration.
 

--- a/modules/home/ai/plugins/nix-build-operations/.apm/skills/worktree-sparsity-eval/SKILL.md
+++ b/modules/home/ai/plugins/nix-build-operations/.apm/skills/worktree-sparsity-eval/SKILL.md
@@ -6,8 +6,8 @@ description: >-
   `git worktree` in any mode, or a `jj workspace add` in a non-flake jj repository — and
   only to size that invocation.** It does not decide whether to create one. In jj mode the
   diamond workflow's development join remains the default for parallel chains and needs no
-  sparsity evaluation; see `~/.claude/skills/jj-version-control/tiered-ceremony.md` for the
-  triggers and `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop" for the
+  sparsity evaluation; see the `jj-version-control` skill's `tiered-ceremony.md` for the
+  triggers and `jj-version-control` §"Worktree interop" for the
   discipline. Also invoke for periodic re-evaluation when a repo has grown significantly.
 ---
 
@@ -17,9 +17,9 @@ Collect repository metrics and determine whether worktrees should use sparse che
 Three conditions must all hold for sparse checkout to be recommended.
 
 This skill sizes a separate working copy that is already warranted; it does not decide whether to create one.
-That decision belongs to `~/.claude/skills/jj-version-control/tiered-ceremony.md`, whose default in jj mode is the diamond workflow's development join in a single working copy — which needs no sparsity evaluation.
+That decision belongs to the `jj-version-control` skill's `tiered-ceremony.md`, whose default in jj mode is the diamond workflow's development join in a single working copy — which needs no sparsity evaluation.
 In a flake repository the separate working copy must be a `git worktree add` rather than `jj workspace add`, so the sparse-checkout recipes below apply directly; the `jj workspace add` form applies only in non-flake jj repositories.
-Before creating a worktree in a jj-colocated repository, read `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop" for the branch-ownership and return-by-ref discipline.
+Before creating a worktree in a jj-colocated repository, read `jj-version-control` §"Worktree interop" for the branch-ownership and return-by-ref discipline.
 
 ## Thresholds
 

--- a/modules/home/ai/plugins/planning-and-development/.apm/skills/agentic-planning-development-workflow/SKILL.md
+++ b/modules/home/ai/plugins/planning-and-development/.apm/skills/agentic-planning-development-workflow/SKILL.md
@@ -21,8 +21,8 @@ For the collaborator map naming who owns what, see references/collaborators.md.
 ### One-time initialization
 
 Run the workspace safety gate first, before any Linear call.
-Assert both `LINEAR_API_KEY` and `LINEAR_WORKSPACE` are unset, then `linear auth whoami --workspace <slug>` to confirm the reported workspace is the intended personal-versus-work one, and pass an explicit `--workspace <slug>` on every later call including reads; the gate mechanics live in linear-project-management/references/linear-workspace-safety-gate.md.
-As a one-time act, create or extend the openspec/linear.yaml registry with the teams and projects entries for the chosen team and project; then, per change at the Backlog-to-Todo bind, write `linear_story_*` plus `linear_team` and `linear_project` and initialize the D10 sync ledger into that change's proposal.md frontmatter only, and seed the Linear issue description from the change's proposal.md business-facing content, referencing the registry's teams and projects entries rather than writing the binding into the registry; the config schema, the one-question setup, and the write-before-read frontmatter binding live in openspec-linear-sync/references/config-and-frontmatter.md.
+Assert both `LINEAR_API_KEY` and `LINEAR_WORKSPACE` are unset, then `linear auth whoami --workspace <slug>` to confirm the reported workspace is the intended personal-versus-work one, and pass an explicit `--workspace <slug>` on every later call including reads; the gate mechanics live in the `linear-project-management` skill's `references/linear-workspace-safety-gate.md`.
+As a one-time act, create or extend the openspec/linear.yaml registry with the teams and projects entries for the chosen team and project; then, per change at the Backlog-to-Todo bind, write `linear_story_*` plus `linear_team` and `linear_project` and initialize the D10 sync ledger into that change's proposal.md frontmatter only, and seed the Linear issue description from the change's proposal.md business-facing content, referencing the registry's teams and projects entries rather than writing the binding into the registry; the config schema, the one-question setup, and the write-before-read frontmatter binding live in the `openspec-linear-sync` skill's `references/config-and-frontmatter.md`.
 Orient beads for the Manual-mode drill-down via /session-orient, with the comprehensive command reference in the issues-beads skill.
 
 ### Quick flow (HIL)
@@ -37,8 +37,8 @@ Each step is a Skill-tool invocation, with the board transition it fires called 
 5. Invoke the `openspec-continue-change` skill for the retrospective artifact, inside the In Review window.
 6. Invoke the `openspec-archive-change` skill: readiness then sync then archive then mirror UPSERT => T4 In Review to Done; Done binds to archive.
 
-The shared re-queue receives a verify.md checked-FAIL `(fail) FAIL` or a rejection at either In-Review sub-gate and routes In Review back to In Progress above the mode fork, under a bounded-retries default of 3; the re-queue and bounded-retries mechanics live in references/board-and-gates.md and the transition mechanics in openspec-linear-sync/references/lifecycle.md.
-Catch-up reconciliation fires a single transition straight to the local phase when the local phase and the resolved Linear state disagree by more than one step, rather than walking the intermediate crossings; it is owned by openspec-linear-sync/references/lifecycle.md, with the board side in references/board-and-gates.md.
+The shared re-queue receives a verify.md checked-FAIL `(fail) FAIL` or a rejection at either In-Review sub-gate and routes In Review back to In Progress above the mode fork, under a bounded-retries default of 3; the re-queue and bounded-retries mechanics live in references/board-and-gates.md and the transition mechanics in the `openspec-linear-sync` skill's `references/lifecycle.md`.
+Catch-up reconciliation fires a single transition straight to the local phase when the local phase and the resolved Linear state disagree by more than one step, rather than walking the intermediate crossings; it is owned by the `openspec-linear-sync` skill's `references/lifecycle.md`, with the board side in references/board-and-gates.md.
 
 ### Step-by-step note
 
@@ -113,7 +113,7 @@ The isolation policy, the apply-gate confirmation, and orchestrator-routed commi
 
 In a development join every editor edits the same empty `@`=`[wip]`, which is the shared coordination surface that keeps concurrent editors safe, and routes completed content downward into the owning chain.
 Never `jj describe @` into content and never relocate `@` with a positional `jj rebase -r @`; either dissolves the surface the others are concurrently writing.
-Defer the full canon to jj-version-control/SKILL.md invariant (iii-b)/(vi).
+Defer the full canon to `jj-version-control` invariant (iii-b)/(vi).
 
 ## Contents
 

--- a/modules/home/ai/plugins/planning-and-development/.apm/skills/agentic-planning-development-workflow/references/hil-isolation.md
+++ b/modules/home/ai/plugins/planning-and-development/.apm/skills/agentic-planning-development-workflow/references/hil-isolation.md
@@ -33,7 +33,7 @@ A worktree and the diamond nest rather than compete: the tree gives an isolated 
 
 A worktree carries obligations the diamond does not.
 A branch is owned by exactly one working copy; work returns from the worktree by ref rather than by checkout; and the primary's HEAD stays detached throughout.
-Read `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop" before creating one — it is the authority for the ownership rules, the return path, the forbidden operations against the primary, and the recovery commands.
+Read `jj-version-control` §"Worktree interop" before creating one — it is the authority for the ownership rules, the return path, the forbidden operations against the primary, and the recovery commands.
 
 ## The apply gate confirms the choice
 
@@ -48,7 +48,7 @@ The orchestrator routes each commit as a new commit onto the unit's chain inside
 Routing is always downward from the shared empty `[wip]` at `@`, never by mutating `@` itself.
 In development-join mode `@` is the empty `[wip]` commit atop the frozen multi-parent merge, and that `[wip]` is the shared coordination surface every editor writes; content leaves it by routing DOWN into the owning chain with `@` left in place and empty.
 Do not consume the wip with `jj describe @`, and do not relocate `@` below the join with a positional `jj rebase -r @ --insert-before/--insert-after`; either drift removes the surface other actors are concurrently writing.
-For the canonical invariant and the editor-safe routing-down command templates (`jj absorb`, `jj squash --from @ … --keep-emptied`, `jj split`), see the development-join invariant (iii-b) in `jj-version-control/SKILL.md`.
+For the canonical invariant and the editor-safe routing-down command templates (`jj absorb`, `jj squash --from @ … --keep-emptied`, `jj split`), see the development-join invariant (iii-b) in `jj-version-control`.
 
 Integration is jj-native and user-gated.
 The bridge's finishing-a-development-branch step would open a PR; under jj the chain is instead linearized onto main by sequential rebase at completion, and that integration is a user-gated decision.

--- a/modules/home/ai/plugins/planning-and-development/.apm/skills/linear-project-management/references/linear-workspace-safety-gate.md
+++ b/modules/home/ai/plugins/planning-and-development/.apm/skills/linear-project-management/references/linear-workspace-safety-gate.md
@@ -17,14 +17,14 @@ Never run mutating `linear auth` commands (`linear auth login`, `linear auth log
 Credentials are nix-managed and immutable here, rendered from sops into a read-only (0400) inline `credentials.toml` (flat `<workspace> = "<api-key>"` keys plus a top-level `default = "<workspace>"`), so a mutating `linear auth` would fail against the read-only file and is in any case ineffective and dangerous.
 linear-cli also supports an OS-keyring credential mode (macOS Keychain via `/usr/bin/security`; Linux secret-tool/libsecret; Windows CredentialManager), but that is not the mode in use; this operator's credentials live in the inline file.
 The auth surface is read-only here: `linear auth whoami` confirms identity, nothing more.
-The `whoami`, `migrate`, and `--plaintext` verbs and the keyring-versus-plaintext credential modes are documented in `~/.claude/skills/linear-cli/references/auth.md`, which is also the authoritative home for the `credentials.toml` flat-key-plus-`default` format; the separate `.linear.toml` project config is covered in `~/.claude/skills/linear-cli/references/config.md`.
+The `whoami`, `migrate`, and `--plaintext` verbs and the keyring-versus-plaintext credential modes are documented in the `linear-cli` skill's `references/auth.md`, which is also the authoritative home for the `credentials.toml` flat-key-plus-`default` format; the separate `.linear.toml` project config is covered in the `linear-cli` skill's `references/config.md`.
 
 ## Why the gate keys on confirmed credentials, not LINEAR_WORKSPACE
 
 Do not key the gate on `LINEAR_WORKSPACE`.
 It is the wrong lever because it is env-overridable and silently outranked by `--workspace` and the API-key tiers, not because of where it sits relative to the credentials default.
 
-The credential precedence and the conflict-throw below are derived from linear-cli upstream source, not from the bundled skill, which does not document them: the resolution chain and the throw live in `src/utils/graphql.ts` (plus the config resolution in `src/config.ts`) at `~/projects/planning-workspace/linear-cli` (schpet/linear-cli).
+The credential precedence and the conflict-throw below are derived from linear-cli upstream source, not from the bundled skill, which does not document them: the resolution chain and the throw live in `src/utils/graphql.ts` (plus the config resolution in `src/config.ts`) in the upstream schpet/linear-cli repository.
 These were verified against v2.0.0; re-check them against the pinned version on any linear-cli bump, since a reordering of the tiers would silently change which workspace a mutation hits.
 
 The credential precedence has five tiers, highest first:
@@ -46,7 +46,7 @@ The safe gate keys on `linear auth whoami` plus an explicit `--workspace`.
 
 Before running the `linear auth whoami` gate, assert that both `LINEAR_API_KEY` and `LINEAR_WORKSPACE` are unset.
 `LINEAR_API_KEY` is tier 1 and silently outranks the gate: if it is set, the resolved workspace is whatever that key authenticates against regardless of what `whoami` is scoped to, so refuse to proceed while it is present.
-Furthermore, linear-cli throws when both `LINEAR_API_KEY` and a `--workspace` flag are set (verified in upstream `src/utils/graphql.ts` at `~/projects/planning-workspace/linear-cli`, v2.0.0; re-verify on a version bump), so an ambient `LINEAR_API_KEY` would also break the mandatory `--workspace` on every command.
+Furthermore, linear-cli throws when both `LINEAR_API_KEY` and a `--workspace` flag are set (verified in upstream `src/utils/graphql.ts`, v2.0.0; re-verify on a version bump), so an ambient `LINEAR_API_KEY` would also break the mandatory `--workspace` on every command.
 `LINEAR_WORKSPACE` is tier 4 and env-overridable, so it too must be unset to keep the resolution path deterministic and keyed on the confirmed credentials default.
 The shell-env assertion is necessary but not sufficient: linear-cli's own loadEnvFiles reads a `./.env` or git-root `.env` and injects `LINEAR_*` keys into its process (resolving at tiers 1 and 4), invisible to a shell check, so the assertion below also rejects such a `.env`.
 

--- a/modules/home/ai/plugins/planning-and-development/.apm/skills/openspec-linear-sync/references/lifecycle.md
+++ b/modules/home/ai/plugins/planning-and-development/.apm/skills/openspec-linear-sync/references/lifecycle.md
@@ -43,13 +43,13 @@ The same non-blocking degradation also covers workspace mode: when `openspec sta
 
 Every transition resolves and passes the team's Linear state NAME (for example "In Review") via linear-cli, never the workflow-state type.
 In Progress and In Review both carry the workflow-state type "started" in the live workspace, so keying on type would conflate the two; passing the exact state name is what disambiguates them.
-That `--state` accepts a name or a type is a linear-cli fact documented in `~/.claude/skills/linear-cli/references/issue.md`.
+That `--state` accepts a name or a type is a linear-cli fact documented in the `linear-cli` skill's `references/issue.md`.
 
 State-name resolution is team-scoped: the ledger's `last_synced_state` and every transition target are resolved against the change's `linear_team`, because Linear workflow states are defined per team.
 The same state name can name different states on different teams, so resolving in the wrong team's context would compare against the wrong board; the change's `linear_team` (from proposal.md frontmatter) is the resolution context.
 
 The overlay degrades gracefully for a team that lacks an In Review state.
-The transition is attempted and its NotFoundError is caught as a dropped best-effort write recorded in the attempt log, leaving the issue In Progress until Done; the NotFoundError error-class on an unresolvable `--state` is a linear-cli behavior documented in `~/.claude/skills/linear-cli/references/issue.md`, and the literal command appears once in references/linear-cli-mapping.md rather than being restated here.
+The transition is attempted and its NotFoundError is caught as a dropped best-effort write recorded in the attempt log, leaving the issue In Progress until Done; the NotFoundError error-class on an unresolvable `--state` is a linear-cli behavior documented in the `linear-cli` skill's `references/issue.md`, and the literal command appears once in references/linear-cli-mapping.md rather than being restated here.
 No Linear state is fabricated, and the dropped write is observable in the ledger rather than silently absorbed.
 
 ## The local sync ledger (D10)

--- a/modules/home/ai/plugins/planning-and-development/.apm/skills/openspec-linear-sync/references/linear-cli-mapping.md
+++ b/modules/home/ai/plugins/planning-and-development/.apm/skills/openspec-linear-sync/references/linear-cli-mapping.md
@@ -2,12 +2,12 @@
 
 This reference maps every Linear operation the overlay needs onto linear-cli verbs, replacing the disabled Linear MCP entirely.
 Verbs are at linear-cli v2.0.0.
-The bundled linear-cli skill is the authoritative home for every flag spelling and JSON shape below, delegated by subfile: issue verbs in `~/.claude/skills/linear-cli/references/issue.md`, document verbs in `~/.claude/skills/linear-cli/references/document.md`, `auth whoami` and `--workspace` in `~/.claude/skills/linear-cli/references/auth.md`, the `linear api` GraphQL fallback in `~/.claude/skills/linear-cli/references/api.md`, and JSON-shape introspection in `~/.claude/skills/linear-cli/references/schema.md`.
+The bundled linear-cli skill is the authoritative home for every flag spelling and JSON shape below, delegated by subfile: issue verbs in the `linear-cli` skill's `references/issue.md`, document verbs in the `linear-cli` skill's `references/document.md`, `auth whoami` and `--workspace` in the `linear-cli` skill's `references/auth.md`, the `linear api` GraphQL fallback in the `linear-cli` skill's `references/api.md`, and JSON-shape introspection in the `linear-cli` skill's `references/schema.md`.
 This file maps operations to verbs and carries the policy; it is not the source of truth for flag spellings or JSON shapes, which live in those subfiles.
 The Linear MCP is recommended against and never invoked here.
 
 Prefer file-based content flags over inline content to avoid escaping artifacts; this is the one content-handling policy this file owns.
-Which verbs expose `--json`, a content-file flag, or `--no-interactive` is mechanics with an authoritative home: see `~/.claude/skills/linear-cli/references/issue.md` and `~/.claude/skills/linear-cli/references/document.md` for per-verb flag availability, and the `## Best Practices for Markdown Content` section of `~/.claude/skills/linear-cli/SKILL.md` for why file-based flags are preferred.
+Which verbs expose `--json`, a content-file flag, or `--no-interactive` is mechanics with an authoritative home: see the `linear-cli` skill's `references/issue.md` and the `linear-cli` skill's `references/document.md` for per-verb flag availability, and the `## Best Practices for Markdown Content` section of `linear-cli` for why file-based flags are preferred.
 
 Every linear-cli invocation in this overlay, reads as well as mutations, passes an explicit `--workspace <slug>`, resolved from `workspace.slug` in the openspec/linear.yaml registry.
 A command that omits `--workspace` resolves to the credentials default, which is the personal workspace in this deployment, so an unscoped read silently queries the wrong workspace exactly as an unscoped mutation would write to it.
@@ -42,9 +42,9 @@ Every command, read or mutation, passes an explicit `--workspace <slug>` after t
 | Document create | `save_document` (create) | `linear document create` |
 | Document update | `save_document` (update) | `linear document update` |
 
-Which verb maps to which operation is the policy this table owns, and the `--workspace <slug>` rule above applies to every row; the exact flags for each verb live in the bundled skill: issue verbs in `~/.claude/skills/linear-cli/references/issue.md` (including the `linear issue update --description-file <path>` flag, documented there as preferred for markdown content, which the issue-description sync uses), document verbs in `~/.claude/skills/linear-cli/references/document.md`, and the setup reads in `~/.claude/skills/linear-cli/references/team.md`, `~/.claude/skills/linear-cli/references/project.md`, and `~/.claude/skills/linear-cli/references/label.md`.
+Which verb maps to which operation is the policy this table owns, and the `--workspace <slug>` rule above applies to every row; the exact flags for each verb live in the bundled skill: issue verbs in the `linear-cli` skill's `references/issue.md` (including the `linear issue update --description-file <path>` flag, documented there as preferred for markdown content, which the issue-description sync uses), document verbs in the `linear-cli` skill's `references/document.md`, and the setup reads in the `linear-cli` skill's `references/team.md`, the `linear-cli` skill's `references/project.md`, and the `linear-cli` skill's `references/label.md`.
 
-Read backlog candidates with `issue query`, not `issue list`; the alias relationship and the `--state`/`--json` reasoning that forces this choice live in `~/.claude/skills/linear-cli/references/issue.md`.
+Read backlog candidates with `issue query`, not `issue list`; the alias relationship and the `--state`/`--json` reasoning that forces this choice live in the `linear-cli` skill's `references/issue.md`.
 
 The state transition always passes the team's Linear state NAME via `--state`, not the workflow-state type, because the name disambiguates In Progress from In Review, which share the "started" type.
 
@@ -65,7 +65,7 @@ For each capability the change produces:
 1. Look up the stored document id first: read `projects."<project-slug>".archive_documents."<capability>".id` from openspec/linear.yaml, where `<project-slug>` is the change's `linear_project`.
 2. If a stored id exists, update in place: `linear document update <stored-id> --title "OpenSpec: <capability>" --content-file <spec-file> --workspace <slug>`.
 3. Only if no stored id exists, fall back to a title scan: `linear document list --project <p> --json --workspace <slug>` and match the deterministic title `OpenSpec: <capability>` over the `.nodes[]` array of the returned connection object.
-   The `--json` output is a connection with `nodes` and `pageInfo`, not a bare array, so the match must walk `.nodes[]`; introspect the exact shape via `linear schema -o <file>` and confirm against `~/.claude/skills/linear-cli/references/api.md` and `~/.claude/skills/linear-cli/references/schema.md`.
+   The `--json` output is a connection with `nodes` and `pageInfo`, not a bare array, so the match must walk `.nodes[]`; introspect the exact shape via `linear schema -o <file>` and confirm against the `linear-cli` skill's `references/api.md` and the `linear-cli` skill's `references/schema.md`.
 4. If the title scan finds a match, update that id as in step 2.
 5. If no stored id and no title match, create: `linear document create --project <p> --title "OpenSpec: <capability>" --content-file <spec-file> --workspace <slug>`, which creates it already parented to the project, and store the returned id back into openspec/linear.yaml under `projects."<project-slug>".archive_documents."<capability>".id` so the next archive takes the stored-id path.
 
@@ -77,7 +77,7 @@ The body mirrors only the canonical folded main-spec content at `<planning-root>
 Escalate to GraphQL only for fields the document subcommand cannot set, because most create and update paths lack `--json`.
 The two sanctioned uses are reparenting an existing document (`document update` has no `--project`, so moving a document to a different project requires GraphQL) and reading back the structured id of a freshly created entity when stdout parsing of the create output is insufficient.
 Do not route routine create or update paths through GraphQL; the document and issue subcommands cover them.
-The CLI surface for the escalation — `linear api` for raw GraphQL requests and `linear schema -o <file>` for type discovery — is documented in `~/.claude/skills/linear-cli/references/api.md` and `~/.claude/skills/linear-cli/references/schema.md`; the no-`--project` premise for `document update` is in `~/.claude/skills/linear-cli/references/document.md`.
+The CLI surface for the escalation — `linear api` for raw GraphQL requests and `linear schema -o <file>` for type discovery — is documented in the `linear-cli` skill's `references/api.md` and the `linear-cli` skill's `references/schema.md`; the no-`--project` premise for `document update` is in the `linear-cli` skill's `references/document.md`.
 
 ## End-to-end worked example: one HIL issue Backlog to Done
 
@@ -87,7 +87,7 @@ Every step is guarded by the strictly-behind rule (see references/lifecycle.md):
 The ledger updates that accompany each transition (`last_synced_state`, `last_synced_at`, `review_round`, `attempt_log`) are written to this change's proposal.md frontmatter, not to openspec/linear.yaml.
 
 This trace is a policy-level walkthrough: the ordering, the guards, the archive sequence, and the per-crossing comment discipline are the load-bearing parts.
-The concrete flags and the two `.nodes[]` jq filters below are illustrative at linear-cli v2.0.0; they are authoritative in `~/.claude/skills/linear-cli/references/issue.md`, `~/.claude/skills/linear-cli/references/document.md`, `~/.claude/skills/linear-cli/references/api.md`, and `~/.claude/skills/linear-cli/references/schema.md`, and in `~/.claude/skills/linear-cli/references/auth.md` for the `whoami` gate.
+The concrete flags and the two `.nodes[]` jq filters below are illustrative at linear-cli v2.0.0; they are authoritative in the `linear-cli` skill's `references/issue.md`, the `linear-cli` skill's `references/document.md`, the `linear-cli` skill's `references/api.md`, and the `linear-cli` skill's `references/schema.md`, and in the `linear-cli` skill's `references/auth.md` for the `whoami` gate.
 
 First, gate on the workspace before any mutation:
 
@@ -102,7 +102,7 @@ Backlog to Todo, fired when proposal.md is created (this step also writes the bi
 linear issue update <id> --state "Todo" --workspace <slug>
 # Seed the Linear issue description (the business "what") distilled from proposal.md Why / What Changes / Capabilities
 # into a stakeholder-facing TL;DR / deliverables / scope / acceptance; technical design stays in design.md.
-# Best-effort and non-blocking; --description-file is preferred for markdown (see issue.md). Record a dropped
+# Best-effort and non-blocking; --description-file is preferred for markdown (see the `linear-cli` skill's `references/issue.md`). Record a dropped
 # attempt in the proposal.md attempt_log if Linear is unavailable.
 <distill proposal.md business sections into /tmp/body.md>
 linear issue update <id> --description-file /tmp/body.md --workspace <slug>
@@ -215,8 +215,8 @@ Here the local milestone files show the change at In Review (proposal.md, a firs
 # 1. Resolve the local phase from milestone-file existence (the authoritative current-phase signal).
 #    proposal.md + first tasks.md `- [x]` + verify.md, not yet archived  =>  local phase is "In Review".
 # 2. Read the current Linear state. The `issue view --json` verb is in
-#    ~/.claude/skills/linear-cli/references/issue.md; the `.state.name` payload shape is
-#    authoritative in ~/.claude/skills/linear-cli/references/api.md and references/schema.md
+#    the `linear-cli` skill's `references/issue.md`; the `.state.name` payload shape is
+#    authoritative in the `linear-cli` skill's `references/api.md` and the `linear-cli` skill's `references/schema.md`
 #    (introspect via `linear schema -o <file>` if the shape is in doubt at the pinned version).
 CUR=$(linear issue view <id> --json --workspace <slug> | jq -r '.state.name')   # => "Todo"
 # 3. Compute strictly-behind: "Todo" is two states behind "In Review".

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-comment-cleanup/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-comment-cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: Uncomment-driven workflow for auditing and removing noise comments 
 
 ## Scope
 
-This skill is the operational enforcement arm of the code-comments policy defined in `~/.claude/skills/preferences-style-and-conventions/SKILL.md` §"Code comments"; it does not restate that policy but drives it over real trees.
+This skill is the operational enforcement arm of the code-comments policy defined in `preferences-style-and-conventions` §"Code comments"; it does not restate that policy but drives it over real trees.
 It is a workflow sibling to `preferences-git-history-cleanup`, and like it, a comment-only cleanup is a legitimate standalone change.
 
 ## The tool: uncomment
@@ -49,10 +49,10 @@ Group the applied cuts by subsystem into a small number of atomic commits; never
 
 Exclude vendored, generated, and upstream-mirrored trees by path, since uncomment has no ignore-glob and its language list is not an allowlist.
 Watch for cross-branch file collisions with any active VCS chains, and keep dry-run-first discipline before every apply.
-A hardened starting config ships beside this skill at `~/.claude/skills/preferences-comment-cleanup/uncommentrc.toml`; it preserves the license/SPDX headers, linter and formatter pragmas, code-generation markers, and `SAFETY:` comments that uncomment's built-ins miss past the first few lines.
+A hardened starting config ships beside this skill at `uncommentrc.toml`; it preserves the license/SPDX headers, linter and formatter pragmas, code-generation markers, and `SAFETY:` comments that uncomment's built-ins miss past the first few lines.
 Copy it to the target repository root as `.uncommentrc.toml` and treat it as a targeted-assist config for a specific run, not a standing repo-wide policy.
 
 ## Cross-links
 
-The owning policy this skill enforces is `~/.claude/skills/preferences-style-and-conventions/SKILL.md` §"Code comments".
+The owning policy this skill enforces is `preferences-style-and-conventions` §"Code comments".
 For the sibling cleanup workflow see `preferences-git-history-cleanup`; for severity grading and adversarial verification of proposed cuts see `preferences-validation-assurance`; for the classification fan-out see `dispatching-parallel-agents` and `preferences-workflow-orchestration-algebra`; and the tool itself is this repository's `uncomment-bin` package at `pkgs/by-name/uncomment-bin`.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-documentation/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-documentation/SKILL.md
@@ -364,7 +364,7 @@ And a search that does not follow symlinks reports nothing at all for a symlinke
   future point.
 - Commit documentation updates atomically in series with the related code changes,
   following the same proactive atomic commit workflow specified in
-  `~/.claude/skills/preferences-git-version-control/SKILL.md`.
+  `preferences-git-version-control`.
 - Be judicious in the use of documentation, ensuring that it is clear, concise,
   and accurate for humans to read and understand.
 - Proactively remove, refactor, and consolidate documentation as relevant to

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-history-cleanup/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-history-cleanup/SKILL.md
@@ -8,9 +8,9 @@ description: Git history cleanup patterns for rewriting, squashing, and reorgani
 ## scope
 
 This skill covers history refinement in git-native and GitButler modes (`git rebase -i`, `git revise`, `but move`/`but squash`/`but reword`, `GIT_SEQUENCE_EDITOR` patterns).
-For jj-mode history refinement (`jj rebase`, `jj squash`, `jj split`, `jj abandon`, `jj describe -r`), see `~/.claude/skills/jj-history-cleanup/SKILL.md`.
-In a jj-colocated repository, do not apply any `git rebase -i` or `git revise` recipe from this file to the working copy; jj history refinement and the `@`-stays-empty-`[wip]` development-join invariant are owned by `~/.claude/skills/jj-history-cleanup/SKILL.md` and `~/.claude/skills/jj-version-control/diamond-workflow.md`.
-Mode detection is described in `~/.claude/skills/preferences-git-version-control/SKILL.md` §"Commit behavior override".
+For jj-mode history refinement (`jj rebase`, `jj squash`, `jj split`, `jj abandon`, `jj describe -r`), see `jj-history-cleanup`.
+In a jj-colocated repository, do not apply any `git rebase -i` or `git revise` recipe from this file to the working copy; jj history refinement and the `@`-stays-empty-`[wip]` development-join invariant are owned by `jj-history-cleanup` and the `jj-version-control` skill's `diamond-workflow.md`.
+Mode detection is described in `preferences-git-version-control` §"Commit behavior override".
 
 ## purpose
 

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/01-git-native-mode.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/01-git-native-mode.md
@@ -1,7 +1,7 @@
 # Git-native mode
 
 This file applies only in **git-native mode** (no `.jj/` directory present in repo root).
-For jj mode — the preferred mode in this workspace — see `03-jj-mode.md` and `~/.claude/skills/jj-version-control/tiered-ceremony.md`.
+For jj mode — the preferred mode in this workspace — see `03-jj-mode.md` and the `jj-version-control` skill's `tiered-ceremony.md`.
 
 Working branch isolation recipes for git-native mode.
 Bead implementation work uses worktrees rooted in `.worktrees/` at the repository root.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/02-gitbutler-mode.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/02-gitbutler-mode.md
@@ -30,7 +30,7 @@ but branch new {issue-ID}-descriptor -a <anchor-commit>
 
 The anchor commit and everything below it become the new branch.
 Everything above the anchor stays with the original branch.
-See the "Split a branch at a commit boundary" recipe in `~/.claude/skills/gitbutler-but-cli/SKILL.md` for details.
+See the "Split a branch at a commit boundary" recipe in `gitbutler-but-cli` for details.
 
 When issue work is complete, commits are already part of the stack's linear history.
 No rebase or merge step is needed — the stack tip integrates all segments at once when merged to main.

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/03-jj-mode.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/03-jj-mode.md
@@ -3,7 +3,7 @@
 Working branch isolation recipes for jj mode.
 jj provides a development join (multi-parent working copy) that achieves the same simultaneous multi-branch editing as GitButler's applied-branches model.
 All bookmarks coexist in a single working tree, so parallel chains need no worktree, and the development join is the default technique for them.
-A linked git worktree remains available and is warranted when a separate filesystem tree is itself the requirement — an external agent framework driving its own process, a long-running build, side-by-side comparison — under the ownership and return-by-ref discipline in `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop".
+A linked git worktree remains available and is warranted when a separate filesystem tree is itself the requirement — an external agent framework driving its own process, a long-running build, side-by-side comparison — under the ownership and return-by-ref discipline in `jj-version-control` §"Worktree interop".
 
 ## Creating a multi-parent working copy
 
@@ -55,7 +55,7 @@ The second half takes `-s`, not `-r`, so that any commits stacked above `[wip]` 
 Do NOT make the empty `[wip]` the subject of a positional rebase — `jj rebase -r @ --insert-before <target>` / `--insert-after <target>` (and the `jj rebase --revisions @ --insert-before/--insert-after <target>` aliases) relocate `@` below or into the join, dropping the shared editing surface concurrent actors are writing and dragging the pushed `wip` deploy bookmark (the catastrophic concurrency failure).
 In the simpler single-commit join — where `@` IS the join with no separate `[wip]` — the sanctioned destination form `jj rebase -r @ -d <chain-a> -d <chain-b> …`, naming one `-d` per chain the join is to carry afterward, re-parents in place and keeps `@` an empty direct child of the join; the two-commit `[merge]`+`[wip]` pair above is canonical for diamond work.
 This destination form is the ONLY `jj rebase` that may name `@`; it is distinct from the prohibited positional `--insert-before/--insert-after` forms.
-See `~/.claude/skills/jj-version-control/SKILL.md` invariant (iii) and §"Adding and removing chains" for the full canon.
+See `jj-version-control` invariant (iii) and §"Adding and removing chains" for the full canon.
 
 ## Auto-rebase behavior
 
@@ -109,7 +109,7 @@ jj squash --into {epic-b}-descriptor -u -- <path>
 In jj mode, subagents do not create bookmarks, and dispatch omits the `isolation` parameter by default.
 All agents — including parallel agents — edit files directly in the shared `@` working copy.
 The orchestrator routes changes to the correct chain via `jj absorb` or `jj squash --into <target> -u -- <path>` after each subagent completes.
-Requesting `isolation: "worktree"` raises an ask rather than a denial; answer it affirmatively only when the subagent genuinely needs its own filesystem tree, and follow the discipline in `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop" when it does.
+Requesting `isolation: "worktree"` raises an ask rather than a denial; answer it affirmatively only when the subagent genuinely needs its own filesystem tree, and follow the discipline in `jj-version-control` §"Worktree interop" when it does.
 
 When working in the development join, use a join + wip structure (two-commit pattern).
 The development join integrates all parent bookmarks and has a description to prevent auto-abandonment.
@@ -122,7 +122,7 @@ The shared `[wip]` is the stable coordination point that makes N concurrent edit
 Never `jj describe @` into a content commit (that consumes the empty wip), and never make `@` the subject of `jj rebase` as a routing move — `jj rebase -r @` / `jj rebase --revisions @` with the positional `--insert-before/--insert-after` forms drifts `@` off the join, removes the shared editing surface concurrent agents write to, and drags the pushed `wip` deploy bookmark.
 Routing verbs leave `@` in place and empty: `jj absorb` (auto-distribute by blame; scoped `jj absorb <path>` under concurrency), `jj squash --from @ --into <chain-tip> --keep-emptied [-- <paths>]` (amend-route), `jj squash --from @ --insert-after <chain-tip> -m "msg" --keep-emptied -- <paths>` (append-route), and `jj split` keeping the wip remainder.
 To place a change BELOW the join, route it down from the live `@` with `jj squash --from @ --insert-before <target> -m "msg" --keep-emptied -- <paths>`; any by-relocation `<target>`/`<commit>` is a SEPARATE already-sealed non-wip commit, never `@` itself.
-The canonical invariants and the `--keep-emptied` routing primitives are normative in `~/.claude/skills/jj-version-control/SKILL.md` invariant (iii).
+The canonical invariants and the `--keep-emptied` routing primitives are normative in `jj-version-control` invariant (iii).
 
 Coordination protocol: atomic one-file changes, periodic `jj log` review, prompt routing to keep `@` clean.
 Subagent dispatch prompts specify which files to edit and the target chain context but do not include jj routing commands.
@@ -130,7 +130,7 @@ The subagent edits files in the shared `@` and does NOT run `jj`, `git`, or `bd`
 
 Example prompt fragment: "Edit only modules/.../<file>.nix; do not run jj/git/bd. Your changes will be routed to the nix-pxj-4-deploy-validate bookmark by the orchestrator after you return."
 
-See the parallel agent coordination protocol in `~/.claude/skills/jj-version-control/SKILL.md` for the full model.
+See the parallel agent coordination protocol in `jj-version-control` for the full model.
 
 ## Completing issues and epics
 
@@ -170,10 +170,10 @@ jj development joins operate in a single working tree, so the repository root's 
 
 When epic-scoped work spans multiple parallel streams — a Linear initiative or project, an OpenSpec change group, or (in Manual mode) a beads epic — it uses the diamond workflow's four phases (diverge, develop, converge, serialize) to map the dependency graph onto jj bookmark chain topology.
 The mechanical implementation leverages jj's multi-parent working copy; the pattern generalizes conceptually to GitButler's applied-branches model and git-native worktrees.
-For the canonical operational recipe, theoretical foundations, and dependency-graph-to-jj mapping (including the beads-to-jj mapping used in Manual mode), see `~/.claude/skills/jj-version-control/diamond-workflow.md`.
+For the canonical operational recipe, theoretical foundations, and dependency-graph-to-jj mapping (including the beads-to-jj mapping used in Manual mode), see the `jj-version-control` skill's `diamond-workflow.md`.
 
 The sibling tools `jj-linearize-join` and `jj-stack-submit` are the canonical tooling for the diamond → linearized-chain → N+1 PR submission path: the former linearizes a development join into a stacked-base chain, the latter handles forge submission (push + N+1 PR creation via `gh`/`tea`).
-See `~/.claude/skills/jj-version-control/diamond-workflow.md` Phase 4 for the operational recipe.
+See the `jj-version-control` skill's `diamond-workflow.md` Phase 4 for the operational recipe.
 
 ## See also
 

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/05-commit-workflow.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/05-commit-workflow.md
@@ -3,7 +3,7 @@
 Operational recipes for the atomic commit workflow across all three VCS modes (git-native, GitButler, jj).
 This file covers file state verification, the per-mode atomic commit cycle, handling pre-existing mixed changes, commit formatting, and session commit summary.
 For the top-level routing index, commit behavior override, VCS terminology glossary, branch workflow, and merge strategy selection, see [`SKILL.md`](SKILL.md).
-For the deep operational detail of the jj development-join edit-route cycle, see `~/.claude/skills/jj-version-control/SKILL.md` §"Development join".
+For the deep operational detail of the jj development-join edit-route cycle, see `jj-version-control` §"Development join".
 
 ## File state verification
 
@@ -44,14 +44,14 @@ In this mode `@` is always the empty `[wip]` commit sitting directly on the mult
 Never `jj describe @` into content and never relocate `@` via the positional rebase forms `jj rebase -r @ --insert-before/--insert-after <target>` (nor `jj rebase --revisions @ --insert-before/--insert-after <target>`).
 Doing so drifts `@` off `[wip]`, destroys the shared editing surface concurrent actors are writing, and — in this repo — drags the pushed `wip` deploy bookmark below the join and breaks the join's single-`[wip]`-child invariant; recover any drift with `jj op restore`.
 The one sanctioned `jj rebase` that may name `@` is the destination add/remove-chain form `jj rebase -r @ -d <chain-a> -d <chain-b> …`, naming one `-d` per chain the join is to carry afterward, which re-anchors the empty `@` onto a rebuilt join without drifting it.
-See `~/.claude/skills/jj-version-control/SKILL.md` §"Development join" for the canonical invariant, splice/by-relocation recipes, and the full concurrency rationale — this section is a routing summary, not the source of truth.
+See `jj-version-control` §"Development join" for the canonical invariant, splice/by-relocation recipes, and the full concurrency rationale — this section is a routing summary, not the source of truth.
 Two routing patterns exist:
 
 - *Amend existing chain commit:* `jj squash --from @ --into <target-parent> --keep-emptied -- <path>` routes the file into the existing commit while leaving `@` the empty `[wip]` on the join.
   Always pass `--from @` (a bare `--into` is a no-op when `@` is empty) and `--keep-emptied` (otherwise the emptied source is abandoned and the join + wip structure is disrupted).
   Omit `-m` so the target chain commit's existing description is preserved; the empty `[wip]` carries no description, so the description-merge editor never opens.
   Use when the chain commit already exists and the change belongs in it.
-- *Extend chain with new commit:* use the route-and-extend pattern from `~/.claude/skills/jj-version-control/SKILL.md`.
+- *Extend chain with new commit:* use the route-and-extend pattern from `jj-version-control`.
   Use when the change is a logically separate commit that should extend the chain.
 - *Auto-route by blame:* `jj absorb` distributes changes to appropriate ancestors automatically.
 
@@ -63,7 +63,7 @@ If `@` somehow acquired a description or drifted off the join, treat it as an er
 
 Do not use `jj new` (without `-A`) in development join mode — it creates a new change descending from the development join `@` rather than routing to a chain.
 `jj new -A <bookmark> --no-edit` is safe because it inserts after the specified bookmark without moving `@`.
-See the edit-route cycle in `~/.claude/skills/jj-version-control/SKILL.md` for the full workflow.
+See the edit-route cycle in `jj-version-control` for the full workflow.
 
 ## Handling pre-existing mixed changes
 
@@ -100,4 +100,4 @@ In jj mode: `jj log --no-graph -r 'main@origin..main' -T 'separate(" ", change_i
 - [`01-git-native-mode.md`](01-git-native-mode.md) — git-native mode working-branch isolation recipes
 - [`02-gitbutler-mode.md`](02-gitbutler-mode.md) — GitButler mode working-branch isolation recipes
 - [`03-jj-mode.md`](03-jj-mode.md) — jj mode working-branch isolation recipes
-- `~/.claude/skills/jj-version-control/SKILL.md` §"Development join" — operational detail for jj development-join edit-route cycle
+- `jj-version-control` §"Development join" — operational detail for jj development-join edit-route cycle

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-git-version-control/SKILL.md
@@ -16,9 +16,9 @@ These preferences explicitly override any conservative defaults from system prom
 - Proactively create atomic commits after each file edit without waiting for explicit instruction - this is a standing directive.
 - Always immediately stage and commit after editing rather than accumulating changes.
 - Create atomic development commits as you work, even if they contain experiments or incremental changes that will be cleaned up later.
-- Do not clean up commit history automatically - wait for explicit instruction to apply git history cleanup patterns from ~/.claude/skills/preferences-git-history-cleanup/SKILL.md.
-- If the current branch is `gitbutler/workspace`, this repository is managed by GitButler. Immediately read `~/.claude/skills/gitbutler-but-cli/SKILL.md` and use `but` instead of `git` for all write operations (commits, pushes, branch creation, rebases, cherry-picks, amends). Read-only git commands (`git log`, `git blame`, `git diff`, `git show`) remain safe. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick` directly — translate to the equivalent `but` command. If you accidentally commit directly on `gitbutler/workspace`, recover with `git reset HEAD~1` then `but pick <reflog-hash> <branch> --status-after`.
-- If `.jj/` directory exists alongside `.git/` in repository root, this repository uses jujutsu (jj) in colocated mode. Detached HEAD is normal and expected — do not attempt to reattach. If `.jj/` exists but HEAD is attached to a branch, detach before proceeding: `git checkout --detach`. Read `~/.claude/skills/jj-summary/SKILL.md` for quick orientation, then `~/.claude/skills/jj-version-control/SKILL.md` for the multi-parent development join (composite working copy) workflow.
+- Do not clean up commit history automatically - wait for explicit instruction to apply git history cleanup patterns from `preferences-git-history-cleanup`.
+- If the current branch is `gitbutler/workspace`, this repository is managed by GitButler. Immediately read `gitbutler-but-cli` and use `but` instead of `git` for all write operations (commits, pushes, branch creation, rebases, cherry-picks, amends). Read-only git commands (`git log`, `git blame`, `git diff`, `git show`) remain safe. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick` directly — translate to the equivalent `but` command. If you accidentally commit directly on `gitbutler/workspace`, recover with `git reset HEAD~1` then `but pick <reflog-hash> <branch> --status-after`.
+- If `.jj/` directory exists alongside `.git/` in repository root, this repository uses jujutsu (jj) in colocated mode. Detached HEAD is normal and expected — do not attempt to reattach. If `.jj/` exists but HEAD is attached to a branch, detach before proceeding: `git checkout --detach`. Read `jj-summary` for quick orientation, then `jj-version-control` for the multi-parent development join (composite working copy) workflow.
 - If the user requests switching to jj in a git-only repo (no `.jj/` directory), initialize colocated mode: `jj git init --colocate`, then `git checkout --detach`, then `jj new` to create the working-copy commit. Proceed with jj workflow as above.
 - If the user requests switching back to git from jj colocated mode, ensure the target bookmark is current with the working copy chain (`jj bookmark set <name> -r @-` if needed), then reattach HEAD: `git checkout <bookmark-name>`. Resume git-native commands. The `.jj/` directory can remain — colocated mode is safe to leave dormant.
 
@@ -69,7 +69,7 @@ Before attempting to edit any files, create a working branch to which you will c
 
 In jj mode, this hook is unnecessary.
 Anonymous chains are first-class and never garbage-collected.
-Create bookmarks when initiating a second chain or when working on a Linear story or OpenSpec change — see the bookmark creation threshold in `~/.claude/skills/jj-version-control/SKILL.md`.
+Create bookmarks when initiating a second chain or when working on a Linear story or OpenSpec change — see the bookmark creation threshold in `jj-version-control`.
 
 Whenever you are working on a Linear story or OpenSpec change, check the current branch name first.
 If it does not correspond to the story, change, or issue you're working on, pause to ask the user whether to create or switch to a matching branch before proceeding.
@@ -129,18 +129,18 @@ In GitButler mode, stacked branches are already linear by construction.
 Fast-forward merge of the stack tip integrates all stacked segments at once.
 Exit GitButler before merging to main: `but teardown`, then `git merge --ff-only`, then `but setup`.
 Do not use `but merge` for this — it always creates merge commits and has no fast-forward mode.
-See the "Stacked PRs with single fast-forward merge" and "Merging multiple independent stacks" recipes in `~/.claude/skills/gitbutler-but-cli/SKILL.md` for the full workflow.
+See the "Stacked PRs with single fast-forward merge" and "Merging multiple independent stacks" recipes in `gitbutler-but-cli` for the full workflow.
 
 In jj mode, integration uses sequential rebase linearization: rebase each chain onto main in dependency order, producing a purely linear history with no merge commits.
 Fast-forward main to the linearized tip via `jj bookmark set main -r <chain-tip>`.
-See the integration strategies section in `~/.claude/skills/jj-version-control/SKILL.md` for the full completion workflow.
+See the integration strategies section in `jj-version-control` for the full completion workflow.
 
 ### Stack management
 
 Branch stacks mirror the dependency structure of the Linear stories or OpenSpec changes they implement: when work items form a dependency chain, the corresponding branches should form a stack with matching parent-child relationships.
 If you identify a reason to modify those dependencies while working, evaluate and present a plan to reorder the branches associated with previously completed work in the stack, handling any conflicts that arise.
 In git-native mode, manage stacks with the graphite CLI (invoke as `graphite`, not `gt`): `graphite log` views stack relationships, `graphite track` registers an existing branch with its parent, `graphite create -m "message"` creates a stacked branch.
-In GitButler mode, `but branch new -a`, `but branch move`, and `but move` replace graphite entirely; see `~/.claude/skills/gitbutler-but-cli/SKILL.md` for the full command reference.
+In GitButler mode, `but branch new -a`, `but branch move`, and `but move` replace graphite entirely; see `gitbutler-but-cli` for the full command reference.
 
 ## Merge strategy selection
 

--- a/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
+++ b/modules/home/ai/plugins/preferences-code-and-collaboration-conventions/.apm/skills/preferences-style-and-conventions/SKILL.md
@@ -12,7 +12,7 @@ description: Style and formatting conventions for code, documentation, naming, a
 - Keep section header nesting shallow. Avoid deeply nested subsections (###, ####) when flatter structure with clear prose transitions would be more readable. Most documents should rarely need headers beyond three levels.
 - Use bold text (`**`) sparingly, primarily for critical emphasis within sentences. Avoid bolding section labels, definitions, or key terms when plain text suffices. Prefer italic (`*`) for subtle emphasis.
 - Avoid using emojis in code, comments, documentation, markdown files, etc unless explicitly requested to do so.
-- For documentation-specific markdown conventions (frontmatter titles, header levels), see "Markdown formatting conventions" in `~/.claude/skills/preferences-documentation/SKILL.md`.
+- For documentation-specific markdown conventions (frontmatter titles, header levels), see "Markdown formatting conventions" in `preferences-documentation`.
 
 ## Naming and case conventions
 
@@ -68,7 +68,7 @@ Ousterhout's calibration applies: comments exist to capture design intent and ra
 
 ## File organization
 
-- Never pollute the repository root or other working directory with markdown files. Always place these types of working notes in suitable paths like: `./docs/notes/[category]/[lower-kebab-case-filename.md]` where you may need to create the directory if it doesn't exist before creating the file. See "Working notes" in `~/.claude/skills/preferences-documentation/SKILL.md` for lifecycle management and integration with formal documentation.
+- Never pollute the repository root or other working directory with markdown files. Always place these types of working notes in suitable paths like: `./docs/notes/[category]/[lower-kebab-case-filename.md]` where you may need to create the directory if it doesn't exist before writing the file. See "Working notes" in `preferences-documentation` for lifecycle management and integration with formal documentation.
 
 ### File length and modularization
 
@@ -97,7 +97,7 @@ Log files captured with `tee` during long-running commands live in a repository'
 
 Before writing there, verify that `logs/` is actually ignored by that repository.
 If it is not ignored, write to `$XDG_STATE_HOME/agent-logs/<repo>/` instead and report the missing ignore entry rather than adding it silently.
-Never leave an untracked, unignored file inside a jj working copy; see `~/.claude/skills/jj-version-control/hazards.md` for why a tracked log file is harmful once jj has begun snapshotting it.
+Never leave an untracked, unignored file inside a jj working copy; see the `jj-version-control` skill's `hazards.md` for why a tracked log file is harmful once jj has begun snapshotting it.
 Never delete logs within a session.
 Pruning anything older than fourteen days is an explicit maintenance action only, never a side effect of other work.
 When writing code, follow the XDG Base Directory specification for config, cache, and data paths.

--- a/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-data-modeling/SKILL.md
+++ b/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-data-modeling/SKILL.md
@@ -187,8 +187,8 @@ DuckDB provides first-class bindings that all produce Arrow record batches throu
 The bindings vary in maturity and ecosystem integration but share the same zero-copy Arrow output path.
 
 - Python: `duckdb` package, the most mature binding with tight pandas and polars integration
-- Julia: `DuckDB.jl` (source at `~/projects/duckdb/tools/juliapkg`), enabling Julia's SciML ecosystem (DiffEq.jl, Lux.jl, KernelAbstractions.jl) to consume lakehouse data directly as Arrow record batches
-- Rust: `duckdb-rs` (`~/projects/omicslake-workspace/duckdb-rs`) for embedded analytics, and `async-duckdb` (`~/projects/rust-workspace/async-duckdb`) for async web application serving via axum
+- Julia: `DuckDB.jl` (`duckdb/DuckDB.jl`), enabling Julia's SciML ecosystem (DiffEq.jl, Lux.jl, KernelAbstractions.jl) to consume lakehouse data directly as Arrow record batches
+- Rust: `duckdb-rs` (`duckdb/duckdb-rs`) for embedded analytics, and `async-duckdb` (`jessekrubin/async-duckdb`) for async web application serving via axum
 
 All three language ecosystems benefit equally from the DuckDB-to-Arrow pipeline.
 A single DuckLake catalog can serve Python notebooks running probabilistic inference, Julia processes solving differential equations, and Rust services delivering query results over HTTP — all consuming the same Arrow record batches without format translation.
@@ -256,10 +256,10 @@ Combined with DuckLake's catalog metadata, the query planner can prune partition
 Parquet is the current standard on-disk columnar format and the default for DuckLake data storage.
 Two emerging formats extend the columnar ecosystem in complementary directions.
 
-Vortex (`~/projects/omicslake-workspace/vortex`) is an emerging successor to Parquet with improved compression and query performance.
+Vortex (`vortex-data/vortex`) is an emerging successor to Parquet with improved compression and query performance.
 DuckDB already supports native Vortex read and write, though DuckLake's catalog implementation does not yet support Vortex as a storage backend.
 
-Lance (used by `~/projects/omicslake-workspace/slaf`) is an Arrow-native format optimized for ML and vector workloads.
+Lance (used by `slaf-project/slaf`) is an Arrow-native format optimized for ML and vector workloads.
 DuckDB supports Lance via extension, and Lance files are lakehouse-compatible.
 
 The practical stance is Parquet today, with Vortex and Lance as they mature.

--- a/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-data-modeling/SKILL.md
+++ b/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-data-modeling/SKILL.md
@@ -94,8 +94,8 @@ Validate data shape and constraints at system boundaries.
 
 For comprehensive guidance on modeling domain types and error handling, see:
 
-- `~/.claude/skills/preferences-algebraic-data-types/SKILL.md` — sum types (discriminated unions), product types, newtype pattern, making illegal states unrepresentable
-- `~/.claude/skills/preferences-railway-oriented-programming/SKILL.md` — Result types, bind/apply composition, effect signatures, two-track model
+- `preferences-algebraic-data-types` — sum types (discriminated unions), product types, newtype pattern, making illegal states unrepresentable
+- `preferences-railway-oriented-programming` — Result types, bind/apply composition, effect signatures, two-track model
 
 Key principles from ADT design:
 - Use sum types (ENUMs, discriminated unions) to model "OR" relationships
@@ -364,4 +364,4 @@ When modeling data, prioritize:
 Remember that data pipelines should make side effects explicit in their signatures and isolate them at boundaries to preserve compositionality, discharging those effects through capability interfaces and handlers rather than committing to any single carrier such as a monad transformer stack.
 See preferences-theoretical-foundations (and its references/effects-handlers.md) for why a capability interface, not a transformer tower, is the primitive.
 
-For concrete implementation patterns see ~/.claude/skills/preferences-railway-oriented-programming/SKILL.md (Result types, bind/apply, effect signatures) and ~/.claude/skills/preferences-algebraic-data-types/SKILL.md (domain modeling with sum/product types).
+For concrete implementation patterns see `preferences-railway-oriented-programming` (Result types, bind/apply, effect signatures) and `preferences-algebraic-data-types` (domain modeling with sum/product types).

--- a/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-workflow-orchestration-algebra/01-dagster-categorical-mapping.md
+++ b/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-workflow-orchestration-algebra/01-dagster-categorical-mapping.md
@@ -2,11 +2,11 @@
 
 Each Dagster primitive maps onto either the free term or the interpreter of the Build Systems à la Carte construction, and naming which side a primitive lives on — and how tightly it fits — is what turns the analogy into a proof obligation.
 
-The framing spine is *Build Systems à la Carte* (Mokhov, Mitchell, Peyton Jones, ICFP 2018, local copy at `~/projects/planning-workspace/engineering-references/mokhov-2018-build-systems-a-la-carte/`): a build is a fixpoint of `value(k) = task_k(values of deps(k))`, every system factors as `scheduler ∘ rebuilder` over a `Tasks c k v` abstraction, and `c` is `Applicative` (static dependencies) or `Monad` (dynamic dependencies).
+The framing spine is *Build Systems à la Carte* (Mokhov, Mitchell, Peyton Jones, ICFP 2018; our copy lives in the private `cameronraysmith/engineering-references` tree at `mokhov-2018-build-systems-a-la-carte/`): a build is a fixpoint of `value(k) = task_k(values of deps(k))`, every system factors as `scheduler ∘ rebuilder` over a `Tasks c k v` abstraction, and `c` is `Applicative` (static dependencies) or `Monad` (dynamic dependencies).
 A `Tasks` value is a free structure (free applicative or free monad) over a signature of fetch-dependency operations; the build system is an interpreter — an algebra, or a natural transformation — that runs it against a store.
 Most of Dagster maps onto *either the free term or the interpreter*, and confusing the two is the main source of muddle.
 
-Each entry below states the exact Dagster API (verified against `~/projects/omicslake-workspace/dagster/python_modules/dagster/dagster/`, version `1!0+dev`), the categorical target, and a tightness tag.
+Each entry below states the exact Dagster API (verified against `dagster-io/dagster` at `python_modules/dagster/dagster/`, version `1!0+dev`), the categorical target, and a tightness tag.
 A tag of *tight* means the structure is present and Dagster maintains it; *almost* means the structure holds exactly when a coherence condition Dagster does not enforce is met, and the entry names that condition.
 
 ## 1. The asset graph is the free diagram — the `Tasks` object itself
@@ -172,4 +172,4 @@ This file says what-maps-to-what; *03-fp-discipline-and-enforcement.md* establis
 - *03-fp-discipline-and-enforcement.md* — the enforcement toolchain and the fully worked lawful IO-manager example discharging the entry-3 proof obligation.
 - preferences-theoretical-foundations, its internal-language reference — free constructions, functors, natural transformations, and the categorical vocabulary underpinning the free-term-versus-interpreter split.
 - preferences-algebraic-laws — the functor, applicative, and monad laws the static-versus-dynamic mapping (entry 2) and the trace replay (entry 5) rest on.
-- Mokhov, Mitchell, Peyton Jones, "Build Systems à la Carte", ICFP 2018, `~/projects/planning-workspace/engineering-references/mokhov-2018-build-systems-a-la-carte/` — the `Tasks c k v` abstraction, the `scheduler ∘ rebuilder` factoring, the constraint hierarchy, and the trace taxonomy. The local copy predates Selective functors (2019 / JFP 2020).
+- Mokhov, Mitchell, Peyton Jones, "Build Systems à la Carte", ICFP 2018, `cameronraysmith/engineering-references` at `mokhov-2018-build-systems-a-la-carte/` — the `Tasks c k v` abstraction, the `scheduler ∘ rebuilder` factoring, the constraint hierarchy, and the trace taxonomy. The local copy predates Selective functors (2019 / JFP 2020).

--- a/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-workflow-orchestration-algebra/02-asset-vs-task-spectrum.md
+++ b/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-workflow-orchestration-algebra/02-asset-vs-task-spectrum.md
@@ -34,7 +34,7 @@ Airflow admits no clean BSàlC reading — not "almost", but genuinely none.
 ## Point 2 — Flyte v2: typed monadic fusion, an almost-indexed-effect monad
 
 Flyte v2 is a clean-break redesign of v1 and inverts v1's model in the one respect that matters here.
-Verified against `~/projects/sciops-workspace/flyte-sdk/src/flyte/`: the v2 public surface is task-centric, and v1's static-DAG vocabulary is gone.
+Verified against `flyteorg/flyte-sdk` at `src/flyte/`: the v2 public surface is task-centric, and v1's static-DAG vocabulary is gone.
 There is no `@workflow`, no `@dynamic`, no `conditional`/`if_`, no `map_task`, no `LaunchPlan`.
 Fan-out is `flyte.map` and human-in-the-loop gating is `flyte.new_condition`/`ConditionWebhook`, but neither reintroduces a static DAG — `map` is run-time fan-out parallelism over a task and `new_condition` is an awaited external signal, both runtime helpers within the async task model rather than v1's static branching.
 The only authoring decorator is `@env.task` on a `flyte.TaskEnvironment`; a "workflow" is just an `async def` parent task that `await`s child tasks.
@@ -108,7 +108,7 @@ Flyte v2 fuses *with types*: the monadic, runtime-grown action tree is lawful at
 That "almost" is where the information is: typed fusion is still principled — a coherent indexed-effect discipline a careful author can hold themselves to — it is simply a different mathematics than the free-applicative-or-monad-term-plus-store-interpreter mathematics that Dagster wears on its sleeve.
 
 A note on provenance for the constraint vocabulary used above.
-The `Applicative ⊂ Selective ⊂ Monad` chain is invoked here through `Applicative` and `Monad` only; the intermediate `Selective` point (static visibility of all candidate dependencies with selective execution of one branch's effects) is the natural home for a conditional, statically-extractable orchestrator, but Mokhov, Mitchell and Peyton Jones, "Build Systems à la Carte" (ICFP 2018, `~/projects/planning-workspace/engineering-references/mokhov-2018-build-systems-a-la-carte/`) predates `Selective`, which was added in their 2019 "Selective Applicative Functors" and folded into the JFP 2020 extended version.
+The `Applicative ⊂ Selective ⊂ Monad` chain is invoked here through `Applicative` and `Monad` only; the intermediate `Selective` point (static visibility of all candidate dependencies with selective execution of one branch's effects) is the natural home for a conditional, statically-extractable orchestrator, but Mokhov, Mitchell and Peyton Jones, "Build Systems à la Carte" (ICFP 2018; our copy lives in the private `cameronraysmith/engineering-references` tree at `mokhov-2018-build-systems-a-la-carte/`) predates `Selective`, which was added in their 2019 "Selective Applicative Functors" and folded into the JFP 2020 extended version.
 None of the three orchestrators here sits cleanly at the `Selective` point, so the omission does not affect the spectrum; flag it only when invoking `Selective` directly.
 
 ## Cross-references
@@ -117,4 +117,4 @@ None of the three orchestrators here sits cleanly at the `Selective` point, so t
 - *03-fp-discipline-and-enforcement.md* — the lawful IO-manager example and the proof obligation that materialization is a pure function of `(AssetKey, PartitionKey)`, which makes Dagster's interpreter side honest.
 - preferences-theoretical-foundations, its internal-language reference — free structures, functors, indexed/fibered families, and the categorical vocabulary the spectrum leans on.
 - preferences-algebraic-laws — the law-as-specification stance behind "almost / aspirational" versus "lawful"; the indexed-monad reading of Flyte v2 is the former, not the latter.
-- Mokhov, Mitchell, Peyton Jones, "Build Systems à la Carte" (ICFP 2018), `~/projects/planning-workspace/engineering-references/mokhov-2018-build-systems-a-la-carte/sections/`.
+- Mokhov, Mitchell, Peyton Jones, "Build Systems à la Carte" (ICFP 2018), `cameronraysmith/engineering-references` at `mokhov-2018-build-systems-a-la-carte/sections/`.

--- a/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-workflow-orchestration-algebra/SKILL.md
+++ b/modules/home/ai/plugins/preferences-data-and-scientific-computing/.apm/skills/preferences-workflow-orchestration-algebra/SKILL.md
@@ -102,7 +102,7 @@ Three skills cover Dagster work and they do not overlap; route by what the quest
 | this skill | the algebra, the BSalC mapping, and the FP-law discipline closing the almost-gaps | mapping a primitive to its categorical object, choosing asset-vs-task, writing a lawful IO manager, enforcing type-safe FP laws on a pipeline |
 
 The boundary is clean: this skill names the *law and structure*, `dagster-expert` holds the *API*, `dignified-python` holds the *imperative style*.
-When this skill needs an operational API it defers to `dagster-expert` by reference rather than restating symbols; both Dagster skills live under `/Users/crs58/projects/omicslake-workspace/dagster-skills/skills/`.
+When this skill needs an operational API it defers to `dagster-expert` by reference rather than restating symbols.
 
 ## Contents
 

--- a/modules/home/ai/plugins/preferences-event-driven-systems/.apm/skills/preferences-event-catalog-tooling/SKILL.md
+++ b/modules/home/ai/plugins/preferences-event-driven-systems/.apm/skills/preferences-event-catalog-tooling/SKILL.md
@@ -65,13 +65,13 @@ It generates static documentation sites from markdown files with structured fron
 
 Source code and tooling for EventCatalog development:
 
-- `~/projects/lakescope-workspace/eventcatalog` - EventCatalog core source
-- `~/projects/lakescope-workspace/create-eventcatalog` - Project scaffolding CLI
-- `~/projects/lakescope-workspace/eventcatalog-mcp-server` - MCP server for AI-assisted catalog queries
-- `~/projects/lakescope-workspace/eventstorm-to-catalog` - EventStorming artifact conversion
+- `event-catalog/eventcatalog` - EventCatalog core source
+- `event-catalog/eventcatalog` (`packages/create-eventcatalog`) - Project scaffolding CLI (the standalone `create-eventcatalog` repo is archived; its content moved into this subpath)
+- `event-catalog/mcp-server` - MCP server for AI-assisted catalog queries
+- `event-catalog/eventstorm-to-catalog` - EventStorming artifact conversion
 
 For documentation queries, use context7 MCP with `/websites/eventcatalog_dev` for the official documentation.
-For source code exploration, search the local repositories above.
+For source code exploration, see the repositories above.
 
 ### Event documentation structure
 

--- a/modules/home/ai/plugins/preferences-event-driven-systems/.apm/skills/preferences-schema-versioning/SKILL.md
+++ b/modules/home/ai/plugins/preferences-event-driven-systems/.apm/skills/preferences-schema-versioning/SKILL.md
@@ -309,8 +309,8 @@ Use these types for cross-database compatibility:
 
 For patterns on modeling domain types in schemas and generated code:
 
-- **~/.claude/skills/preferences-algebraic-data-types/SKILL.md** - ENUMs (sum types), DOMAIN types (newtypes), making illegal states unrepresentable, cross-language ADT patterns
-- **~/.claude/skills/preferences-railway-oriented-programming/SKILL.md** - Result types in generated code, effect signatures for database operations
+- **`preferences-algebraic-data-types`** - ENUMs (sum types), DOMAIN types (newtypes), making illegal states unrepresentable, cross-language ADT patterns
+- **`preferences-railway-oriented-programming`** - Result types in generated code, effect signatures for database operations
 
 Apply these patterns to:
 - Model order status as ENUM instead of VARCHAR
@@ -388,7 +388,7 @@ def test_migration_compatibility():
 The same PostgreSQL schema generates type-safe code across languages.
 Each language uses its native type system and validation libraries.
 
-For detailed patterns on sum types, newtypes, and Result types in generated code, see ~/.claude/skills/preferences-algebraic-data-types/SKILL.md and ~/.claude/skills/preferences-railway-oriented-programming/SKILL.md.
+For detailed patterns on sum types, newtypes, and Result types in generated code, see `preferences-algebraic-data-types` and `preferences-railway-oriented-programming`.
 
 ### Python (Pydantic)
 

--- a/modules/home/ai/plugins/preferences-functional-programming-theory/.apm/skills/preferences-algebraic-data-types/SKILL.md
+++ b/modules/home/ai/plugins/preferences-functional-programming-theory/.apm/skills/preferences-algebraic-data-types/SKILL.md
@@ -1139,7 +1139,7 @@ See `event-sourcing.md#the-decider-pattern` for operational patterns and prefere
 
 ## Integration with schema versioning
 
-See `~/.claude/skills/preferences-schema-versioning/SKILL.md` for:
+See `preferences-schema-versioning` for:
 - How to configure sqlc to generate ADT types
 - Cross-database compatibility (PostgreSQL ENUMs → DuckDB CHECK)
 - Migration patterns for evolving ADTs
@@ -1147,6 +1147,6 @@ See `~/.claude/skills/preferences-schema-versioning/SKILL.md` for:
 Beyond sqlc's SQL-as-source generation, a single schema can drive multi-target binding generation: the LinkML family co-generates SQL DDL alongside language bindings (pydantic, JSON Schema, protobuf, TypeScript) from one schema, in the same codegen-from-one-schema family as sqlc.
 This is the lowering-path bifurcation — see preferences-data-modeling for the full mechanism and nucleus-platform for the spec-anchored instance — under which product-oriented schema types factor through schema-first codegen while sum-rich domain types lower domain-direct, precisely because frame-based and relational schemas cannot natively carry exhaustiveness-checked discriminated sums (the ENUM and JSONB-plus-CHECK workarounds above are exactly that gap showing through).
 
-See `~/.claude/skills/preferences-railway-oriented-programming/SKILL.md` for:
+See `preferences-railway-oriented-programming` for:
 - How to use ADTs with Result types for error handling
 - Composing operations on sum types with bind/apply

--- a/modules/home/ai/plugins/preferences-functional-programming-theory/.apm/skills/preferences-railway-oriented-programming/SKILL.md
+++ b/modules/home/ai/plugins/preferences-functional-programming-theory/.apm/skills/preferences-railway-oriented-programming/SKILL.md
@@ -1388,16 +1388,16 @@ Cross-reference `preferences-observability-engineering` for the observability mo
 
 ## Integration with other preferences
 
-See `~/.claude/skills/preferences-algebraic-data-types/SKILL.md` for:
+See `preferences-algebraic-data-types` for:
 - How to model domain types that work with Result
 - Sum types for error variants
 - Newtypes for validated values
 
-See `~/.claude/skills/preferences-schema-versioning/SKILL.md` for:
+See `preferences-schema-versioning` for:
 - Configuring sqlc to generate Result-returning queries
 - Database operations in railway-oriented style
 
-See `~/.claude/skills/preferences-data-modeling/SKILL.md` for:
+See `preferences-data-modeling` for:
 - How ROP fits into data pipeline architecture
 - Effect isolation at boundaries
 - Capability-interface discharge for effect composition at boundaries

--- a/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-checks-architecture/references/derivation-patterns.md
+++ b/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-checks-architecture/references/derivation-patterns.md
@@ -220,7 +220,7 @@ Each package maintains its own dependency resolution while sharing a common Pyth
 `mkEditablePyprojectOverlay` produces an editable overlay for the devshell where source changes are reflected without rebuilding.
 `pyproject-build-systems.overlays.default` provides build system packages (setuptools, hatchling, maturin, etc.) that pyproject-nix needs.
 
-Reference repos: `~/projects/nix-workspace/pyproject.nix`, `~/projects/nix-workspace/uv2nix`, `~/projects/nix-workspace/python-nix-template`.
+Reference repos: `pyproject-nix/pyproject.nix`, `pyproject-nix/uv2nix`, `sciexp/python-nix-template`.
 
 
 ## Rust/Python interop (crane-maturin)
@@ -249,7 +249,7 @@ in
 The `nixpkgsPrebuilt` function from pyproject-nix's hacks module (`pyproject-nix.build.hacks.nixpkgsPrebuilt`) injects the crane-maturin compiled output into the uv2nix package set, avoiding a second compilation during Python packaging.
 The package exposes `passthru.tests` with pytest, clippy, documentation, formatting, and cargo test derivations.
 
-Reference repo: `~/projects/nix-workspace/crane-maturin`.
+Reference repo: `vlaci/crane-maturin`.
 
 
 ## JavaScript/TypeScript (bun2nix)

--- a/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-ci-cd-integration/references/nix-native-effects.md
+++ b/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-ci-cd-integration/references/nix-native-effects.md
@@ -273,9 +273,9 @@ The exception is network-dependent effects: the local machine may have different
 
 ## Reference repositories
 
-`~/projects/nix-workspace/buildbot-nix` contains the buildbot-nix source, including the effect runner, the NixOS modules for master and worker, the GitHub and Gitea forge backends, and the `buildbot-effects` CLI.
+`nix-community/buildbot-nix` contains the buildbot-nix source, including the effect runner, the NixOS modules for master and worker, the GitHub and Gitea forge backends, and the `buildbot-effects` CLI.
 The `GITHUB.md` file documents the GitHub App setup procedure.
 
-`~/projects/nix-workspace/hercules-ci-effects` contains the upstream effect library: `mkEffect`, `modularEffect`, all common effect types (`runNixOS`, `runNixDarwin`, `flakeUpdate`, etc.), the flake-parts module, and the `secretsMap` infrastructure.
+`hercules-ci/hercules-ci-effects` contains the upstream effect library: `mkEffect`, `modularEffect`, all common effect types (`runNixOS`, `runNixDarwin`, `flakeUpdate`, etc.), the flake-parts module, and the `secretsMap` infrastructure.
 The `effects/` directory contains the implementation of each effect type.
 The `flake-module.nix` file contains the flake-parts integration.

--- a/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-nix-development/SKILL.md
@@ -83,12 +83,12 @@ Conflating the two causes silent failures in cross-compilation and missing runti
 Rust packages use crane, which separates dependency compilation from source compilation for incremental caching.
 The typical pattern chains `buildDepsOnly` (compiles only Cargo dependencies), `buildPackage` (compiles project source against cached deps), `cargoClippy` (lint check), and `cargoNextest` (test runner).
 For PyO3/maturin hybrid packages that produce Python wheels from Rust source, crane-maturin provides `buildMaturinPackage`.
-Reference repo: `~/projects/nix-workspace/crane-maturin`.
+Reference repo: `vlaci/crane-maturin`.
 
 Python packaging uses uv2nix and pyproject-nix rather than nixpkgs' `buildPythonPackage`.
 The uv2nix approach reads `uv.lock` files via `workspace.loadWorkspace`, produces nix overlays through `mkPyprojectOverlay`, and composes them with `pyproject-build-systems` into a Python package set.
 `mkVirtualEnv` produces the final installable environment.
-Reference repos: `~/projects/nix-workspace/pyproject.nix`, `~/projects/nix-workspace/uv2nix`.
+Reference repos: `pyproject-nix/pyproject.nix`, `pyproject-nix/uv2nix`.
 The nixpkgs `buildPythonPackage` remains a fallback for packages not managed by uv that need nix-specific fixups.
 
 JavaScript packages use bun2nix with `fetchBunDeps` for reproducible dependency fetching from `bun.lock` files.

--- a/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-secrets/SKILL.md
+++ b/modules/home/ai/plugins/preferences-nix-and-secrets/.apm/skills/preferences-secrets/SKILL.md
@@ -785,7 +785,7 @@ cf-secrets-list env="production":
 
 **Pattern**: Non-sensitive config in `wrangler.jsonc`, sensitive secrets via `wrangler secret put` from sops.
 
-See @~/.claude/skills/preferences-web-application-deployment/SKILL.md for Cloudflare secrets management details.
+See `preferences-web-application-deployment` for Cloudflare secrets management details.
 
 ## Best practices
 
@@ -918,7 +918,7 @@ This project uses sops for secrets management.
 
 ## Integration with other preferences
 
-- Cloudflare Workers secrets: @~/.claude/skills/preferences-web-application-deployment/SKILL.md
-- sops-nix in flakes: @~/.claude/skills/preferences-nix-development/SKILL.md
-- Pre-commit hooks: @~/.claude/skills/preferences-git-version-control/SKILL.md
-- CI/CD patterns: @~/.claude/skills/preferences-typescript-nodejs-development/SKILL.md
+- Cloudflare Workers secrets: `preferences-web-application-deployment`
+- sops-nix in flakes: `preferences-nix-development`
+- Pre-commit hooks: `preferences-git-version-control`
+- CI/CD patterns: `preferences-typescript-nodejs-development`

--- a/modules/home/ai/plugins/preferences-operations-and-reliability/.apm/skills/preferences-adaptive-planning/SKILL.md
+++ b/modules/home/ai/plugins/preferences-operations-and-reliability/.apm/skills/preferences-adaptive-planning/SKILL.md
@@ -118,7 +118,7 @@ See `preferences-validation-assurance` for the full treatment of evidence qualit
   - Graph homomorphisms: structural mappings between specification DAGs and implementation DAGs = traceability.
   - Incremental recomputation: when a spec node changes, the minimal subgraph requiring replanning is determinable (cf. build systems a la carte — Mokhov, Mitchell, Peyton Jones).
 - *References*: Mokhov, *Algebraic Graphs with Class* (Haskell Symposium, 2017); Mokhov, Mitchell & Peyton Jones, "Build Systems a la Carte" (ICFP, 2018); Davey & Priestley, *Introduction to Lattices and Order*.
-- *See also*: the diamond workflow in `~/.claude/skills/jj-version-control/SKILL.md` applies these algebraic structures to connect beads epic graphs to jj chain topology.
+- *See also*: the diamond workflow in `jj-version-control` applies these algebraic structures to connect beads epic graphs to jj chain topology.
 
 ## Operational framework
 
@@ -149,7 +149,7 @@ Keep the operational buffer at $B^*$ items — enough to absorb planning variabi
 
 Place validation gates at topological convergence points in the DAG — nodes where multiple independent implementation chains merge.
 These are natural integration boundaries where architectural assumptions face reality.
-The jj diamond workflow's *converge* phase (see `~/.claude/skills/jj-version-control/diamond-workflow.md`) occurs at a planning-DAG convergence point in this sense — they refer to the same node-shape from different perspectives.
+The jj diamond workflow's *converge* phase (see the `jj-version-control` skill's `diamond-workflow.md`) occurs at a planning-DAG convergence point in this sense — they refer to the same node-shape from different perspectives.
 The interval between gates should satisfy:
 
 $$\text{Expected rework cost between gates} < \text{Validation overhead per gate}$$

--- a/modules/home/ai/plugins/preferences-operations-and-reliability/.apm/skills/preferences-compositional-continuous-verification/SKILL.md
+++ b/modules/home/ai/plugins/preferences-operations-and-reliability/.apm/skills/preferences-compositional-continuous-verification/SKILL.md
@@ -132,7 +132,7 @@ The meta-check derivations — traceability, adequacy, integrity, and exemption-
 Their design, the structured manifest declaring per-package deliverables and required check kinds, the coverage-model schema, and the mutation-testing sampling strategy are all flake-level engineering documented in the CCV reference proper.
 This skill provides the theoretical anchor and the agent-side habit; the flake-side machinery is a separate concern that `preferences-nix-checks-architecture` covers from the construction side.
 
-Per-package manifests, per-artifact coverage profiles, and the incident-to-check feedback loop are documented in the CCV doc proper at `~/projects/sciexp/planning/docs/notes/development/continuous-verification/compositional-continuous-verification.md`; their adoption into the vanixiets flake is a deferred epic to be tracked separately when the prerequisites land.
+Per-package manifests, per-artifact coverage profiles, and the incident-to-check feedback loop are documented in the CCV doc proper in the private `sciexp/planning` tree at `docs/notes/development/continuous-verification/compositional-continuous-verification.md`; their adoption into the vanixiets flake is a deferred epic to be tracked separately when the prerequisites land.
 
 ## Forward hooks
 

--- a/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-python-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-python-development/SKILL.md
@@ -7,7 +7,7 @@ description: Python development conventions including type safety with basedpyri
 
 ## Architectural patterns alignment
 
-See @~/.claude/skills/preferences-architectural-patterns/SKILL.md for overarching principles.
+See `preferences-architectural-patterns` for overarching principles.
 
 Python can approximate functional programming patterns through careful library selection and disciplined type usage.
 
@@ -26,8 +26,8 @@ Python can approximate functional programming patterns through careful library s
 - Isolate IO and side effects to specific layers or boundaries
 
 For detailed patterns on Result types, error composition, and ADT modeling in Python:
-- **~/.claude/skills/preferences-railway-oriented-programming/SKILL.md** - Result type implementation, bind/apply, async effects
-- **~/.claude/skills/preferences-algebraic-data-types/SKILL.md** - Discriminated unions with Pydantic, newtypes, domain modeling
+- **`preferences-railway-oriented-programming`** - Result type implementation, bind/apply, async effects
+- **`preferences-algebraic-data-types`** - Discriminated unions with Pydantic, newtypes, domain modeling
 
 ## Functional domain modeling in Python
 

--- a/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-rust-development/02-error-handling.md
+++ b/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-rust-development/02-error-handling.md
@@ -290,7 +290,7 @@ Railway-oriented programming treats error handling as a two-track railway: succe
 The `?` operator provides monadic composition (bind) for fail-fast behavior.
 This section focuses on applicative composition for error accumulation.
 
-See `~/.claude/skills/preferences-railway-oriented-programming/SKILL.md` for comprehensive patterns including bind vs apply, effect signatures, and the two-track model.
+See `preferences-railway-oriented-programming` for comprehensive patterns including bind vs apply, effect signatures, and the two-track model.
 
 ### Fail-fast vs error accumulation
 

--- a/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-rust-development/04-api-design.md
+++ b/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-rust-development/04-api-design.md
@@ -292,7 +292,7 @@ See [01-functional-domain-modeling.md](./01-functional-domain-modeling.md#patter
 
 Domain types should remain ignorant of serialization concerns.
 This preserves persistence ignorance and keeps domain logic independent of infrastructure choices.
-For conceptual foundation, see `~/.claude/skills/preferences-architectural-patterns/SKILL.md` (Onion/hexagonal architecture, infrastructure layer responsibilities).
+For conceptual foundation, see `preferences-architectural-patterns` (Onion/hexagonal architecture, infrastructure layer responsibilities).
 
 ### DTO separation pattern
 
@@ -435,7 +435,7 @@ This organization makes it clear:
 
 Workflows have typed inputs (commands) and outputs (events) that document intent and outcomes.
 Commands represent actions to perform; events represent facts about what occurred.
-For conceptual foundation, see `~/.claude/skills/preferences-architectural-patterns/SKILL.md` (Commands and events as workflow boundaries).
+For conceptual foundation, see `preferences-architectural-patterns` (Commands and events as workflow boundaries).
 
 **Local vs. distributed semantics**: The command/event pattern here describes in-process workflow documentation.
 When commands or events cross service boundaries (HTTP, gRPC, message queues), additional concerns apply:

--- a/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-rust-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-programming-languages/.apm/skills/preferences-rust-development/SKILL.md
@@ -50,12 +50,12 @@ This guide is organized into focused topic files for easy navigation and AI agen
 
 This document integrates guidance from:
 
-- **Functional domain modeling**: See `~/.claude/skills/preferences-domain-modeling/SKILL.md` for universal patterns, `~/.claude/skills/preferences-architectural-patterns/SKILL.md` for application structure, `~/.claude/skills/preferences-railway-oriented-programming/SKILL.md` for error composition
+- **Functional domain modeling**: See `preferences-domain-modeling` for universal patterns, `preferences-architectural-patterns` for application structure, `preferences-railway-oriented-programming` for error composition
 - **Microsoft Pragmatic Rust Guidelines**: https://microsoft.github.io/rust-guidelines/agents/all.txt - comprehensive production Rust guidance from Microsoft engineers
 - **Rust API Guidelines**: https://rust-lang.github.io/api-guidelines/ - official Rust API design checklist
 
 ### Related documents
 
-- `~/.claude/skills/preferences-distributed-systems/SKILL.md` - universal distributed systems decision framework
+- `preferences-distributed-systems` - universal distributed systems decision framework
 - preferences-theoretical-foundations - category-theoretic underpinnings
-- `~/.claude/skills/preferences-algebraic-data-types/SKILL.md` - sum/product type patterns
+- `preferences-algebraic-data-types` - sum/product type patterns

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-cloudflare-wrangler-reference/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-cloudflare-wrangler-reference/SKILL.md
@@ -7,7 +7,7 @@ description: Cloudflare wrangler comprehensive reference for Workers, D1, R2, an
 
 Comprehensive configuration reference for Cloudflare Wrangler synthesized from production patterns.
 
-See @~/.claude/skills/preferences-web-application-deployment/SKILL.md for deployment workflows and practical patterns.
+See `preferences-web-application-deployment` for deployment workflows and practical patterns.
 
 ## Configuration schema
 

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/01-architecture.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/01-architecture.md
@@ -385,6 +385,6 @@ SPAs trade large client bundles and dual state management for richer client-side
 - `02-sse-patterns.md` - Server-Sent Events streaming patterns and error handling
 - `03-signals.md` - Reactive state synchronization between server and client
 - `04-testing.md` - Testing strategies for hypermedia applications
-- `~/.claude/skills/preferences-domain-modeling/SKILL.md` - Functional domain modeling with algebraic types
-- `~/.claude/skills/preferences-railway-oriented-programming/SKILL.md` - Result-based error handling patterns
-- `~/.claude/skills/preferences-architectural-patterns/SKILL.md` - General architectural principles
+- `preferences-domain-modeling` - Functional domain modeling with algebraic types
+- `preferences-railway-oriented-programming` - Result-based error handling patterns
+- `preferences-architectural-patterns` - General architectural principles

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/08-analytics-data-serving.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/08-analytics-data-serving.md
@@ -202,6 +202,6 @@ Cross-reference section 07 for the event architecture foundation, including the 
 - `02-sse-patterns.md` - SSE streaming mechanics, reconnection
 - `03-datastar.md` - signal system, ReadSignals pattern, PatchElements/PatchSignals
 - `07-event-architecture.md` - event sourcing, projection pipelines, CQRS
-- `~/.claude/skills/preferences-data-modeling/SKILL.md` - DuckDB/DuckLake patterns, materialized views, scientific data contracts
-- `~/.claude/skills/preferences-rust-development/SKILL.md` - Rust-specific patterns for axum integration
-- `~/.claude/skills/preferences-scalable-probabilistic-modeling-workflow/SKILL.md` - section 06 defines the diagnostic artifacts (simulation ensembles, posterior samples, calibration tables) that this serving pipeline delivers to visualization tools
+- `preferences-data-modeling` - DuckDB/DuckLake patterns, materialized views, scientific data contracts
+- `preferences-rust-development` - Rust-specific patterns for axum integration
+- `preferences-scalable-probabilistic-modeling-workflow` - section 06 defines the diagnostic artifacts (simulation ensembles, posterior samples, calibration tables) that this serving pipeline delivers to visualization tools

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/SKILL.md
@@ -46,7 +46,7 @@ The Decider pattern (fmodel-rust) enforces this structurally: `decide` and `evol
 - Real-time updates are server-pushed (notifications, live data)
 
 **For standalone documents (no server):**
-When the document is self-contained and does not need server state (experiments, presentations, visualizations), see `~/.claude/skills/preferences-hypermedia-documents/SKILL.md` for the standalone authoring patterns that share the same design system and progressive enhancement approach.
+When the document is self-contained and does not need server state (experiments, presentations, visualizations), see `preferences-hypermedia-documents` for the standalone authoring patterns that share the same design system and progressive enhancement approach.
 
 **Reconsider when:**
 - Application requires offline-first functionality
@@ -80,13 +80,13 @@ It demonstrates the Go-style handler pattern `(Context, Writer) -> None`, declar
 
 ## Related documents
 
-- `~/.claude/skills/preferences-web-platform-foundations/SKILL.md` - shared vocabulary: 15 web platform properties, capability ladder, paradigm routing
-- `~/.claude/skills/preferences-hypermedia-documents/SKILL.md` - standalone document authoring (presentations, experiments, visualizations) without a server backend
+- `preferences-web-platform-foundations` - shared vocabulary: 15 web platform properties, capability ladder, paradigm routing
+- `preferences-hypermedia-documents` - standalone document authoring (presentations, experiments, visualizations) without a server backend
 - preferences-theoretical-foundations - algebraic foundations: signals as comonads, web components as coalgebras, event sourcing as free monoids (see its decide-evolve-lens reference)
-- `~/.claude/skills/preferences-architectural-patterns/SKILL.md` - onion/hexagonal architecture, effect boundaries
-- `~/.claude/skills/preferences-domain-modeling/SKILL.md` - functional domain modeling, smart constructors
-- `~/.claude/skills/preferences-railway-oriented-programming/SKILL.md` - Result-based error handling
-- `~/.claude/skills/preferences-distributed-systems/SKILL.md` - event log authority, CQRS, idempotency patterns
-- `~/.claude/skills/preferences-data-modeling/SKILL.md` - materialized views, DuckDB/DuckLake patterns
-- `~/.claude/skills/preferences-rust-development/SKILL.md` - Rust-specific patterns (integrates with Datastar-Rust/hypertext)
-- `~/.claude/skills/preferences-typescript-nodejs-development/SKILL.md` - TypeScript patterns for Node.js backends
+- `preferences-architectural-patterns` - onion/hexagonal architecture, effect boundaries
+- `preferences-domain-modeling` - functional domain modeling, smart constructors
+- `preferences-railway-oriented-programming` - Result-based error handling
+- `preferences-distributed-systems` - event log authority, CQRS, idempotency patterns
+- `preferences-data-modeling` - materialized views, DuckDB/DuckLake patterns
+- `preferences-rust-development` - Rust-specific patterns (integrates with Datastar-Rust/hypertext)
+- `preferences-typescript-nodejs-development` - TypeScript patterns for Node.js backends

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-development/SKILL.md
@@ -71,11 +71,11 @@ When the document is self-contained and does not need server state (experiments,
 
 **Reference implementations:**
 
-Ironstar (`~/projects/rust-workspace/ironstar`) is the canonical Rust integration of algebraic DDD with hypermedia architecture.
+Ironstar (`sciexp/ironstar`) is the canonical Rust integration of algebraic DDD with hypermedia architecture.
 It demonstrates the Decider pattern (fmodel-rust) for pure domain logic, embedded infrastructure (SQLite event store, Zenoh pub/sub, DuckDB analytics, moka cache), Open Props + CUBE CSS cascade layer architecture, hypertext lazy templates with datastar-rust SSE events, and Idris2 formal specifications for domain model verification.
 See the repo's CLAUDE.md for the authoritative architectural context.
 
-Stario (`~/projects/lakescope-workspace/stario`) is an illustrative Python 3.14+ framework for Datastar integration.
+Stario (`Bobowski/stario`) is an illustrative Python 3.14+ framework for Datastar integration.
 It demonstrates the Go-style handler pattern `(Context, Writer) -> None`, declarative HTML element functions, `data`/`at` Datastar attribute helpers, and the Relay in-process pub/sub system for broadcasting events across SSE connections.
 
 ## Related documents

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/01-design-system.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/01-design-system.md
@@ -34,7 +34,7 @@ Each utility applies exactly one property, and utilities override block defaults
 The `exceptions` layer handles per-context overrides via `data-*` attributes.
 These are state-specific or variant-specific adjustments that need the highest layer priority.
 
-This layer ordering follows the same priority hierarchy as Ironstar (`~/projects/rust-workspace/ironstar`), which uses `components, utilities, app` for the equivalent positions.
+This layer ordering follows the same priority hierarchy as Ironstar (`sciexp/ironstar`), which uses `components, utilities, app` for the equivalent positions.
 The document skill uses CUBE CSS terminology (`blocks`, `utilities`, `exceptions`) while preserving the same cascade semantics: utilities override blocks, exceptions override everything.
 
 ## Open Props design tokens

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/02-progressive-layers.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/02-progressive-layers.md
@@ -250,7 +250,7 @@ Key practices for web components in documents:
 - Clean up resources in `disconnectedCallback` (WebGL contexts, animation frames, event listeners)
 - Components are guests in the document and should not take over layout or navigation
 
-For detailed web component patterns, see `~/.claude/skills/preferences-hypermedia-development/05-web-components.md`.
+For detailed web component patterns, see the `preferences-hypermedia-development` skill's `05-web-components.md`.
 
 ## Layer 7: Datastar (server connectivity)
 
@@ -267,7 +267,7 @@ Activating this layer means a backend is required (Ironstar/Rust, Stario/Python,
 The preceding layers 0-6 remain in effect.
 Datastar enhances the document; it does not replace its foundation.
 
-For detailed Datastar patterns, see `~/.claude/skills/preferences-hypermedia-development/03-datastar.md`.
+For detailed Datastar patterns, see the `preferences-hypermedia-development` skill's `03-datastar.md`.
 
 ## Layer activation by purpose
 

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/SKILL.md
@@ -15,8 +15,8 @@ A document becomes an application when it requires server-side state management,
 Most of the work described here stays within the document regime, where the browser is the runtime and the filesystem (or a static host) is the server.
 
 This skill covers the standalone (no server) case.
-For server-connected hypermedia applications, see `~/.claude/skills/preferences-hypermedia-development/SKILL.md`.
-For the shared vocabulary of web platform properties and the paradigm routing framework, see `~/.claude/skills/preferences-web-platform-foundations/SKILL.md`.
+For server-connected hypermedia applications, see `preferences-hypermedia-development`.
+For the shared vocabulary of web platform properties and the paradigm routing framework, see `preferences-web-platform-foundations`.
 
 ## Contents
 
@@ -176,8 +176,8 @@ This suits multi-step demos or documentation sites that do not warrant a static 
 
 ## Related documents
 
-- `~/.claude/skills/preferences-web-platform-foundations/SKILL.md` -- shared vocabulary: 15 platform properties, capability ladder, paradigm routing
-- `~/.claude/skills/preferences-hypermedia-development/SKILL.md` -- server-connected hypermedia applications with Datastar, SSE, event architecture
-- `~/.claude/skills/preferences-hypermedia-development/04-css-architecture.md` -- detailed CSS architecture reference (CUBE CSS, Open Props, cascade layers)
-- `~/.claude/skills/preferences-hypermedia-development/05-web-components.md` -- detailed web component patterns (Lit, morph exclusion, event design)
-- `~/.claude/skills/preferences-architectural-patterns/SKILL.md` -- onion/hexagonal architecture, effect boundaries
+- `preferences-web-platform-foundations` -- shared vocabulary: 15 platform properties, capability ladder, paradigm routing
+- `preferences-hypermedia-development` -- server-connected hypermedia applications with Datastar, SSE, event architecture
+- the `preferences-hypermedia-development` skill's `04-css-architecture.md` -- detailed CSS architecture reference (CUBE CSS, Open Props, cascade layers)
+- the `preferences-hypermedia-development` skill's `05-web-components.md` -- detailed web component patterns (Lit, morph exclusion, event design)
+- `preferences-architectural-patterns` -- onion/hexagonal architecture, effect boundaries

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-hypermedia-documents/SKILL.md
@@ -155,7 +155,7 @@ See `04-presentations.md` for the complete presentation architecture.
 
 *Server connectivity (when needed):* Datastar (~15KB) provides SSE-driven reactivity when the document transitions to a hybrid application.
 
-*Reference implementation:* Ironstar (`~/projects/rust-workspace/ironstar`) demonstrates the full Open Props + CUBE CSS + Datastar integration in a server-connected context.
+*Reference implementation:* Ironstar (`sciexp/ironstar`) demonstrates the full Open Props + CUBE CSS + Datastar integration in a server-connected context.
 Ironstar is primarily a server-connected application, but its CSS architecture and design token usage apply directly to standalone documents.
 
 ## File organization

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-react-tanstack-ui-development/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-react-tanstack-ui-development/SKILL.md
@@ -9,11 +9,11 @@ description: React and TanStack UI development patterns including component desi
 
 This skill describes the SPA (client-driven) paradigm.
 The SPA approach trades progressive enhancement, layered failure independence, and inspectability for client-side interactivity, offline capability, and complex client state management.
-See `~/.claude/skills/preferences-web-platform-foundations/SKILL.md` for the shared vocabulary of web platform properties and the paradigm routing framework that contextualizes this tradeoff.
+See `preferences-web-platform-foundations` for the shared vocabulary of web platform properties and the paradigm routing framework that contextualizes this tradeoff.
 
 ## Architectural patterns alignment
 
-See @~/.claude/skills/preferences-architectural-patterns/SKILL.md for overarching principles.
+See `preferences-architectural-patterns` for overarching principles.
 
 Apply functional programming patterns to React UI development:
 - Components are pure functions from props to JSX
@@ -188,7 +188,7 @@ const { roomStore, useRoomStore } = createRoomStore<RoomConfig, RoomState>(
 
 #### Type-safe S3/HTTPFS data sources with Zod
 
-Use discriminated unions for data source configuration (matches ADT patterns from @~/.claude/skills/preferences-algebraic-data-types/SKILL.md):
+Use discriminated unions for data source configuration (matches ADT patterns from `preferences-algebraic-data-types`):
 
 ```typescript
 // From @sqlrooms/room-config - Zod schemas for type safety
@@ -243,7 +243,7 @@ RoomConfig.parse(config) // Runtime validation
 
 Apply Result types to query execution for explicit error handling.
 
-See @~/.claude/skills/preferences-railway-oriented-programming/SKILL.md for Result patterns and error composition.
+See `preferences-railway-oriented-programming` for Result patterns and error composition.
 
 ```typescript
 import { z } from 'zod'
@@ -635,7 +635,7 @@ Integrate TanStack Form with Zod for type-safe validation and railway-oriented s
 
 ### Form patterns with railway-oriented programming
 
-See @~/.claude/skills/preferences-railway-oriented-programming/SKILL.md for Result types and error composition.
+See `preferences-railway-oriented-programming` for Result types and error composition.
 
 ```typescript
 import { useForm } from '@tanstack/react-form'
@@ -715,7 +715,7 @@ function UserForm() {
 
 Use applicative validation for better UX - show all errors at once.
 
-See @~/.claude/skills/preferences-railway-oriented-programming/SKILL.md for applicative patterns.
+See `preferences-railway-oriented-programming` for applicative patterns.
 
 ```typescript
 // TanStack Form validates all fields before submit
@@ -997,7 +997,7 @@ export default defineConfig({
 
 ## Deployment
 
-See @~/.claude/skills/preferences-web-application-deployment/SKILL.md for comprehensive deployment guidance including:
+See `preferences-web-application-deployment` for comprehensive deployment guidance including:
 - Cloudflare Workers/Pages deployment (preferred)
 - Database configuration (D1, PostgreSQL)
 - Wrangler configuration and platform bindings
@@ -1189,7 +1189,7 @@ Most UI code should use simpler patterns (TanStack Query, tRPC) unless:
 - Multiple dependent effects need composition
 - Advanced concurrency control needed
 
-See @~/.claude/skills/preferences-typescript-nodejs-development/SKILL.md for Effect-TS patterns in backend code.
+See `preferences-typescript-nodejs-development` for Effect-TS patterns in backend code.
 
 ## Testing UI components
 
@@ -1249,7 +1249,7 @@ describe('UserList', () => {
 
 ## Integration with algebraic data types
 
-See @~/.claude/skills/preferences-algebraic-data-types/SKILL.md for ADT patterns in TypeScript.
+See `preferences-algebraic-data-types` for ADT patterns in TypeScript.
 
 **Use discriminated unions for component state machines**:
 

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-web-application-deployment/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-web-application-deployment/SKILL.md
@@ -243,7 +243,7 @@ pnpm run drizzle:migrate              # Apply to database
 pnpm run pull-drizzle-schema          # Verify schema sync
 ```
 
-See @~/.claude/skills/preferences-schema-versioning/SKILL.md for migration patterns and versioning strategies.
+See `preferences-schema-versioning` for migration patterns and versioning strategies.
 
 ## Wrangler configuration
 
@@ -358,7 +358,7 @@ env.MY_VAR    // Type: string
 
 Cloudflare Workers integrate with platform resources via bindings configured in wrangler.jsonc.
 
-See @~/.claude/skills/preferences-cloudflare-wrangler-reference/SKILL.md for comprehensive binding configuration.
+See `preferences-cloudflare-wrangler-reference` for comprehensive binding configuration.
 
 ### D1 databases (serverless SQL)
 
@@ -1153,8 +1153,8 @@ env.ANALYTICS.writeDataPoint({
 
 See related preference files for complementary patterns:
 
-- @~/.claude/skills/preferences-react-tanstack-ui-development/SKILL.md - TanStack Start SSR patterns
-- @~/.claude/skills/preferences-typescript-nodejs-development/SKILL.md - Hono backend patterns
-- @~/.claude/skills/preferences-schema-versioning/SKILL.md - Database migration workflows
-- @~/.claude/skills/preferences-railway-oriented-programming/SKILL.md - Error handling in server functions
-- @~/.claude/skills/preferences-cloudflare-wrangler-reference/SKILL.md - Comprehensive wrangler configuration
+- `preferences-react-tanstack-ui-development` - TanStack Start SSR patterns
+- `preferences-typescript-nodejs-development` - Hono backend patterns
+- `preferences-schema-versioning` - Database migration workflows
+- `preferences-railway-oriented-programming` - Error handling in server functions
+- `preferences-cloudflare-wrangler-reference` - Comprehensive wrangler configuration

--- a/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-web-platform-foundations/SKILL.md
+++ b/modules/home/ai/plugins/preferences-web-platform-and-deployment/.apm/skills/preferences-web-platform-foundations/SKILL.md
@@ -176,7 +176,7 @@ Datastar serves as the thin reactivity layer at approximately 15KB, providing de
 Choose this paradigm when the server is authoritative for state, UI updates tolerate a server round-trip, minimal client JavaScript is valued, and real-time updates are server-pushed.
 This is the default paradigm for new projects unless specific requirements demand otherwise.
 
-Reference: `~/.claude/skills/preferences-hypermedia-development/SKILL.md`
+Reference: `preferences-hypermedia-development`
 
 ### Standalone document (static)
 
@@ -189,7 +189,7 @@ This paradigm is appropriate for content that is complete at authoring time: doc
 Choose this paradigm when content is self-contained, no server state is needed, or the use case is experimentation or presentation.
 Static documents can be hosted anywhere (CDN, local filesystem, embedded in other documents) because they have no runtime dependencies beyond the browser.
 
-Reference: `~/.claude/skills/preferences-hypermedia-documents/SKILL.md`
+Reference: `preferences-hypermedia-documents`
 
 ### SPA (client-driven)
 
@@ -201,7 +201,7 @@ The application assumes JavaScript execution and typically requires a build step
 
 Choose this paradigm when an offline-first requirement exists, ultra-low-latency interactions are needed, complex client-side state is unavoidable (video editor, CAD, collaborative canvas), or existing React ecosystem investment makes migration impractical.
 
-Reference: `~/.claude/skills/preferences-react-tanstack-ui-development/SKILL.md`
+Reference: `preferences-react-tanstack-ui-development`
 
 ### Decision procedure
 
@@ -251,8 +251,8 @@ When a feature is Chrome-only, document the degraded experience for other browse
 
 ## Related documents
 
-- `~/.claude/skills/preferences-hypermedia-development/SKILL.md` — server-connected hypermedia applications
-- `~/.claude/skills/preferences-hypermedia-documents/SKILL.md` — standalone document authoring
-- `~/.claude/skills/preferences-react-tanstack-ui-development/SKILL.md` — client-driven SPA development
-- `~/.claude/skills/preferences-functional-reactive-programming/SKILL.md` — theoretical foundations (signals as comonads, web components as coalgebras)
-- `~/.claude/skills/preferences-architectural-patterns/SKILL.md` — onion/hexagonal architecture, effect boundaries
+- `preferences-hypermedia-development` — server-connected hypermedia applications
+- `preferences-hypermedia-documents` — standalone document authoring
+- `preferences-react-tanstack-ui-development` — client-driven SPA development
+- `preferences-functional-reactive-programming` — theoretical foundations (signals as comonads, web components as coalgebras)
+- `preferences-architectural-patterns` — onion/hexagonal architecture, effect boundaries

--- a/modules/home/ai/plugins/testing-and-quality/.apm/skills/bdd-gherkin-formulation/SKILL.md
+++ b/modules/home/ai/plugins/testing-and-quality/.apm/skills/bdd-gherkin-formulation/SKILL.md
@@ -149,6 +149,6 @@ Each of these is documented with its exact assertion and file-and-line citation 
 
 ## Sources and attribution
 
-The BRIEF framework, the Rules-versus-Examples grouping, the formulation checklist, and the review process are adapted from yaks by Matt Wynne (MIT), de-branded and re-anchored on the ledger narrative; see [`NOTICE-yaks.md`](NOTICE-yaks.md) for the license and attribution, which credits yaks and the underlying work of Seb Rose ("Keep Your Scenarios BRIEF") and Liz Keogh ("Acceptance Criteria vs. Scenarios").
+The BRIEF framework, the Rules-versus-Examples grouping, the formulation checklist, and the review process are adapted from yaks by Matt Wynne, released under the MIT licence, de-branded and re-anchored on the ledger narrative; yaks itself credits the underlying work of Seb Rose ("Keep Your Scenarios BRIEF") and Liz Keogh ("Acceptance Criteria vs. Scenarios").
 The declarative-over-imperative treatment, the implementation-change litmus, the conjunction-step and feature-coupled anti-patterns, the one-thing-per-Given rule, and the Gherkin constructs are cited and paraphrased from the cucumber documentation (bdd/better-gherkin, guides/anti-patterns, bdd/who-does-what, gherkin/reference).
 The observable-outcome corpus embeds exemplars from the user's own safeadt project, cited to its source test tree.

--- a/modules/home/ai/plugins/testing-and-quality/.apm/skills/bdd-gherkin-formulation/references/brief-checklist.md
+++ b/modules/home/ai/plugins/testing-and-quality/.apm/skills/bdd-gherkin-formulation/references/brief-checklist.md
@@ -1,7 +1,8 @@
 # BRIEF and the formulation checklist
 
 This reference expands the BRIEF framework, the seven-point formulation checklist, the review loop, and the common-mistakes table.
-The material is adapted from yaks (MIT, see [`../NOTICE-yaks.md`](../NOTICE-yaks.md)), de-branded and re-anchored on the account-ledger narrative: an account is opened, deposited into, withdrawn from, and closed; it exposes a balance; it rejects an overdraft.
+The material is adapted from yaks by Matt Wynne, released under the MIT licence, de-branded and re-anchored on the account-ledger narrative: an account is opened, deposited into, withdrawn from, and closed; it exposes a balance; it rejects an overdraft.
+Yaks itself credits the underlying work of Seb Rose ("Keep Your Scenarios BRIEF") and Liz Keogh ("Acceptance Criteria vs. Scenarios").
 
 ## BRIEF, property by property
 

--- a/modules/home/ai/plugins/testing-and-quality/.apm/skills/executable-specification-testing/references/cross-language-verification.md
+++ b/modules/home/ai/plugins/testing-and-quality/.apm/skills/executable-specification-testing/references/cross-language-verification.md
@@ -4,8 +4,6 @@ This matrix places the three modalities this skill owns — property-based testi
 Cells grounded in a local clone cite its source path.
 Cells resting on model knowledge are marked *(model knowledge)* explicitly, and the one deliberate exclusion (Aeneas is not in the SMT column) is stated where it would otherwise be miscategorized.
 
-Local clones read for this matrix live under `/Users/crs58/projects/rust-workspace/`, `/Users/crs58/projects/haskell-workspace/`, `/Users/crs58/projects/python-workspace/`, and `/Users/crs58/projects/functional-programming-workspace/`.
-
 ## The matrix
 
 | Language | PBT | DbC / refinement | SMT / concolic |

--- a/modules/home/ai/plugins/testing-and-quality/.apm/skills/executable-specification-testing/references/tool-integration-sharp-edges.md
+++ b/modules/home/ai/plugins/testing-and-quality/.apm/skills/executable-specification-testing/references/tool-integration-sharp-edges.md
@@ -1,7 +1,7 @@
 # Tool-integration sharp edges
 
 These are the friction points the safeadt worked example surfaced by actually running the single-contract stack under a current toolchain.
-Each is grounded in the safeadt source tree at `/Users/crs58/projects/functional-programming-workspace/safeadt/`, read at the revision whose README reports CPython 3.14.2, Hypothesis 6.139.3, basedpyright 1.39.9, crosshair-tool 0.0.107, and icontract-hypothesis 1.1.7.
+Each is grounded in the private `cameronraysmith/safeadt` source tree — not independently checkable by a reader without access — read at the revision whose README reports CPython 3.14.2, Hypothesis 6.139.3, basedpyright 1.39.9, crosshair-tool 0.0.107, and icontract-hypothesis 1.1.7.
 
 ## beartype's claw hook crashes CrossHair's native importer
 

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/gitbutler-but-cli/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/gitbutler-but-cli/SKILL.md
@@ -287,7 +287,7 @@ but pull
 - Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a failed attempt.
 - Run `but skill check` only when command behavior diverges from this skill, not as routine preflight.
 - jj provides an equivalent multi-parent working copy pattern via `jj new bookmark-a bookmark-b`.
-  See `~/.claude/skills/jj-workflow/SKILL.md` for the jj-native workflow and `~/.claude/skills/preferences-git-version-control/SKILL.md` for the cross-tool mapping.
+  See `jj-workflow` for the jj-native workflow and `preferences-git-version-control` for the cross-tool mapping.
 - For command syntax and flags: `references/reference.md`
 - For workspace model: `references/concepts.md`
 - For workflow examples: `references/examples.md`

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-git-interactive-rebase-to-jj/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-git-interactive-rebase-to-jj/SKILL.md
@@ -14,7 +14,7 @@ A comprehensive guide for Git users transitioning to Jujutsu, mapping all intera
 > In this repo a pushed `wip` deploy bookmark additionally tracks `@`, so machines rebuild from it.
 > Inside a join never `jj describe @`, never `jj rebase -r @` / `--revisions @`, and never bare `jj squash -r @` (the form at the squashing example below advances `@` through a chain and consumes the `[wip]`).
 > Route changes downward while leaving `@` empty in place with `jj squash --from @ --insert-after <target> -m "..." --keep-emptied [-- <paths>]` (or `--insert-before`), `jj absorb` (documented below as the blame-routed down-route), or `jj split` keeping the wip.
-> Canonical rule, the single-shared-`[wip]` invariant, and rationale live in `~/.claude/skills/jj-version-control/diamond-workflow.md`; join mechanics in `~/.claude/skills/jj-version-control/SKILL.md`; non-interactive command execution in `~/.claude/skills/jj-workflow/SKILL.md`.
+> Canonical rule, the single-shared-`[wip]` invariant, and rationale live in the `jj-version-control` skill's `diamond-workflow.md`; join mechanics in `jj-version-control`; non-interactive command execution in `jj-workflow`.
 
 ## Table of Contents
 
@@ -183,7 +183,7 @@ jj squash -r @      # D squashed into C, @ now points to C
 > Single-chain cleanup only.
 > In a development join `@` is the shared empty `[wip]` sitting on the multi-parent join, so `jj squash -r @` would consume that `[wip]` into its parent and re-point `@` — emptying the editing surface concurrent actors write to and, in this repo, dragging the pushed `wip` deploy bookmark.
 > There, route changes downward with `jj squash --from @ --insert-before <target> --keep-emptied -m "..."` (or `--insert-after <target>`), which leaves `@` empty and in place, or `jj absorb`.
-> See `~/.claude/skills/jj-version-control/diamond-workflow.md`.
+> See the `jj-version-control` skill's `diamond-workflow.md`.
 
 Or more directly:
 ```bash
@@ -545,7 +545,7 @@ jj split -r <commit> -- file1.txt -m "Part 1"
 | Edit commit without checkout | `jj diffedit -r <commit>` |
 | Duplicate commit | `jj duplicate <commit>` |
 | Duplicate to specific location | `jj duplicate <commit> -d <dest>` |
-| Inside a development join: keep `@` as the empty `[wip]` | Do not `describe @` / `rebase -r @` / bare `squash -r @`; route down with `jj squash --from @ --insert-after <target> -m "..." --keep-emptied`, `jj absorb`, or `jj split` (keep wip). See `~/.claude/skills/jj-version-control/diamond-workflow.md`. |
+| Inside a development join: keep `@` as the empty `[wip]` | Do not `describe @` / `rebase -r @` / bare `squash -r @`; route down with `jj squash --from @ --insert-after <target> -m "..." --keep-emptied`, `jj absorb`, or `jj split` (keep wip). See the `jj-version-control` skill's `diamond-workflow.md`. |
 
 #### Commit Reordering & Moving
 

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-history-cleanup/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-history-cleanup/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Jujutsu history cleanup
 
-**IMPORTANT for AI agents**: Commands like `jj describe -r` and `jj split <paths>` require `-m "message"` flag for non-interactive execution. See `~/.claude/skills/jj-workflow/SKILL.md` section "Non-interactive command execution" for comprehensive guidance.
+**IMPORTANT for AI agents**: Commands like `jj describe -r` and `jj split <paths>` require `-m "message"` flag for non-interactive execution. See `jj-workflow` §"Non-interactive command execution" for comprehensive guidance.
 
 ## Purpose
 
@@ -39,7 +39,7 @@ Use the operation log (`jj op log`) as your safety net instead of backup branche
 
 ## Operations
 
-For detailed command mappings from git interactive rebase, see `~/.claude/skills/jj-git-interactive-rebase-to-jj/SKILL.md`.
+For detailed command mappings from git interactive rebase, see `jj-git-interactive-rebase-to-jj`.
 
 ### Reorder commits
 
@@ -470,7 +470,7 @@ Auto-rebase of `@` triggered by editing its ancestors is safe and jj-managed, an
 What you must never do is make `@` itself a content commit or relocate it off the join: do not `jj describe @` (consumes the wip into a content commit) and do not relocate it via the positional forms `jj rebase -r @ --insert-before/--insert-after <target>` or `jj rebase --revisions @ --insert-before/--insert-after <target>` (drops the wip into a chain interval).
 Either removes the shared editing surface other actors are concurrently writing and breaks the diamond invariants.
 To route a change down a chain while leaving `@` empty, use `jj absorb` (above) — the preferred routing-down verb in a development join, which distributes the working-copy diff into the commits that last touched each path while leaving `@` in place and empty — or `jj squash --from @ --into <chain-tip> --keep-emptied [-- <paths>]` (amend, `-m` omitted to preserve the tip description) and `jj squash --from @ --insert-after/--insert-before <target> -m "msg" --keep-emptied [-- <paths>]` (append/splice), each carrying explicit `-m` for non-interactive safety.
-The six diamond invariants and the never-rewrite-`@` discipline are canonical in `~/.claude/skills/jj-version-control/SKILL.md` and `jj-version-control/diamond-workflow.md`; defer to them for the join-safe routing and splice recipes before applying any cleanup idiom from this skill.
+The six diamond invariants and the never-rewrite-`@` discipline are canonical in the `jj-version-control` skill's `SKILL.md` and `diamond-workflow.md`; defer to them for the join-safe routing and splice recipes before applying any cleanup idiom from this skill.
 
 The linear-chain idioms throughout this skill assume a single chain rooted at `main` with `@` at its tip, and several of them move or reuse `@` (the per-commit `jj new $commit` test loop under "Verify atomicity", `jj bookmark set ... -r @`, `jj squash -r <c>  # into current @`).
 In a multi-parent development join `@` is the shared empty `[wip]` sitting on the join: never `jj describe @` and never positional `jj rebase -r @`/`--revisions @ --insert-before/--insert-after`, since either drifts the wip off the join, breaks concurrent editing, and drags the pushed `wip` deploy bookmark below the join.
@@ -494,7 +494,7 @@ Recovery: `jj undo`.
 - `jj op restore <id>` returns to any prior state
 - Test incrementally instead of at the end
 - `jj revert` reverses a change. Requires explicit placement: `--onto`, `--insert-before`, or `--insert-after`.
-- Reference `~/.claude/skills/jj-git-interactive-rebase-to-jj/SKILL.md` for detailed command mappings
+- Reference `jj-git-interactive-rebase-to-jj` for detailed command mappings
 
 ## Advanced patterns
 

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-summary/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-summary/SKILL.md
@@ -5,7 +5,7 @@ description: Jujutsu workflow summary with essential paradigm shifts and decisio
 
 # Jujutsu workflow summary
 
-Quick reference and decision guide for jj version control. Full documentation: ~/.claude/skills/jj-workflow/SKILL.md
+Quick reference and decision guide for jj version control. Full documentation: `jj-workflow`
 
 ## When to read full documentation
 
@@ -145,7 +145,7 @@ jj bookmark set <bookmark> -r <id>        # Advance bookmark to new tip (use the
 # Route-and-extend multi-commit-range form: relocate an N-commit linear segment into a chain
 jj rebase --revisions '<range-start>::<range-end>' --insert-after <chain-tip>
 jj bookmark set <chain-bookmark> -r <range-end>
-# See ~/.claude/skills/jj-version-control/SKILL.md §"Extending a chain with a new commit (route-and-extend pattern)" → Multi-commit-range form
+# See `jj-version-control` §"Extending a chain with a new commit (route-and-extend pattern)" → Multi-commit-range form
 # Add/remove chains dynamically:
 # name one -d per chain the join is to carry afterward
 jj rebase -r @ -d <chain-a> -d <chain-b> -d new-bm    # Add chain to the development join
@@ -162,13 +162,13 @@ jj squash --from @ --insert-before 'children(fork_point(parents(<join>))) & ::<j
 # Precondition (by-relocation only): relocation set's files must be disjoint from any chain's files
 # (skill/aggregator files frequently collide; on collision use route-and-extend or new-chain instead)
 jj rebase --revisions <separate-sealed-non-wip-commit> --insert-before 'children(fork_point(parents(<join>))) & ::<join>'
-# See ~/.claude/skills/jj-version-control/SKILL.md §"Splice-below-join"
+# See `jj-version-control` §"Splice-below-join"
 
 # Diamond integration on remote advance: rebase diamond onto fast-forwarded remote
 jj git fetch
 jj rebase --source 'roots(<base>@origin..@)' --destination '<base>@origin'
 jj bookmark set <base> -r '<base>@origin'
-# See ~/.claude/skills/jj-version-control/SKILL.md §"Diamond integration on remote advance"
+# See `jj-version-control` §"Diamond integration on remote advance"
 
 # Diamond-health diagnostic (surfaces all five diamond invariants in one view)
 jj log -r 'present(@) | ancestors(immutable_heads().., 2) | trunk()'
@@ -316,7 +316,7 @@ jj rebase -r @ -d <chain-a> -d <chain-b>                   # Remove chain
 **Diamond workflow (epic-scoped, four phases):**
 
 The diamond connects a beads epic graph to jj chain topology via diverge, develop, converge, serialize.
-Canonical recipe: `~/.claude/skills/jj-version-control/diamond-workflow.md`.
+Canonical recipe: the `jj-version-control` skill's `diamond-workflow.md`.
 
 ```bash
 # Pre-edit recon: which chain (if any) already touched this file?
@@ -366,7 +366,7 @@ jj log -r 'mine() & ~bookmarks()'
 - **No backup branches**: Use `jj op log` and `jj op restore` instead
 - **Bookmarks stay put**: Explicitly move with `jj bookmark set`, don't assume movement
 - **@ is ephemeral**: Working copy commit constantly rewritten, bookmark @ parent not @
-- **@ stays empty `[wip]` in a development join**: when a multi-parent join exists, `@` is the empty `[wip]` directly atop `[merge]` and the SHARED editing surface for all concurrent editors. Never `jj describe @` into a content commit and never `jj rebase -r @` / `jj rebase --revisions @` — both drift `@` off `[wip]`, vanish the shared coordination point, break the join's one-child invariant (vi), and (in this repo) drag the pushed `wip` deploy bookmark. Route DOWN into the owning chain via `jj squash --from @ … --keep-emptied`, `jj absorb`, or `jj split` (keeping the wip). Canon: `~/.claude/skills/jj-version-control/SKILL.md` §development join / invariants (iii-b)/(vi), and `diamond-workflow.md`.
+- **@ stays empty `[wip]` in a development join**: when a multi-parent join exists, `@` is the empty `[wip]` directly atop `[merge]` and the SHARED editing surface for all concurrent editors. Never `jj describe @` into a content commit and never `jj rebase -r @` / `jj rebase --revisions @` — both drift `@` off `[wip]`, vanish the shared coordination point, break the join's one-child invariant (vi), and (in this repo) drag the pushed `wip` deploy bookmark. Route DOWN into the owning chain via `jj squash --from @ … --keep-emptied`, `jj absorb`, or `jj split` (keeping the wip). Canon: `jj-version-control` §development join / invariants (iii-b)/(vi), and `diamond-workflow.md`.
 - **Conflicts are first-class**: Committed and resolved when convenient, never blocking
 - **Detached HEAD is normal**: In a jj-colocated repo, detached HEAD is the expected state. Do not attempt to reattach HEAD or "fix" this.
 
@@ -380,25 +380,25 @@ jj log -r 'mine() & ~bookmarks()'
 
 2. Need PR/CI validation via buildbot flake checks (multi-platform fleet matrix, large change benefiting from unified PR review, or fleet-wide gate before trunk)?
    → Tier 2: single named bookmark created retroactively on the chain.
-   `jj bookmark create <name> -r <change-id>` then `jj git push --bookmark <name>`; follow `~/.claude/skills/nix-flake-pr-cycle/SKILL.md`.
+   `jj bookmark create <name> -r <change-id>` then `jj git push --bookmark <name>`; follow `nix-flake-pr-cycle`.
 
 3. Multiple independent work streams in flight (multiple beads issues within an epic, parallel agent dispatch, parallel experiments to compose)?
    → Tier 3: diamond workflow via development join over the chains' bookmarks.
    `jj new <existing-bookmark> <new-bookmark> -m "join N=2: <alphabetical bookmarks, comma-separated>"`; route edits via `jj squash --from @ --into <tip> -u` plus `jj bookmark move <name> --to <tip>`, and rewrite the `[merge]` description in full whenever the parent set changes so it always reflects the current `join N=<cardinality>: <alphabetical bookmarks>` state.
-   - Mid-diamond commit belongs on `<base>` below all chains → splice-below-join (see `~/.claude/skills/jj-version-control/SKILL.md` §"Splice-below-join")
-   - Remote `<base>` advanced during diamond work → diamond integration on remote advance (see `~/.claude/skills/jj-version-control/SKILL.md` §"Diamond integration on remote advance")
+   - Mid-diamond commit belongs on `<base>` below all chains → splice-below-join (see `jj-version-control` §"Splice-below-join")
+   - Remote `<base>` advanced during diamond work → diamond integration on remote advance (see `jj-version-control` §"Diamond integration on remote advance")
 
 4. Does something outside this session need its own filesystem tree (an external framework driving its own agent process, a long-running build, side-by-side comparison), or did the user explicitly request isolation by name (`worktree`, `workspace`, `isolate`, `separate working copy`, or path forms like `.worktrees/X`)?
    → Create a separate tree; otherwise stay at tier 3 and parallelize via the development join in a single working copy, which remains the default for parallel chains.
    In a flake repository that tree is a `git worktree add`, not `jj workspace add`, because a jj workspace has no `.git` and flake evaluation there loses the revision.
    `EnterWorktree`, `git worktree add` against a jj-colocated repository, and subagent dispatch (tool name `Agent`) with `isolation: "worktree"` each raise an ask; `ExitWorktree` is ungated.
-   Before creating one, read `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop" — exclusive branch ownership and return-by-ref are the load-bearing rules.
+   Before creating one, read `jj-version-control` §"Worktree interop" — exclusive branch ownership and return-by-ref are the load-bearing rules.
 
 **Should I read jj-workflow.md?**
 1. Never used jj? → Read "Core philosophy" and "Foundation"
 2. Need parallel experiments? → Read "Parallel experimentation" and `jj-version-control/tiered-ceremony.md` tier 3
 3. A separate filesystem tree is warranted? → Read "Workspace creation" there, and `jj-version-control/SKILL.md` §"Worktree interop" for the git-worktree form a flake repository requires
-4. Working on 2+ independent chains? → Tier 3 development join over per-chain bookmarks; see `~/.claude/skills/jj-version-control/SKILL.md` for mechanics and `tiered-ceremony.md` for the policy.
+4. Working on 2+ independent chains? → Tier 3 development join over per-chain bookmarks; see `jj-version-control` for mechanics and `tiered-ceremony.md` for the policy.
 5. Cleaning history? → Read "History refinement"
 6. Integrating work? → Read "Advanced patterns"
 7. Just need command? → Check "Quick command reference" above or "Reference" section
@@ -411,6 +411,6 @@ jj log -r 'mine() & ~bookmarks()'
 
 ## For full documentation
 
-- Full jj workflow reference: `~/.claude/skills/jj-workflow/SKILL.md`
-- Development join workflow, beads integration: `~/.claude/skills/jj-version-control/SKILL.md`
-- VCS mode detection, beads conventions: `~/.claude/skills/preferences-git-version-control/SKILL.md`
+- Full jj workflow reference: `jj-workflow`
+- Development join workflow, beads integration: `jj-version-control`
+- VCS mode detection, beads conventions: `preferences-git-version-control`

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/SKILL.md
@@ -1550,7 +1550,7 @@ Its fleet-sync runs `git fetch --prune`, `git branch -D` on gone-tracking branch
 
 Cite upstream `jj-vcs/jj` source by symbol and file rather than by line, following `preferences-documentation` §"Citing source files".
 
-The local clone at `~/ghq/github.com/jj-vcs/jj` is shallow at `v0.44.0-12-g8f29cac` while the installed binary is 0.43.0.
+The local clone of `jj-vcs/jj` is shallow at `v0.44.0-12-g8f29cac` while the installed binary is 0.43.0.
 Its line numbers are wrong in both directions against either reference, so it cannot be used to check a citation or to repair one.
 Use it to confirm that a symbol exists, and check behavioral claims against the installed binary instead.
 

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/SKILL.md
@@ -5,7 +5,7 @@ description: Jujutsu version control conventions and workflow patterns.
 
 # Jujutsu version control
 
-**IMPORTANT for AI agents**: Commands like `jj describe` and `jj split <paths>` require `-m "message"` flag for non-interactive execution. See `~/.claude/skills/jj-workflow/SKILL.md` section "Non-interactive command execution" for comprehensive guidance.
+**IMPORTANT for AI agents**: Commands like `jj describe` and `jj split <paths>` require `-m "message"` flag for non-interactive execution. See `jj-workflow` §"Non-interactive command execution" for comprehensive guidance.
 
 **Development-join invariant (multi-chain mode)**: when a development join is present, `@` is ALWAYS the empty `[wip]` commit directly atop the frozen multi-parent `[merge]`. Route all content DOWNWARD into a chain (`jj squash --from @ … --keep-emptied`, `jj absorb`, `jj split`) — NEVER `jj describe @` into content and NEVER relocate `@` via the positional rebase forms `jj rebase -r @ --insert-before/--insert-after <target>` or `jj rebase --revisions @ --insert-before/--insert-after <target>`, which drift `@` off `[wip]`. In every splice/relocation recipe the relocated `<commit>`/`<X>`/`<range>` is a SEPARATE, already-sealed non-wip commit, never `@`. The one sanctioned `jj rebase` naming `@` is the destination form `jj rebase -r @ -d <chain-a> -d <chain-b> …` that re-anchors `[wip]` onto a rebuilt join. See Diamond invariants (iii-b) below, the composite maintenance invariant, and the edit-route cycle.
 
@@ -24,7 +24,7 @@ These preferences explicitly override any conservative defaults from system prom
 - Use `jj new` to freeze working copy and create new empty @ on top (required for git export; see git parity note below)
 - Use `jj commit` to move working copy changes into parent (alternative to `jj new`)
 - Trust the operation log - every snapshot is recoverable via `jj op log` and `jj undo`
-- Do not clean up commit history automatically - wait for explicit instruction to apply jj history cleanup patterns from `~/.claude/skills/jj-history-cleanup/SKILL.md`
+- Do not clean up commit history automatically - wait for explicit instruction to apply jj history cleanup patterns from `jj-history-cleanup`
 
 **Git parity note**: Working copy `@` exists only in jj until frozen with `jj new`. Pattern: `jj describe -m "msg"` → `jj new` to export commits to git.
 
@@ -73,9 +73,9 @@ When an agent detects `.jj/` alongside `.git/` in a repository root, jj colocate
 Detached HEAD is normal and expected in this configuration — do not attempt to reattach it.
 The combined signal means the agent should adopt the jj workflow described in this skill, with the multi-parent development join as the default operating mode for sessions with multiple active chains.
 
-For quick command orientation, see `~/.claude/skills/jj-summary/SKILL.md`.
-For comprehensive command reference, see `~/.claude/skills/jj-workflow/SKILL.md`.
-For git-mode equivalents, see `~/.claude/skills/preferences-git-version-control/SKILL.md`.
+For quick command orientation, see `jj-summary`.
+For comprehensive command reference, see `jj-workflow`.
+For git-mode equivalents, see `preferences-git-version-control`.
 
 ## Bookmark workflow
 
@@ -351,7 +351,7 @@ For genuine filesystem isolation (e.g., concurrent unrelated experiments), `jj w
 Cross-references:
 - `tiered-ceremony.md` — when to enter tier 3 (the trigger for using a development join at all)
 - `diamond-workflow.md` — the four-phase process (diverge, develop, converge, serialize) in which the development join participates
-- `~/.claude/skills/preferences-git-version-control/03-jj-mode.md` — mode-detection context and equivalences with git-native and GitButler modes
+- The `preferences-git-version-control` skill's `03-jj-mode.md` — mode-detection context and equivalences with git-native and GitButler modes
 
 ### Two-commit structure: join + wip structure
 
@@ -1260,7 +1260,7 @@ jj git push --bookmark chain-a
 gh pr create -d -a "@me" -B main -H chain-a -t "feat: description" -b ""
 ```
 
-Follow the PR creation protocol in `~/.claude/skills/preferences-git-version-control/SKILL.md` for placeholder content and safety conventions.
+Follow the PR creation protocol in `preferences-git-version-control` for placeholder content and safety conventions.
 
 For GitHub-only repositories, Mergify's Stack-Aware Base feature would handle single-CI-gate behavior natively without an explicit aggregate PR; see the footnote in `diamond-workflow.md` Phase 4 for the trade-off against forge-agnostic compatibility.
 
@@ -1548,7 +1548,7 @@ Its fleet-sync runs `git fetch --prune`, `git branch -D` on gone-tracking branch
 
 ## Citing upstream jj source
 
-Cite upstream `jj-vcs/jj` source by symbol and file rather than by line, following "Citing source files" in `~/.claude/skills/preferences-documentation/SKILL.md`.
+Cite upstream `jj-vcs/jj` source by symbol and file rather than by line, following `preferences-documentation` §"Citing source files".
 
 The local clone at `~/ghq/github.com/jj-vcs/jj` is shallow at `v0.44.0-12-g8f29cac` while the installed binary is 0.43.0.
 Its line numbers are wrong in both directions against either reference, so it cannot be used to check a citation or to repair one.

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/diamond-workflow.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/diamond-workflow.md
@@ -5,7 +5,7 @@ It describes the diamond workflow pattern that connects beads epic issue graphs 
 
 The companion design note at `docs/notes/development/version-control/epic-to-branch-diamond-workflow.md` is the theoretical foundation with full citations (Winskel event structures, Dilworth's antichain theorem, Lamport's partial order, Beer's VSM, Krycho's effective theory); when the *why* is in question, read the design note.
 The sibling `tiered-ceremony.md` is the policy authority for *when* the diamond workflow applies — it answers "should I be using the diamond at all?" before this document answers "how do I run a diamond?".
-The sibling `~/.claude/skills/jj-version-control/SKILL.md` is the operational entity-level reference for the development join itself (the multi-parent `@`, conflict behavior, edit-route cycle, route-and-extend recipe); when you need the day-to-day mechanics of working in a join, look there.
+The sibling `SKILL.md` is the operational entity-level reference for the development join itself (the multi-parent `@`, conflict behavior, edit-route cycle, route-and-extend recipe); when you need the day-to-day mechanics of working in a join, look there.
 
 ## Two-peer ontology: process and entity
 
@@ -139,7 +139,7 @@ Independent chains within the same linearization step can be ordered discretiona
    Throughout the develop phase `@` stays the single empty `[wip]` directly atop `[merge]` (invariant (iii)/(vi)); this shared `[wip]` is the stable coordination point that lets multiple concurrent editors write the same integrated surface safely.
    Route every change DOWN from `@` using only `@`-preserving verbs — `jj squash --from @ … --keep-emptied`, `jj absorb`, or `jj split` keeping the wip — and never `jj describe @` into content nor make `@` the subject of `jj rebase` / `--revisions @`, which drift `@` off `[wip]`, remove the surface other actors are concurrently writing, and (in this repo) drag the pushed `wip` deploy bookmark that machines rebuild from.
    The one sanctioned `jj rebase` touching `@` is the destination add/remove-chain form `jj rebase -r @ -d <chain-a> -d <chain-b> …`, which keeps `@` an empty child of the rebuilt join; the positional `--insert-before` / `--insert-after` (and the `-A` / `-B` aliases) forms are the prohibited ones.
-   See `~/.claude/skills/jj-version-control/SKILL.md` invariant (iii-b) for the canonical statement.
+   See the sibling `SKILL.md` invariant (iii-b) for the canonical statement.
    Each route from `[wip]` to a chain is either an append-route (default: land a new atomic commit on the chain) or an amend-route (fixups against the existing tip).
    The append-route is the default for landing new work:
    ```bash
@@ -152,7 +152,7 @@ Independent chains within the same linearization step can be ordered discretiona
    As of jj 0.43.0, `jj squash --help` documents `-o`, `-A`, and `-B` under a heading of EXPERIMENTAL FEATURES.
    `--keep-emptied` preserves the single shared `[wip]` on top of `[merge]` (invariant (vi)); the bookmark-move is a separate explicit step because jj does not auto-advance a bookmark onto a newly inserted commit.
    Target the new commit's change ID from the `Created new commit <id>` output line, not `@-`: in a multi-parent join, `@-` resolves to the rebuilt `[merge]` (the new commit is one of its parents, not a direct ancestor of `@`), and pointing the bookmark there advances `<chain>` onto `[merge]`.
-   See `~/.claude/skills/jj-version-control/SKILL.md` §"Routing to a chain: append vs amend" for the full rationale and the amend-route fixup recipe.
+   See the sibling `SKILL.md` §"Routing to a chain: append vs amend" for the full rationale and the amend-route fixup recipe.
 
    Path-restriction (`-- <paths>`) can be added to either recipe when multiple streams' hunks coexist in `[wip]` and only one stream's paths should be routed in this operation.
 
@@ -196,11 +196,11 @@ jj describe <merge-change-id> -m "join N=k+1: <alphabetical bookmarks including 
 Step 4 is the second half of the `jj rebase -r <merge>` tool-pair documented in `SKILL.md` §"Re-attaching `[wip]` after `jj rebase -r <merge>`".
 Steps 3 and 4 are one sequence: issuing step 3 without step 4 leaves `@` a two-parent merge at the old parent set with the rebuilt join orphaned.
 Step 4 names `[merge]`'s former direct child and uses `-s` so that its descendants come along; `-r` would move `[wip]` alone and orphan any commits stacked above it.
-After step 5, run the diamond-health diagnostic from `~/.claude/skills/jj-version-control/SKILL.md` as a sanity check on the executed recipe.
+After step 5, run the diamond-health diagnostic from the sibling `SKILL.md` as a sanity check on the executed recipe.
 
 ### Phase 3: converge (validate)
 
-The converge phase occurs *at* a planning-DAG convergence point in the sense used by `~/.claude/skills/preferences-adaptive-planning/SKILL.md` and `~/.claude/skills/session-review/SKILL.md` — the diamond's converge phase and the planning DAG's topological convergence node refer to the same shape of synchronization point in the workflow.
+The converge phase occurs *at* a planning-DAG convergence point in the sense used by `preferences-adaptive-planning` and `session-review` — the diamond's converge phase and the planning DAG's topological convergence node refer to the same shape of synchronization point in the workflow.
 
 7. The development join working copy represents the full integration.
 8. Run tests, manual QA, and integration validation against the development join.
@@ -307,19 +307,19 @@ Invariant for every operation in this section: `@` is and stays the empty `[wip]
 Never `jj describe @` into a content commit and never make `@` the subject of `jj rebase` / `--revisions @` (nor the positional `--insert-before` / `--insert-after` / `-A` / `-B` forms); the by-relocation arm below relocates a SEPARATE, already-sealed non-wip commit, and `<X>` is never `@`/`[wip]`.
 Drifting `@` below the join removes the shared `[wip]` that concurrent editors write to — the stable coordination point that makes N concurrent editors safe by construction — and, in this repo, drags the pushed `wip` deploy bookmark below the join, from which machines rebuild.
 Route content that is still live in `@` DOWN with `jj squash --from @ … --keep-emptied`, which leaves `@` empty atop the join; only relocate already-sealed separate commits.
-See `~/.claude/skills/jj-version-control/SKILL.md` invariant (iii-b) for the canonical statement.
+See the sibling `SKILL.md` invariant (iii-b) for the canonical statement.
 
 **Splice-below-join** handles `<base>`-bound commits — hotfixes, formatting, config tweaks, dependency bumps — that should land on `<base>` before the diamond's chains.
 Two arms: *by-construction* (author the commit directly in the splice position with `jj new --insert-before 'children(fork_point(parents(<join>))) & ::<join>'`) and *by-relocation* (move an EXISTING, SEPARATE, already-sealed NON-wip commit `<X>` — `<X>` MUST NOT be `@`/`[wip]` — from above the join into the splice region with `jj rebase --revisions <X> --insert-before 'children(fork_point(parents(<join>))) & ::<join>'`).
 Never `jj describe @` then `jj rebase --revisions @ --insert-before <splice-target>`: that drifts `@` off `[wip]`, opens a transient window with NO `[wip]` on the join (catastrophic under concurrency), and (in this repo) drags the pushed `wip` deploy bookmark below the join.
 When the change is still live in `@`, route it down with `jj squash --from @ --insert-before 'children(fork_point(parents(<join>))) & ::<join>' -m "fix(scope): description" --keep-emptied -- <paths>` instead, which leaves `@` empty atop the join.
 The accumulated splice region fast-forwards `<base>` independently of when the diamond's chains land in Phase 4.
-See `~/.claude/skills/jj-version-control/SKILL.md` §"Splice-below-join" for the full recipe, anti-patterns (naked `--insert-after <base>`, single-target `--insert-before <one-root>`, `jj rebase -r <X> -d <base>` destination form), and verification.
+See the sibling `SKILL.md` §"Splice-below-join" for the full recipe, anti-patterns (naked `--insert-after <base>`, single-target `--insert-before <one-root>`, `jj rebase -r <X> -d <base>` destination form), and verification.
 
 **Diamond integration on remote advance** handles the case where `<base>@origin` advances during diamond work — typically because a collaborator merged to remote, or a dependency-update bot pushed.
 The recipe rebases the entire diamond (splice region if any, chain roots, chains, chain tips, join, `@`) onto the new remote tip in one operation, after `jj git fetch`.
 This is distinct from Phase 4 serialize: it preserves the diamond shape rather than linearizing it.
-See `~/.claude/skills/jj-version-control/SKILL.md` §"Diamond integration on remote advance" for the recipe, the breakdown of what `jj git fetch` handles automatically versus the diamond-on-old-base gap requiring explicit rebase, and verification.
+See the sibling `SKILL.md` §"Diamond integration on remote advance" for the recipe, the breakdown of what `jj git fetch` handles automatically versus the diamond-on-old-base gap requiring explicit rebase, and verification.
 
 Both operations target the same topological location — commits between `<base>` and the antichain `children(fork_point(parents(<join>))) & ::<join>`.
 Splice-below-join inserts new commits there during diamond work; diamond integration on remote advance moves the entire diamond above a new `<base>` position, carrying the splice region (if any) with it.
@@ -349,5 +349,5 @@ The adaptive planning skill's MPC framework suggests this depends on requirement
 
 - `docs/notes/development/version-control/epic-to-branch-diamond-workflow.md` — the ratified design note containing the working-document version of the citations above, with motivation, design history, and open questions in their original context.
 - `tiered-ceremony.md` (sibling) — the policy authority establishing when the diamond workflow applies (tier 3 of the three-tier ceremony model); read this before deciding to run a diamond.
-- `~/.claude/skills/jj-version-control/SKILL.md` (sibling) — the operational entity-level reference for the development join (multi-parent `@`, conflict behavior, edit-route cycle, route-and-extend recipe, composite maintenance invariant).
-- `~/.claude/skills/preferences-adaptive-planning/SKILL.md` and `~/.claude/skills/session-review/SKILL.md` — the planning-DAG convergence-point semantics that align with the diamond's converge phase.
+- `SKILL.md` (sibling) — the operational entity-level reference for the development join (multi-parent `@`, conflict behavior, edit-route cycle, route-and-extend recipe, composite maintenance invariant).
+- `preferences-adaptive-planning` and `session-review` — the planning-DAG convergence-point semantics that align with the diamond's converge phase.

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/tiered-ceremony.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-version-control/tiered-ceremony.md
@@ -8,7 +8,7 @@ The diamond workflow is reserved for genuine multi-stream parallel work, not for
 
 For the theoretical treatment of the diamond workflow (lattice theory, event structures, VSM mapping, four-phase recipe), see `diamond-workflow.md` in this directory.
 For the operational reference on the development join entity (edit-route cycle, conflict behavior, join + wip structure, composite maintenance invariant), see `SKILL.md` in this directory.
-For mode-detection context (when this document applies versus git-native or GitButler), see `~/.claude/skills/preferences-git-version-control/03-jj-mode.md`.
+For mode-detection context (when this document applies versus git-native or GitButler), see the `preferences-git-version-control` skill's `03-jj-mode.md`.
 
 ## Tier 1: anonymous chain on `@`
 
@@ -46,7 +46,7 @@ jj bookmark create <name> -r <change-id>   # or -r @- for the chain tip
 jj git push --bookmark <name>
 ```
 
-Then follow `~/.claude/skills/nix-flake-pr-cycle/SKILL.md` for the canonical draft-PR / buildbot-monitor / ready / Mergify sequence.
+Then follow `nix-flake-pr-cycle` for the canonical draft-PR / buildbot-monitor / ready / Mergify sequence.
 
 Operations to integrate: rebase the bookmark onto trunk when ready, then either let Mergify FF-merge the PR or perform the FF merge directly.
 After merge, delete the bookmark and return to tier 1 for subsequent work.

--- a/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-workflow/SKILL.md
+++ b/modules/home/ai/plugins/version-control-and-forge/.apm/skills/jj-workflow/SKILL.md
@@ -77,7 +77,7 @@ Two routes avoid this, neither of which moves `@`: resolve at the join by naming
 Prefer the squash route for a hand-crafted resolution.
 The built-in tools `--tool :ours` and `--tool :theirs` select side #1 and side #2 of the conflict, and which parent those correspond to under a merge with three or more parents is not established here.
 
-`~/.claude/skills/jj-version-control/SKILL.md` holds the full procedure and the join-specific recovery steps.
+`jj-version-control` holds the full procedure and the join-specific recovery steps.
 
 ### Mandatory command verification protocol
 
@@ -171,7 +171,7 @@ All content leaves `@` by routing downward with `@` left in place and empty, via
 
 The splice-below-join must use the `--keep-emptied` squash form, never `jj describe @` followed by `jj rebase --revisions @ --insert-before <target>`: that two-step opens a transient window with no `[wip]` on the join, which is catastrophic under concurrency, and in this repo drags the pushed `wip` deploy bookmark below the join.
 In every splice/relocation recipe the relocated `<commit>`/`<X>`/`<range>` is a separate, already-sealed non-wip commit, never `@`/`[wip]` itself.
-For the canonical invariant statement (iii-b), command templates, and rationale, see `~/.claude/skills/jj-version-control/SKILL.md` §"Development join".
+For the canonical invariant statement (iii-b), command templates, and rationale, see `jj-version-control` §"Development join".
 
 ### Git parity and the `jj new` requirement
 
@@ -440,13 +440,13 @@ Workspace creation is reserved for cases where a separate filesystem tree is its
 Parallel related work in jj mode uses the diamond workflow's development join, which remains the default.
 
 In a flake repository the separate tree must be a `git worktree add` rather than a `jj workspace add`, because a jj workspace has no `.git` and flake evaluation there degrades to a `path:` source with no revision.
-The `jj workspace add` mechanics below therefore apply to non-flake repositories; for the git-worktree path and the discipline that governs it, see `~/.claude/skills/jj-version-control/SKILL.md` §"Worktree interop".
+The `jj workspace add` mechanics below therefore apply to non-flake repositories; for the git-worktree path and the discipline that governs it, see `jj-version-control` §"Worktree interop".
 
 Cross-references:
-- `~/.claude/skills/jj-version-control/tiered-ceremony.md` — policy authority for when ceremony escalates from anonymous chain to bookmarked chain, and for why a separate working copy is not a tier.
-- `~/.claude/skills/jj-version-control/diamond-workflow.md` — default parallel-work technique using multi-parent `@`.
-- `~/.claude/skills/jj-version-control/SKILL.md` "Development join" — the multi-parent working-copy entity that carries parallel work in one tree.
-- `~/.claude/skills/jj-version-control/SKILL.md` "Worktree interop" — the git-worktree alternative, its ownership rules, and its recovery commands.
+- The `jj-version-control` skill's `tiered-ceremony.md` — policy authority for when ceremony escalates from anonymous chain to bookmarked chain, and for why a separate working copy is not a tier.
+- The `jj-version-control` skill's `diamond-workflow.md` — default parallel-work technique using multi-parent `@`.
+- `jj-version-control` §"Development join" — the multi-parent working-copy entity that carries parallel work in one tree.
+- `jj-version-control` §"Worktree interop" — the git-worktree alternative, its ownership rules, and its recovery commands.
 
 ### Trigger condition
 
@@ -714,8 +714,8 @@ The resulting `@` is a development join.
 When a parent bookmark advances (via `squash --into`, `absorb`, commits from another workspace, collaborator push, or `jj git fetch`), jj automatically rebases `@` onto the updated parents.
 The development join's working tree stays current without manual rebase steps.
 
-For the operational workflow, conflict semantics, edit-route cycle, route-and-extend pattern, composite-maintenance invariant, and beads-integration recipes, see `~/.claude/skills/jj-version-control/SKILL.md` §"Development join".
-For the cross-tool terminology mapping ("GitButler equivalence mapping"), see `~/.claude/skills/preferences-git-version-control/03-jj-mode.md`.
+For the operational workflow, conflict semantics, edit-route cycle, route-and-extend pattern, composite-maintenance invariant, and beads-integration recipes, see `jj-version-control` §"Development join".
+For the cross-tool terminology mapping ("GitButler equivalence mapping"), see the `preferences-git-version-control` skill's `03-jj-mode.md`.
 For background on multi-parent `jj new` and the design rationale, see Chris Krycho's ["jj init" essay](https://raw.githubusercontent.com/chriskrycho/v5.chriskrycho.com/d3f989498a3828aeb7e5e816e115b9fc0196d8d0/site/essays/jj%20init.md), particularly the section on creating three-parent merges.
 
 ## History refinement
@@ -763,7 +763,7 @@ Each step executes immediately. Use `jj undo` to back out of any step.
 
 These rebase-by-revision recipes assume `<commit>` is a stacked, non-wip commit in a single chain.
 When a multi-parent development join is present (see "Composite working copy maintenance" above and §"Diamond workflow"), never pass `@` (the empty `[wip]`) as the rebased revision: relocating `@` below the join destroys the shared editing surface concurrent actors write to and drags the pushed `wip` deploy bookmark.
-To splice a fix below the join from the working copy, use `jj squash --from @ --insert-before <target> -m "msg" --keep-emptied -- <paths>`, which leaves `@` in place and empty; see the splice-below-join recipe in `~/.claude/skills/jj-version-control/SKILL.md` §"Development join".
+To splice a fix below the join from the working copy, use `jj squash --from @ --insert-before <target> -m "msg" --keep-emptied -- <paths>`, which leaves `@` in place and empty; see the splice-below-join recipe in `jj-version-control` §"Development join".
 
 Reorder commits:
 
@@ -1018,7 +1018,7 @@ If any step fails, `jj undo` backs out immediately.
 
 The diamond workflow connects beads epic issue graphs to jj chain topology through four phases: diverge, develop, converge, serialize.
 Tactical commands at use-sites include `jj new chain-a chain-b ...` for the development join, `jj describe -m "join N=<cardinality>: <alphabetical bookmarks, comma-separated>"` then `jj new` for the join + wip structure, and `jj squash --from <src> --into <chain>` for routing changes.
-For the canonical operational recipe, theoretical foundations, and beads-to-jj mapping, see `~/.claude/skills/jj-version-control/diamond-workflow.md`.
+For the canonical operational recipe, theoretical foundations, and beads-to-jj mapping, see the `jj-version-control` skill's `diamond-workflow.md`.
 
 ### Integration strategies
 
@@ -1055,7 +1055,7 @@ jj git push --bookmark main
 
 Integrate multiple experiments (when both valuable):
 
-For dissolving a development join and sequential rebase linearization of N chains onto main, see `~/.claude/skills/jj-version-control/SKILL.md` §"Integration strategies at completion" (canonical entity reference) and `~/.claude/skills/jj-version-control/diamond-workflow.md` §"Phase 4: serialize (integrate)" (full recipe including N+1 stacked-base PR submission).
+For dissolving a development join and sequential rebase linearization of N chains onto main, see `jj-version-control` §"Integration strategies at completion" (canonical entity reference) and the `jj-version-control` skill's `diamond-workflow.md` §"Phase 4: serialize (integrate)" (full recipe including N+1 stacked-base PR submission).
 
 ### Sub-experiments within experiments
 
@@ -1336,7 +1336,7 @@ jj absorb                      # Auto-distribute @ to ancestors
 #   concurrency, drags the pushed wip deploy bookmark, breaks the one-child invariant); jj describe @ consumes
 #   the wip into content. Route down instead via jj absorb or
 #   jj squash --from @ --into/--insert-after <target> --keep-emptied.
-#   See "Composite working copy maintenance" and ~/.claude/skills/jj-version-control/SKILL.md §"Development join".
+#   See "Composite working copy maintenance" and `jj-version-control` §"Development join".
 jj rebase -r <commit> -d <dest>       # Move commit to new parent
 jj rebase -s <commit> -d <dest>       # Move commit and descendants
 jj rebase -r <commit> -A <after>      # Insert after commit
@@ -1403,7 +1403,7 @@ Use explicit operation IDs from session start for precise ranges.
 - Operation log is history (commits are snapshots, operations are timeline)
 - Bookmarks don't move automatically (only on commit rewrites)
 - Working copy commit `@` is ephemeral in solo work (constantly rewritten); in a multi-parent development join it is held STABLE as the empty `[wip]` coordination point — do not treat it as freely rewritable (see "Composite working copy maintenance")
-- `@` is the stable `[wip]` in a development join: when a multi-parent join is active, `@` is the empty `[wip]` shared by all concurrent editors and tracked by the pushed `wip` deploy bookmark (machines rebuild from it); route changes DOWN with `jj absorb` or `jj squash --from @ --insert-before/--insert-after <target> -m "msg" --keep-emptied [-- <paths>]`, and never `jj describe @` into content nor `jj rebase -r @` / `jj rebase --revisions @` — either drifts `@` off the join, destroys the shared editing surface, and drags the deploy bookmark (see `~/.claude/skills/jj-version-control/SKILL.md` §"Development join")
+- `@` is the stable `[wip]` in a development join: when a multi-parent join is active, `@` is the empty `[wip]` shared by all concurrent editors and tracked by the pushed `wip` deploy bookmark (machines rebuild from it); route changes DOWN with `jj absorb` or `jj squash --from @ --insert-before/--insert-after <target> -m "msg" --keep-emptied [-- <paths>]`, and never `jj describe @` into content nor `jj rebase -r @` / `jj rebase --revisions @` — either drifts `@` off the join, destroys the shared editing surface, and drags the deploy bookmark (see `jj-version-control` §"Development join")
 - Change IDs provide stability (commit IDs change, change IDs don't)
 - No staging area (working copy state is commit state)
 - Conflicts are first-class (committed, resolved when convenient)

--- a/modules/home/ai/skills/default.nix
+++ b/modules/home/ai/skills/default.nix
@@ -1,7 +1,7 @@
 # Unified AI agent skills for claude-code, codex, opencode, droid, and hermes-agent
 #
 # First-party skills (apm packages under ../plugins/<package>/.apm/skills, e.g. the
-# 11 openspec-* skills shipped inside planning-and-development) plus superpowers — a
+# openspec-* skills shipped inside planning-and-development) plus superpowers — a
 # regular remote apm dependency resolved offline via the git-cache pre-warm (D11) —
 # are composed offline into a single flat marketplace tree by aiSkills.composed (see
 # compose.nix). This module re-globs that derivation's .claude/skills/ subtree, so

--- a/modules/home/tools/agents-md.nix
+++ b/modules/home/tools/agents-md.nix
@@ -6,23 +6,8 @@
 { ... }:
 {
   flake.modules.homeManager.tools =
-    { config, lib, ... }:
-    let
-      # Base path for skills (without @ prefix)
-      # The @ prefix triggers Claude Code auto-loading; applied deliberately
-      # and selectively, currently only to the style-and-conventions skill,
-      # which applies to every artifact any session produces
-      # All tools share the same text; @ auto-loading is Claude Code-specific
-      skillsPath = "${config.home.homeDirectory}/.claude/skills";
-    in
+    { lib, ... }:
     {
-      # https://github.com/mirkolenz/nixos/blob/0911e2e/home/options/agents-md.nix#L22-L31
-      #
-      # The @ prefix on a full path triggers auto-loading in generated
-      # CLAUDE.md; applied selectively, not to every skill. The topical index
-      # of proactively-read skills previously maintained here is archived in
-      # modules/home/ai/plugins/README.md
-      #
       # Two harness hazards worth recording here rather than fixing: omp
       # resolves exactly one user-level context file by provider priority,
       # and ~/.omp/agent/AGENTS.md at priority 100 would outrank
@@ -48,8 +33,7 @@
           authorship — repositories we maintain live under `~/projects/<repo>/`,
           repositories we only read live under `~/ghq/<host>/<org>/<repo>/`. The
           full lookup procedure, on-miss acquisition, and the `(see local)`
-          marker directive live in
-          ${skillsPath}/dependency-source-acquisition/SKILL.md.
+          marker directive live in the `dependency-source-acquisition` skill.
           4. Should I present my task decomposition for approval before
           dispatching?
 
@@ -75,10 +59,9 @@
 
           # Development guidelines
 
-          The style-and-conventions skill governs every artifact this session
-          produces, so it stays force-loaded regardless of topic:
-
-          - style and conventions: @${skillsPath}/preferences-style-and-conventions/SKILL.md
+          The `preferences-style-and-conventions` skill governs every
+          artifact this session produces; load it before writing or editing
+          any artifact, regardless of topic.
 
           Every other skill in this corpus is discoverable through each
           harness's own name-and-description catalog; do not maintain or consult
@@ -99,7 +82,7 @@
           contradictions to the user with provenance evidence — file paths,
           dates, relevant line ranges — rather than silently choosing one
           interpretation. The full procedure and its application scope live in
-          ${skillsPath}/preferences-documentation/SKILL.md under "Temporal
+          the `preferences-documentation` skill §"Temporal
           provenance".
 
           # Operating principles
@@ -123,8 +106,8 @@
           when an assumption is wrong, say so directly and explain why
           rather than building on it.
           Applied per medium:
-          - prose, any writing or editing: ${skillsPath}/preferences-prose-clarity/SKILL.md
-          - code, specs, and proofs: ${skillsPath}/preferences-essential-complexity/SKILL.md
+          - prose, any writing or editing: `preferences-prose-clarity`
+          - code, specs, and proofs: `preferences-essential-complexity`
 
           # Communication
 
@@ -328,8 +311,8 @@
           control; agent teams for parallel independent streams and adversarial
           review; hybrid — DAG research first, then a team for implementation
           and review. For teammate isolation, Linear/OpenSpec-to-task-list
-          mirroring, and the orient/checkpoint lifecycle, see
-          ${skillsPath}/meta-agent-teams/SKILL.md
+          mirroring, and the orient/checkpoint lifecycle, see the
+          `meta-agent-teams` skill.
 
           # Version control and work dispatch
 
@@ -344,15 +327,14 @@
           mode (the default for this workspace); otherwise almost surely
           git-native mode.
 
-          See ${skillsPath}/preferences-git-version-control/SKILL.md for
+          See the `preferences-git-version-control` skill for
           working-branch isolation conventions and subagent dispatch in each
-          mode. For the three-tier ceremony model in jj mode, see
-          ${skillsPath}/jj-version-control/tiered-ceremony.md. For multi-stream
-          parallel work in jj mode, the default is the diamond workflow's
-          development join — see ${skillsPath}/jj-version-control/SKILL.md
-          "Development join" for the entity reference and
-          ${skillsPath}/jj-version-control/diamond-workflow.md for the
-          four-phase process recipe.
+          mode. For the three-tier ceremony model in jj mode, see the
+          `jj-version-control` skill's `tiered-ceremony.md`. For
+          multi-stream parallel work in jj mode, the default is the diamond
+          workflow's development join — see the `jj-version-control` skill
+          §"Development join" for the entity reference and its
+          `diamond-workflow.md` for the four-phase process recipe.
 
           ## Stacked landing protocol
 
@@ -411,8 +393,7 @@
           Read-only inspection takes the global `--ignore-working-copy` so it
           does not snapshot and race a concurrent session. Recovery for the
           destructive class is top-level `jj undo`; there is no `jj op undo`.
-          See ${skillsPath}/jj-version-control/SKILL.md for the diamond
-          workflow.
+          See the `jj-version-control` skill for the diamond workflow.
 
           ## Working-copy hazards
 
@@ -423,8 +404,8 @@
           there is no `jj op undo`. The full catalog — splice impossibility
           below the join, the clan-install second child, the `wip` bookmark
           slide, snapshot size gating, concurrent-session foreign modifications,
-          auto-rebase commit-id churn — lives in
-          ${skillsPath}/jj-version-control/hazards.md.
+          auto-rebase commit-id churn — lives in the `jj-version-control`
+          skill's `hazards.md`.
 
           ## Worktree interop and external frameworks
 
@@ -439,8 +420,8 @@
           fetch --prune`, or `git stash` in a jj working copy. An external agent
           framework such as firstmate gets its own clone rather than a symlink
           to a working copy we also use, because its fleet-sync runs exactly the
-          operations forbidden above. Full mechanics and recovery:
-          ${skillsPath}/jj-version-control/SKILL.md under "Worktree interop"
+          operations forbidden above. Full mechanics and recovery: the
+          `jj-version-control` skill §"Worktree interop".
         '';
       };
     };


### PR DESCRIPTION
Puts every cross-reference in the first-party skill corpus on one harness-neutral convention, and removes every machine-local path that only resolves on one workstation.

Stacked on #2772. Reviewable question: was the convention applied correctly and completely.

## The convention

A skill is cited as a backticked bare name — `` `jj-version-control` `` — with no sigil. A repository is cited as a backticked `owner/repo` handle. A sub-document of the *citing* skill keeps its plain relative path (`references/foo.md`, `hazards.md`), which is the canonical Agent Skills progressive-disclosure form; a sub-document of a *different* skill names both, because a bare relative path resolves against the citing skill's own directory.

Why nothing else works, established by reading the loaders of nine harnesses:

- **No slash form is portable.** Claude Code and droid take `/name`, omp and pi take `/skill:name`, codex takes `$name`, gemini and opencode reserve `/name` for command files, crush has no user skill invocation at all.
- **A slash form in shared prose can execute.** omp's `MID_PROMPT_SKILL_RE` matches `/skill:<name>` *embedded in ordinary prose* of a user draft, so a slash citation that is ever quoted into a prompt invokes a skill nobody asked for. A backtick immediately before the `/` blocks the match.
- **`@<path>` is not Claude-Code-only.** omp expands `@` imports in every context file it loads, ungated, to depth 5. gemini-cli *rejects* an absolute `@` path and substitutes `<!-- Import failed: … - Path traversal attempt -->`.
- **A backticked bare name is inert everywhere and resolves everywhere**, because backticks are the documented escape in every `@`-importer and prose scanner examined, and every harness injects its own name-and-description catalog of the delivered tree.

## Two live defects this fixes

The single `@`-prefixed force-load in the generated user-level context was inlining an entire skill body into every omp session as well as every Claude Code one, and `~/.gemini/GEMINI.md` was carrying that import-failed comment where the force-load was meant to be. The force-load intent survives as a named reference with an explicit loading *condition* — phrased conditionally on purpose, because codex instructs the model that a skill named in plain text must be used for that turn, so a bare list of names in always-loaded prose would push it to load all of them every turn.

Twenty-two further `@`-prefixed paths across five skills were attaching whole files at skill-invocation time in Claude Code and inlining them in omp — unintended context inflation, now gone.

## Repository handles

Every handle was resolved from an actual `git remote` on a located checkout or from a GitHub API response, never inferred from a directory name, because the two frequently disagree. Where a checkout was a fork the citation names the upstream. That process surfaced three factual errors, corrected rather than reformatted: `DuckDB.jl` was cited as a subpath of the DuckDB monorepo, which has no such directory and never did; the EventCatalog MCP server was cited under a repository name that does not exist; and `create-eventcatalog` is archived with its content moved into the monorepo. Two citations resolved to nothing at all and had their unverifiable location claims dropped rather than receiving invented handles.

Private repositories are named by handle too, and where the prose invites a reader to verify the source it now says the tree is private — most sharply in a document whose every finding rests on one private tree while listing exact tool versions that invite checking.

## Deliberately left alone

Paths that are executed or pasted rather than read, since converting an argument of a runnable command breaks it; prose that defines the `~/projects/` layout convention itself, which is most of the `dependency-source-acquisition` skill; and illustrative placeholders naming no real repository. Of 74 repository-path occurrences, 26 converted and 48 were correctly left — the `document-authoring-and-visualization` package has 24 occurrences and zero conversions, all of them `cognee add` arguments, `mkdir`/`cd` lines, or an `--aggregate` default.

## Also in here

Two stray repairs found in passing. A `NOTICE-yaks.md` was linked twice and has never existed; searching for the upstream found `mattwynne/yaks` under MIT, but it is a CLI task tracker with no relation to BRIEF or Rules-versus-Examples, so reproducing its licence would have substituted one misattribution for another. The credit is now self-contained prose naming every party, with no invented copyright line — and **the provenance claim itself may be wrong**, which is worth a second opinion. Separately, a module comment claimed eleven `openspec-*` skills where there are fourteen; the count is replaced by the glob prefix that identifies them.

## Verification

`nix build .#checks.aarch64-darwin.{eval-agents-md,home-manager-crs58}` and `.#apm-skills-compose` all exit 0 — the last proves the corpus still composes and deploys, and the home-manager build exercises the nix-unit assertion pinning `piConfig.context == programs.agents-md.settings.text` across a full generation. A residual sweep leaves only the four intended classes.
