### PR TITLE
perf(devshells): only compose agent context when AGENTS.md is absent

### DIFF
--- a/modules/devshells/default.nix
+++ b/modules/devshells/default.nix
@@ -31,20 +31,30 @@
           config.pre-commit.devShell
         ];
 
-        # Composes the repo-root AGENTS.md/CLAUDE.md from the agent-context-*
-        # apm fragments on shell entry, mirroring the git-hooks.nix precedent
-        # above of writing a git-ignored generated file from a shellHook.
-        # `lib.getExe` embeds the store path at eval time so entering the
-        # shell costs a fork+exec, not a nix evaluation; `--if-stale` makes
-        # that exec a no-op once the composed output already matches the
-        # fragments. `--auto` lets the script itself pick the repository
-        # tier vs every tier by checking for a user-level agent context file
-        # (see apm-context-compile.sh); it never fails the shell, since a
-        # missing AGENTS.md degrades an agent session but must not block a
-        # human terminal or direnv.
+        # Materializes the repo-root AGENTS.md/CLAUDE.md from the
+        # agent-context-* apm fragments once per clone; run `just
+        # agents-context` to refresh after editing the fragments. The
+        # presence check below is a bash builtin, so the common case
+        # (AGENTS.md already exists) execs nothing: the compile wrapper's
+        # runtimeInputs (apm, git, yq-go, coreutils, findutils) exec
+        # roughly 20 non-Apple binaries even just to check staleness, and
+        # each exec of non-Apple code on macOS triggers a syspolicyd
+        # Gatekeeper adjudication -- paying that cost on every shell entry
+        # and direnv reload, across every worktree, contributed to a
+        # syspolicyd lockup. `lib.getExe` embeds the store path at eval
+        # time; `--auto` lets the script itself pick the repository tier
+        # vs every tier by checking for a user-level agent context file
+        # (see apm-context-compile.sh); the `if !` guard means a failure
+        # never fails the shell, since a missing AGENTS.md degrades an
+        # agent session but must not block a human terminal or direnv.
+        # The check below is `$PWD`-relative, not repo-root-relative:
+        # entering the devShell from a subdirectory can miss an
+        # AGENTS.md that exists only at the repo root.
         shellHook = ''
-          if ! ${lib.getExe config.packages.apm-context-compile} --if-stale --auto; then
-            echo "apm-context-compile: skipped (run 'just agents-context' to regenerate AGENTS.md/CLAUDE.md manually)" >&2
+          if [[ ! -f "$PWD/AGENTS.md" ]]; then
+            if ! ${lib.getExe config.packages.apm-context-compile} --auto; then
+              echo "apm-context-compile: skipped (run 'just agents-context' to regenerate AGENTS.md/CLAUDE.md manually)" >&2
+            fi
           fi
         '';
 


### PR DESCRIPTION
The hook this replaces ran on every devShell entry and every direnv
reload, in every worktree. Its staleness guard alone execs about twenty
non-Apple binaries, since the wrapper carries apm, git, yq-go,
coreutils and findutils in runtimeInputs, and on macOS every such exec
is a syspolicyd Gatekeeper adjudication. That load was a contributing
factor in a machine lockup, and it bought nothing on a machine with a
home-manager profile, where nix already delivers the user-level context.

The guard is now a bash builtin test, so the common case execs nothing
at all, and the wrapper runs only when the repository root has no
AGENTS.md to begin with. That makes the contract materialize once per
clone and refresh explicitly through just agents-context, which is the
loop this file already supported. --if-stale becomes redundant under an
absent-file guard and is dropped; --auto still selects the tier.

The check is $PWD-relative, because resolving the repository root would
itself require the exec this change exists to avoid. Entering the shell
from a subdirectory therefore recomposes; the comment records that.

Depends-On: #2929