### PR TITLE
feat(devshell): supply the CLIs the skill corpus shells out to

### DIFF
--- a/modules/devshells/default.nix
+++ b/modules/devshells/default.nix
@@ -102,6 +102,18 @@
           # Document typesetting
           pkgs.typstWithPackages
           pkgs.svgo
+          # The skills apm deploys into .agents/skills/ shell out to these CLIs.
+          # Home-manager supplies them on a fleet machine and nowhere else, so
+          # on a CI runner, an agent sandbox, or a fresh checkout a skill loads
+          # and then dies on its first command. duckdb here is the CLI; the
+          # python binding above is a separate output.
+          pkgs.jujutsu
+          pkgs.ghq
+          pkgs.jaq
+          pkgs.duckdb
+          self'.packages.linear-cli
+          self'.packages.mergify-cli-bin
+          inputs'.llm-agents.packages.openspec
         ]
         # buildbot-effects CLI for local dispatch of hercules-ci-effects
         # (see buildbot-nix/docs/EFFECTS.md). Linux-only: depends on bwrap.


### PR DESCRIPTION
## Summary

`just agents-install` deploys 168 skills from the flake, but the CLIs those skills invoke arrive only through home-manager. On a machine without that profile — a CI runner, a cloud agent sandbox, a fresh contributor checkout — a skill loads and then dies on its first command: `meta-search-sessions` on `jaq`, `agentic-planning-development-workflow` on `linear auth whoami`, `mergify-stack` on `mergify`. Every one of them is already flake-reachable, so `devShells.default` can carry them.

```nix
pkgs.jujutsu
pkgs.ghq
pkgs.jaq
pkgs.duckdb                                # the CLI; the python binding above is a separate output
self'.packages.linear-cli
self'.packages.mergify-cli-bin
inputs'.llm-agents.packages.openspec
```

`.envrc` pins `.#default`, and both the skills and `.devin/blueprint.yaml` run recipes through `direnv exec .`, so `default` is the only shell that makes them work; a sibling `devShells.agents` would stay invisible to every one of those callers.

`atuin` stays out: `meta-search-sessions` searches a harness history that exists on a workstation and nowhere else.

## Verification

All seven commands resolve inside `nix develop`, and every path substituted — entering the shell copied 47 of them, 800 MiB of NAR, with no local build; the deno runtime under `linear-cli` and the node runtime under `openspec` account for most of that. `devShells.aarch64-darwin.default` still evaluates, and `just lint` passes.

`jj` is inert until a checkout is colocated (`jj git init --colocate`); the binary being present is what its skills need.


Link to Devin session: https://app.devin.ai/sessions/d8f060379a874a37ba13571d8f1f48a3
Open in Devin Desktop: https://app.devin.ai/desktop/session/d8f060379a874a37ba13571d8f1f48a3?variant=devin
Requested by: @cameronraysmith