### PR TITLE
fix(gpg): disable the darwin gpg-agent launchd service

### DIFF
--- a/modules/home/tools/gpg.nix
+++ b/modules/home/tools/gpg.nix
@@ -3,8 +3,12 @@
   flake.modules.homeManager.tools =
     { lib, pkgs, ... }:
     {
+      # `services.gpg-agent.enable` launches the agent via `gpg-agent
+      # --supervised`, which on launchd (no inherited LISTEN_FDS socket)
+      # exits immediately and gets endlessly respawned; systemd's user
+      # instance does supply that socket, so the agent only works on Linux.
       services.gpg-agent = {
-        enable = true;
+        enable = pkgs.stdenv.hostPlatform.isLinux;
 
         defaultCacheTtl = 43200; # 12 hours for normal cache
         maxCacheTtl = 86400; # 1 day maximum cache lifetime
@@ -12,6 +16,18 @@
         pinentry.package = pkgs.pinentry-tty;
 
         extraConfig = "";
+      };
+
+      # home-manager only writes gpg-agent.conf when services.gpg-agent.enable
+      # is true (it's under that module's `mkIf cfg.enable`), so on darwin -
+      # where the service above stays disabled - this reproduces the same
+      # settings for on-demand invocation by either nixpkgs gpg or GPG Suite.
+      home.file.".gnupg/gpg-agent.conf" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+        text = ''
+          default-cache-ttl 43200
+          max-cache-ttl 86400
+          pinentry-program ${pkgs.pinentry-tty}/bin/pinentry-tty
+        '';
       };
 
       programs.gpg = {


### PR DESCRIPTION
gpg-agent --supervised expects a systemd-style inherited listening
socket on fd 3. launchd never provides one, so the process exits 2, and
KeepAlive.SuccessfulExit = false respawns it about every ten seconds.
It had accumulated 501 runs since boot without ever serving a request,
each respawn costing an exec that macOS adjudicates through syspolicyd.

Commit signing on this fleet goes through Bitwarden ssh-agent, and the
GPG Suite agent already serves the interactive cases, so nothing
depended on the home-manager agent. Linux keeps it: there the socket
contract the flag assumes is the one systemd actually implements.

home-manager writes ~/.gnupg/gpg-agent.conf only from inside the
service module and gates its whole config block on the service being
enabled, so disabling the service would also drop the configuration
that an on-demand agent start reads. A darwin-only home.file carries
the same three settings forward, keeping the cache lifetimes and the
pinentry program identical to what the service produced.