### PR TITLE
feat(skills): bump superpowers to v6.3.0 and mattpocock to v1.2.3

### DIFF
--- a/modules/home/ai/plugins/planning-and-development/apm.yml
+++ b/modules/home/ai/plugins/planning-and-development/apm.yml
@@ -8,13 +8,13 @@ dependencies:
     # git checkout cache from the flake-pinned tree before `apm install`, so it
     # records a remote-style resolved_commit lock with zero network. The full SHA
     # is required; a short ref forces a network fetch.
-    - obra/superpowers#f268f7c953744036f0fa7e9d4b73535c04e57cb8
+    - obra/superpowers#b36e0829c6d0140e93cfef2ca599b1b07d4a7797
     # mattpocock/skills as a walked whole-plugin remote dep (claude-plugin repo:
-    # plugin.json, no apm.yml). apm normalizes its 21 plugin.json-declared skills
-    # (16 engineering + 5 productivity) into flat skills at install; the nix compose
+    # plugin.json, no apm.yml). apm normalizes its 25 plugin.json-declared skills
+    # (18 engineering + 7 productivity) into flat skills at install; the nix compose
     # pre-seeds the git checkout cache from the flake-pinned tree for zero-network
     # resolution. Full 40-char SHA required.
-    - mattpocock/skills#d574778f94cf620fcc8ce741584093bc650a61d3
+    - mattpocock/skills#6acc160e4e0cd062dbbbd7a1b26ae92855edf07e
     - git: srid/agency
       ref: 81455051ccca654c57ad6088838c85e7248ac159
       skills: [hickey, lowy, fact-check]

--- a/modules/home/ai/skills/default.nix
+++ b/modules/home/ai/skills/default.nix
@@ -49,11 +49,23 @@
       # readDir over a derivation output is import-from-derivation: evaluating the
       # skills attrset realizes aiSkills.composed.
       #
-      # mattpocock/skills is adopted whole-plugin; its bare-named `tdd` shadows our
-      # atdd-outer-loop -> test-driven-development ecosystem at model-selection time and
-      # would bypass ATDD routing, so it is withheld from delivery here. The compose
-      # still builds it; only the harness symlink is dropped. Remove the name to re-include.
-      excludedUpstreamSkills = [ "tdd" ];
+      # mattpocock/skills is adopted whole-plugin, and two of its bare-named skills
+      # shadow first-party ecosystems at model-selection time, so they are withheld
+      # from delivery here. The compose still builds them; only the harness symlink
+      # is dropped. Remove a name to re-include it.
+      #
+      # `tdd` shadows our atdd-outer-loop -> test-driven-development ecosystem and
+      # would bypass ATDD routing.
+      #
+      # `writing-for-agents` arrived in v1.2.3 as a rename of `writing-great-skills`
+      # that both dropped `disable-model-invocation: true` and broadened its scope to
+      # editing AGENTS.md and CLAUDE.md, so it became model-invocable in territory
+      # meta-skill-creator, preferences-documentation and preferences-prose-clarity
+      # already own. Same routing-bypass class as `tdd`, no name collision.
+      excludedUpstreamSkills = [
+        "tdd"
+        "writing-for-agents"
+      ];
 
       allSkills = removeAttrs (readSkillsFrom "${config.aiSkills.composed}/.claude/skills") excludedUpstreamSkills;
 

--- a/pkgs/by-name/agent-plugins/mattpocock-skills/package.nix
+++ b/pkgs/by-name/agent-plugins/mattpocock-skills/package.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "mattpocock";
   repo = "skills";
-  rev = "d574778f94cf620fcc8ce741584093bc650a61d3";
-  hash = "sha256-XqF709Y9GMKINzZITlbCTyatG9AxRZh0qn2vcv1Z8yo=";
+  rev = "6acc160e4e0cd062dbbbd7a1b26ae92855edf07e";
+  hash = "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=";
 }

--- a/pkgs/by-name/agent-plugins/superpowers/package.nix
+++ b/pkgs/by-name/agent-plugins/superpowers/package.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "obra";
   repo = "superpowers";
-  rev = "f268f7c953744036f0fa7e9d4b73535c04e57cb8";
-  hash = "sha256-gvFbbT6uTPSvpFZdPvOiddZxs6amBdL/vm2qp97Dej4=";
+  rev = "b36e0829c6d0140e93cfef2ca599b1b07d4a7797";
+  hash = "sha256-EsGNO0dULWf5Bx6bGrCv2kI2Z8aKH0kRvGiuN23wChQ=";
 }


### PR DESCRIPTION
Both upstreams are pinned twice, in the plugin manifest and in the
agent-plugins derivation that pre-seeds apm git cache for zero-network
resolution, so each bump moves two files to the same full SHA. Both
tags are annotated and were dereferenced to their commits: superpowers
v6.3.0 is main tip, mattpocock v1.2.3 is a reachable ancestor 39
commits behind. Both are the maximum semver tag in their repository,
cross-checked against releases/latest.

superpowers changes no skill names at all. mattpocock adds five and
renames one: writing-great-skills becomes writing-for-agents. None of
the five collides with any of the 125 first-party skill names, and tdd
still exists under its own name, so the exclusion that withholds it
stays live rather than silently becoming dead.

writing-for-agents joins that exclusion. The rename dropped
disable-model-invocation, which had kept the old skill invocable only
by name, and broadened its description to editing AGENTS.md and
CLAUDE.md. It therefore became model-invocable in territory
meta-skill-creator, preferences-documentation and
preferences-prose-clarity already hold. That is the same routing
bypass the tdd exclusion exists to prevent, reached without a name
collision, so the delivery layer is the right place to stop it and the
compose still builds it.

The lockfile is deliberately untouched. It resolves the first-party
packages from their published main rather than from the worktree, so
these manifest edits are invisible to it until they land; relocking is
the follow-up, not part of this change.