### PR TITLE
fix(darwin): stop Sparkle apps installing updates unattended

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -34,6 +34,10 @@
           "itsycal"
           "hewigovens/tap/jayjay"
           "linear"
+          # This declares which version Homebrew installs; the app's own in-app
+          # updater replaces its bundle independently of Homebrew and has no
+          # `defaults` key to disable, so that toggle must stay off by hand
+          # (a mid-session bundle swap forces a full Gatekeeper re-assessment).
           "logi-options+"
           "logseq"
           "neohtop"

--- a/modules/darwin/system-defaults/custom-user-prefs.nix
+++ b/modules/darwin/system-defaults/custom-user-prefs.nix
@@ -36,6 +36,20 @@
             DateFormat = "EEE d MMM HH:mm:ss";
             FlashDateSeparators = false;
           };
+          # Sparkle auto-install (SUAutomaticallyUpdate) replaces an app's own bundle
+          # mid-session, forcing a full Gatekeeper re-assessment; a Sparkle auto-install
+          # on 2026-09-03 compounded a Logi Options+ lockup. Update *checks*
+          # (SUEnableAutomaticChecks) stay on for all of these; only unattended
+          # installation is disabled.
+          "net.imput.helium" = {
+            SUAutomaticallyUpdate = false;
+          };
+          "com.openai.codex" = {
+            SUAutomaticallyUpdate = false;
+          };
+          "com.steipete.codexbar" = {
+            SUAutomaticallyUpdate = false;
+          };
         };
       };
     };


### PR DESCRIPTION
A Sparkle app with SUAutomaticallyUpdate set replaces its own bundle
while the machine is in use, and macOS then re-assesses the whole
replacement through Gatekeeper. One such auto-install landed in the
middle of an unrelated 40-minute syspolicyd stall and extended it.

Three domains had it enabled: net.imput.helium, com.openai.codex and
com.steipete.codexbar. Update checks stay on in all three, so the apps
still report that a release exists; only the unattended install of it
is disabled. BetterDisplay already sat in that state and needed no
change, which is what the target state looks like.

The homebrew comment records the boundary this does not reach. The
logi-options+ cask was already declared, and an in-app updater replaces
its bundle independently of Homebrew, so the declaration governs which
version brew installs and nothing more. That toggle has no defaults
key and has to be turned off inside the application.

Depends-On: #2930