### PR TITLE
feat(skills): bump worktrunk to v0.76.0

### DIFF
--- a/modules/home/ai/plugins/version-control-and-forge/apm.yml
+++ b/modules/home/ai/plugins/version-control-and-forge/apm.yml
@@ -8,8 +8,13 @@ dependencies:
     # offline by pre-seeding apm's git checkout cache from the flake-pinned tree
     # before `apm install`, recording a remote-style resolved_commit lock with zero
     # network. The full 40-char SHA is required; a short ref forces a network fetch.
+    # Upstream's tag series is not monotonic: `apm outdated` reported v0.1.4
+    # (b08d381f...) as "latest", but that tag is an orphan not reachable from
+    # main (verify ancestry via `gh api .../compare/<sha>...main` before
+    # trusting the table on a future bump). This pin instead tracks v0.76.0,
+    # the release actually reachable from main at bump time.
     - git: max-sixty/worktrunk
-      ref: 5175153b39d2737b4c35810fc58b0fd1a58ee609
+      ref: de0052d8db917e46c1663979d376eff3f90c8119
       skills: [worktrunk, wt-switch-create]
     # gh-stack is a Go CLI repo that also ships one agent skill under
     # skills/gh-stack/. apm types it SKILL_BUNDLE (nested skills/<name>/SKILL.md,

--- a/pkgs/by-name/agent-plugins/worktrunk/package.nix
+++ b/pkgs/by-name/agent-plugins/worktrunk/package.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "max-sixty";
   repo = "worktrunk";
-  rev = "5175153b39d2737b4c35810fc58b0fd1a58ee609";
-  hash = "sha256-q3xjxDW0X3jaG3PUqNB2gFsEb/2Mz5VD6PA8sZDX8tg=";
+  rev = "de0052d8db917e46c1663979d376eff3f90c8119";
+  hash = "sha256-GrkBwQOhFur1TVUufUJdp9f7nHwUXGa46+YRsgK1S6w=";
 }

--- a/pkgs/by-name/worktrunk-bin/package.nix
+++ b/pkgs/by-name/worktrunk-bin/package.nix
@@ -10,26 +10,26 @@ let
   systemToPlatform = {
     "x86_64-linux" = {
       asset = "x86_64-unknown-linux-musl";
-      hash = "sha256-2f3h+TbH33WXYPbrFuF45wOXM1h/HqmTEHbb4lb+b4U=";
+      hash = "sha256-O/TXwCbWHxuN+AvOO8xc4TOK7Sggu0tdBETkt0aZBpM=";
     };
     "aarch64-linux" = {
       asset = "aarch64-unknown-linux-musl";
-      hash = "sha256-nQiBZHkCDx2JiMlE59etNUQyjjDssdQuXudU3csXztQ=";
+      hash = "sha256-JEvn9doeVqbYBa0vzXD0beVm9SK+Or8oxUUOGCzabcI=";
     };
     "x86_64-darwin" = {
       asset = "x86_64-apple-darwin";
-      hash = "sha256-Hhhu1G5UlpXIsyX3KPbjhVflAAWuGnEDZQCZQflGjPk=";
+      hash = "sha256-CA93Vgr10mBJCD8UnsBA60dq9zQf6xOkVybohVEMEak=";
     };
     "aarch64-darwin" = {
       asset = "aarch64-apple-darwin";
-      hash = "sha256-X4seMCmoKlIb1XH4ixlkCnNjq5OyFUh6L2dP/Kx3K+k=";
+      hash = "sha256-exm7nV7GDqS5vLEdkmBuBXW98XoB7f5LhB9CgeXQ9W0=";
     };
   };
   platform = systemToPlatform.${system} or (throw "worktrunk-bin: unsupported platform ${system}");
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "worktrunk-bin";
-  version = "0.65.0";
+  version = "0.76.0";
 
   src = fetchurl {
     url = "https://github.com/max-sixty/worktrunk/releases/download/v${finalAttrs.version}/worktrunk-${platform.asset}.tar.xz";


### PR DESCRIPTION
apm outdated named v0.1.4 as latest for this upstream and that tag is
unusable. Its commit is diverged from main rather than reachable,
ahead by 4447 and behind by 1, evidently left behind by a history
rewrite. Its Cargo.toml reports 0.1.4, older than the pinned 0.65.0,
and it carries only one of the two skills the allowlist names. Taking
it would have been a dangling ref, a downgrade and a broken allowlist
at once.

v0.76.0 is the real target: a strict ancestor of main, merge base
equal to itself and behind by zero, carrying both worktrunk and
wt-switch-create. The upstream tag series is not monotonic, so the
manifest now records that ancestry has to be checked rather than
inferred from the outdated table.

The delta is eleven minor releases, which makes the second pin matter.
This repository packages the wt CLI separately in worktrunk-bin, and
the skills document that binary flags, so the two move together here;
its own update script independently resolved v0.76.0 as latest,
confirming the tag choice through a second path.

The lockfile is untouched for the same reason as the preceding change:
it resolves first-party packages from published main, not from the
worktree.

Depends-On: #2933