### PR TITLE
feat(devin): enable Outposts workers on stibnite and magnetite

### DIFF
--- a/modules/checks/devin-worker.nix
+++ b/modules/checks/devin-worker.nix
@@ -1,12 +1,12 @@
 # Structural check for `flake.modules.homeManager.devin`'s worker surface
 # (see modules/home/ai/devin/worker.nix).
 #
-# The module lands disabled on every host, so nothing in the machine
-# configurations exercises it. What the module promises when enabled is
-# checked here instead, with a dummy token path standing in for the sops-nix
-# secret the operator has yet to mint. Only names, counts, and booleans are
-# serialized into the diff, so this check evaluates and never builds a
-# worker's launcher.
+# Two hosts enable the module, but their machine configurations only assert
+# what those two deployments happen to need. What the module promises for any
+# enabled host is checked here instead, on both platforms, with a dummy token
+# path in place of the sops-nix secret so no real path is a build input. Only
+# names, counts, and booleans are serialized into the diff, so this check
+# evaluates and never builds a worker's launcher.
 #
 # Two evaluation vehicles, for two different reasons.
 #
@@ -118,8 +118,8 @@
       # partial definition merges with it instead of replacing it -- an option
       # `default` would have dropped the entries and the platforms.
       wired = {
-        "stibnite-01".tokenFile = "/run/secrets/devin-outposts-token-stibnite.dummy";
-        "magnetite-01".tokenFile = "/run/secrets/devin-outposts-token-magnetite.dummy";
+        "stibnite".tokenFile = "/run/secrets/devin-outposts-token-stibnite.dummy";
+        "magnetite".tokenFile = "/run/secrets/devin-outposts-token-magnetite.dummy";
       };
 
       darwin = evalHome {
@@ -128,7 +128,7 @@
         worker = {
           enable = true;
           workers = 2;
-          outpost = "stibnite-01";
+          outpost = "stibnite";
           outposts = wired;
         };
       };
@@ -139,7 +139,7 @@
         worker = {
           enable = true;
           workers = 2;
-          outpost = "magnetite-01";
+          outpost = "magnetite";
           outposts = wired;
         };
       };
@@ -177,10 +177,17 @@
         ) (config.warnings or [ ]);
 
       # A no-platform queue selected on a darwin host: warned, not asserted.
+      # The registry gives magnetite a platform, so the null is set here
+      # explicitly -- a plain definition outranks the registry's mkDefault.
       platformUnsetProbe = evalBare "aarch64-darwin" {
         enable = true;
-        outpost = "magnetite-01";
-        outposts = wired;
+        outpost = "magnetite";
+        outposts = wired // {
+          "magnetite" = {
+            platform = null;
+            inherit (wired."magnetite") tokenFile;
+          };
+        };
       };
 
       distinctWorkDirs = paths: paths != [ ] && lib.length (lib.unique paths) == lib.length paths;
@@ -226,16 +233,14 @@
 
           linuxSelectedPlatform =
             linux.services.devin-worker.outposts.${linux.services.devin-worker.outpost}.platform;
-          # magnetite-01 carries no platform, so agreement with a linux host is
-          # unestablished rather than confirmed. Named as its own state: not a
-          # match, not a mismatch, and deliberately not an assertion, because
-          # whether a no-platform queue can serve this worker is unproven.
+          # magnetite is registered for linux, so this is a confirmed match
+          # with the host rather than the unestablished state it used to be.
           linuxWarned = warnedClauses linux;
 
           wellFormed = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              outpost = "stibnite-01";
+              outpost = "stibnite";
               outposts = wired;
             }
           );
@@ -244,20 +249,20 @@
           tokenless = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              outpost = "stibnite-01";
+              outpost = "stibnite";
               outposts = {
-                "magnetite-01".tokenFile = wired."magnetite-01".tokenFile;
+                "magnetite".tokenFile = wired."magnetite".tokenFile;
               };
             }
           );
           idless = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              outpost = "stibnite-01";
+              outpost = "stibnite";
               outposts = wired // {
-                "stibnite-01" = {
+                "stibnite" = {
                   id = null;
-                  inherit (wired."stibnite-01") tokenFile;
+                  inherit (wired."stibnite") tokenFile;
                 };
               };
             }
@@ -267,11 +272,11 @@
           platformMismatch = firedClauses (
             evalBare "aarch64-darwin" {
               enable = true;
-              outpost = "magnetite-01";
+              outpost = "magnetite";
               outposts = wired // {
-                "magnetite-01" = {
+                "magnetite" = {
                   platform = "linux";
-                  inherit (wired."magnetite-01") tokenFile;
+                  inherit (wired."magnetite") tokenFile;
                 };
               };
             }
@@ -297,7 +302,7 @@
           secondLinuxHostBorrowing = firedClauses (
             evalBare "x86_64-linux" {
               enable = true;
-              outpost = "magnetite-01";
+              outpost = "magnetite";
             }
           );
         };
@@ -323,8 +328,8 @@
           outpostDefault = null;
           darwinSelectedPlatform = "macos";
           darwinWarned = [ ];
-          linuxSelectedPlatform = null;
-          linuxWarned = [ "platform-unset" ];
+          linuxSelectedPlatform = "linux";
+          linuxWarned = [ ];
 
           wellFormed = [ ];
           tokenless = [ "token" ];

--- a/modules/home/ai/devin/worker.nix
+++ b/modules/home/ai/devin/worker.nix
@@ -341,7 +341,7 @@
             `id` or `tokenFile` through a default-carried registry would drop
             every other entry, and drop the `platform` of the entry it was
             editing. Definitions merge, so with the registry in the config
-            layer a caller writing `outposts."magnetite-01".tokenFile = ...`
+            layer a caller writing `outposts."magnetite".tokenFile = ...`
             adds to it. Overriding a value this module sets needs
             `lib.mkForce`, since the module's own entries are `lib.mkDefault`.
           '';
@@ -350,7 +350,7 @@
         outpost = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          example = "magnetite-01";
+          example = "magnetite";
           description = ''
             Queue this host's workers serve, named per host. Required whenever
             the service is enabled: enabling without it fails evaluation and
@@ -418,22 +418,19 @@
         # `outpost` to resolve its default, and describing a queue commits this
         # host to nothing.
         {
-          # Read from the live account through the fleet API, not assumed: the
-          # names carry an -01 suffix, and magnetite-01 was created without a
-          # platform. Addressing by id is what makes the suffix a labelling
-          # detail rather than a claim-time failure.
+          # Read from the live account through the fleet API, not assumed:
+          # both queues carry the bare machine name as their label, and both
+          # were created with a platform. Addressing by id is what makes the
+          # label a display detail rather than a claim-time failure.
           services.devin-worker.outposts = {
-            "stibnite-01" = {
-              id = lib.mkDefault "outpost_env-f47bd2ee30824fe6bc5f9330f67f3670";
+            "stibnite" = {
+              id = lib.mkDefault "outpost_env-2955ae307356487b869030ddb4fc45f7";
               platform = lib.mkDefault "macos";
               description = lib.mkDefault "Apple silicon workstation with a live desktop session for computer use";
             };
-            "magnetite-01" = {
-              id = lib.mkDefault "outpost_env-e178cc2f14f84011b05f52ea17ccdb66";
-              # Platform deliberately left null, mirroring the account: the
-              # outpost was created without one, and asserting linux here
-              # would be this module inventing a fact the account does not
-              # carry.
+            "magnetite" = {
+              id = lib.mkDefault "outpost_env-4e8894859f8443258b52e992d4f2d112";
+              platform = lib.mkDefault "linux";
               description = lib.mkDefault "x86_64 server capacity for headless sessions";
             };
           };
@@ -446,7 +443,7 @@
               message = ''
                 services.devin-worker is enabled on ${hostLabel} but services.devin-worker.outpost is
                 unset, so this host has not been told which queue it serves. Name it, e.g.
-                services.devin-worker.outpost = "magnetite-01"; known queues are
+                services.devin-worker.outpost = "magnetite"; known queues are
                 ${lib.concatStringsSep ", " (lib.attrNames cfg.outposts)}.
 
                 There is no default on purpose. Inferring the queue from this host's platform would

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -276,10 +276,26 @@ let
       imports = [
         (
           let
+            # Queue label per host. The labels coincide with the machine
+            # names because the operator named the queues after the machines,
+            # not because either is derived from the other: a host absent
+            # from this table serves no queue, which is the property that
+            # keeps the fleet's other linux machines off magnetite's queue.
             outpostByHost = {
-              stibnite = "stibnite-01";
-              magnetite = "magnetite-01";
+              stibnite = "stibnite";
+              magnetite = "magnetite";
             };
+
+            # Hosts that actually run workers, named separately from the
+            # assignment above. Which queue a host would serve is a
+            # deployment fact recorded whenever it is decided; running a
+            # worker there additionally needs that queue's token present in
+            # secrets.yaml, so the two are not the same statement and do not
+            # necessarily land together.
+            workerHosts = [
+              "stibnite"
+              "magnetite"
+            ];
 
             hostName = if osConfig == null then null else osConfig.networking.hostName;
             hostOutpost = if hostName == null then null else outpostByHost.${hostName} or null;
@@ -299,15 +315,17 @@ let
               && config.services.devin-worker.outpost == name;
           in
           {
+            services.devin-worker.enable = lib.mkIf (lib.elem hostName workerHosts) true;
+
             services.devin-worker.outpost = lib.mkIf (hostOutpost != null) (lib.mkDefault hostOutpost);
 
             sops.secrets = lib.mkMerge [
-              (lib.mkIf (serves "stibnite-01") {
+              (lib.mkIf (serves "stibnite") {
                 devin-outposts-token-stibnite = {
                   mode = "0400";
                 };
               })
-              (lib.mkIf (serves "magnetite-01") {
+              (lib.mkIf (serves "magnetite") {
                 devin-outposts-token-magnetite = {
                   mode = "0400";
                 };
@@ -315,10 +333,10 @@ let
             ];
 
             services.devin-worker.outposts = {
-              "stibnite-01".tokenFile =
-                lib.mkIf (serves "stibnite-01") config.sops.secrets.devin-outposts-token-stibnite.path;
-              "magnetite-01".tokenFile =
-                lib.mkIf (serves "magnetite-01") config.sops.secrets.devin-outposts-token-magnetite.path;
+              "stibnite".tokenFile =
+                lib.mkIf (serves "stibnite") config.sops.secrets.devin-outposts-token-stibnite.path;
+              "magnetite".tokenFile =
+                lib.mkIf (serves "magnetite") config.sops.secrets.devin-outposts-token-magnetite.path;
             };
           }
         )

--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -61,6 +61,15 @@ let
       # modules/home/ai/openspec/default.nix.
       programs.openspec.enable = true;
 
+      # The interactive CLI on PATH, with its config rendered from
+      # modules/home/ai/devin/default.nix. Unconditional and independent of
+      # services.devin-worker below: the worker runs the CLI from its own
+      # store path and needs nothing on a user's PATH, while a person driving
+      # `devin` wants it wherever this home lands. It carries no credential --
+      # the rendered config.json is a world-readable store symlink and no
+      # option feeds a secret into it.
+      programs.devin.enable = true;
+
       programs.omnigraph = {
         enable = true;
         settings = {


### PR DESCRIPTION
## What changed

Both Devin outposts were deleted and recreated in the console, so the registry this repository carried addressed two queues that no longer exist. This updates the registry to the live account and turns the workers on for the two hosts that serve those queues.

Three facts moved together.

**Labels lost the `-01` suffix.** The console shows the queues as `stibnite` and `magnetite`; the previous entries were keyed `stibnite-01` and `magnetite-01`. The label is a display detail — the worker is addressed by id — but it is also the key the per-host wiring agrees on, so all five sites move at once: the registry entries in `modules/home/ai/devin/worker.nix`, the `outpostByHost` values, both `serves "…"` guards, and both `tokenFile` assignments in `modules/home/users/crs58/default.nix`. A disagreement among them is what the `serves` predicate exists to catch, and it fails evaluation by name rather than silently.

**Both ids are new.**

| Outpost | Id | Platform |
| --- | --- | --- |
| `stibnite` | `outpost_env-2955ae307356487b869030ddb4fc45f7` | macOS |
| `magnetite` | `outpost_env-4e8894859f8443258b52e992d4f2d112` | Linux |

Each row is checkable against the outpost's page in the Devin console. Neither dead id survives anywhere in the tree; `git grep outpost_env-` returns five hits, the two ids above plus three documentation strings in `worker.nix` — one synthetic `outpost_env-0123…` example and two references to the `outpost_env-<32 hex>` form.

**Magnetite now reports a platform.** The previous outpost was created without one, and the entry deliberately carried `null` rather than asserting a fact the account did not hold. The recreated outpost is Linux, so the entry records `platform = "linux"`. This is the change with real consequence: it turns the module's platform guard from skipped into active for magnetite, which is what closes the case where some other host is pointed at magnetite's queue.

The service is enabled for the `crs58` home on stibnite and magnetite only, through a `workerHosts` list read against `osConfig.networking.hostName` — the same host-conditional mechanism the queue assignment already uses. The list is kept separate from `outpostByHost` because recording which queue a host would serve and deciding to run a worker there are different statements that need not land together.

No credential is touched. Both worker tokens already exist as ciphertext in `secrets/home-manager/users/crs58/secrets.yaml` under the key names the wiring declares; nothing here reads, decrypts, or moves them.

## Proof

**Per-host resolution.** Each host resolves exactly its own outpost and its own token path:

| Host | Home user | `outpost` | Resolved id | Platform | Token path | sops keys declared |
| --- | --- | --- | --- | --- | --- | --- |
| stibnite | `crs58` | `stibnite` | `outpost_env-2955ae307356487b869030ddb4fc45f7` | `macos` | `/Users/crs58/.config/sops-nix/secrets/devin-outposts-token-stibnite` | `devin-outposts-token-stibnite` |
| magnetite | `cameron` | `magnetite` | `outpost_env-4e8894859f8443258b52e992d4f2d112` | `linux` | `/home/cameron/.config/sops-nix/secrets/devin-outposts-token-magnetite` | `devin-outposts-token-magnetite` |

Read from `darwinConfigurations.stibnite` and `nixosConfigurations.magnetite` respectively, through `config.home-manager.users.<user>`.

**The guard bites, and the platform change is what makes it bite.** Pointing `outpostByHost.stibnite` at magnetite's label in a scratch edit and evaluating `darwinConfigurations.stibnite.config.system.build.toplevel.drvPath`:

```
error:
Failed assertions:
- crs58 profile: services.devin-worker.outpost "magnetite" is registered for platform
"linux" but this host is "macos". The worker
validates the machine's OS against the outpost's platform and refuses to serve a mismatch.
```

Restoring `platform = null` on magnetite while leaving the misdirection in place, the same evaluation **succeeds** and emits only a warning that the queue "carries no platform, so this host's agreement with it is unestablished". So the platform value is load-carrying rather than cosmetic: with `null`, a macOS host could have been aimed at magnetite's Linux queue holding magnetite's credential, with nothing failing. Both scratch edits were reverted; the branch carries neither.

**No other host is affected.** Every home across all ten machine configurations plus all eighteen standalone `homeConfigurations` was evaluated for `services.devin-worker.enable` and for any `devin-outposts-*` sops key. Exactly two are non-empty:

```
magnetite/cameron: enable=true  outpost=magnetite keys=[devin-outposts-token-magnetite]
stibnite/crs58:    enable=true  outpost=stibnite  keys=[devin-outposts-token-stibnite]
```

The other thirteen machine homes and all eighteen standalone homes report `enable=false`, `outpost=null`, and no key.

**Checks run.**

| Check | Result |
| --- | --- |
| `checks.aarch64-darwin.devin-worker-structural` | green |
| `checks.aarch64-darwin.gitleaks` | green |
| `darwinConfigurations.stibnite` → `system.build.toplevel.drvPath` | evaluates, no failing assertion, no devin warning |
| `nixosConfigurations.magnetite` → `system.build.toplevel.drvPath` | evaluates, no failing assertion, no devin warning |

The structural check is the one that covers this module, and it evaluates both an `aarch64-darwin` and an `x86_64-linux` home internally, so the platform routing this change touches is exercised from a single system. The two machine-closure evaluations are what enforce the module's assertions in the embedded home path, where a home-level evaluation alone does not. Gitleaks runs because new identifier strings enter the tree. Deliberately not run: the full `nix flake check` sweep, which is far wider than this diff, and the `x86_64-linux` copy of the structural check, whose content is identical to the darwin one and which would need a Linux builder to realise.

The structural check itself was updated alongside the module, since its probes name the registry keys and one of them asserted magnetite's absent platform. That probe now sets `platform = null` explicitly — a plain definition outranks the registry's `mkDefault` — so the no-platform state stays covered rather than disappearing with the account change.

## Activation

Not activated. A declared sops secret with no rendered value fails activation, so switching stibnite and magnetite is the operator's step, on his own machines, after this merges.

---

## Second commit: the interactive CLI (`d462c8e35`)

Separate concern, separately revertible. `programs.devin` and `services.devin-worker` are two options with two blast radii, and the first commit set only the second. The worker runs the CLI from its own store path, so enabling it puts nothing on a user's PATH — `which devin` is empty on a host whose worker is running. This commit sets `programs.devin.enable = true` for the `crs58` home, at the home layer rather than in a machine module, because the interactive CLI is a user-facing tool rather than a host capability.

Unconditional, so it lands wherever this home lands: ten homes across four `aarch64-darwin` and six `x86_64-linux` machines. Two are named `crs58` (blackphos, stibnite) and eight `cameron`, the alias the newer machines use for the same account.

Credential-free. `programs.devin` exposes `model`, `autoUpdate`, `notify`, `themeMode`, `attribution` and a free-form `settings`; none is a secret. Every typed option is at its default and `settings` is empty, so the rendered `config.json` carries `auto_update: false` and nothing else — appropriate for a world-readable store symlink.

**Per-host proof.** All ten homes resolve `devin-cli-3000.6.7` to a concrete derivation, one per platform:

| Homes | Platform | Derivation |
| --- | --- | --- |
| argentum/cameron, blackphos/crs58, rosegold/cameron, stibnite/crs58 | aarch64-darwin | `ck8jdfh7…-devin-cli-3000.6.7.drv` |
| cinnabar, electrum, galena, magnetite, pyrite, scheelite (all /cameron) | x86_64-linux | `9mqxi02w…-devin-cli-3000.6.7.drv` |

Forcing the `drvPath` forces `src = srcs.${system} or throwSystem`, so this shows the throw is unreachable in this fleet — the only uncovered system is `x86_64-darwin` and no machine here is one.

**Worker scope unchanged by this commit.** Still `enable = true` on exactly `stibnite/crs58` (`outpost = stibnite`, key `devin-outposts-token-stibnite`) and `magnetite/cameron` (`outpost = magnetite`, key `devin-outposts-token-magnetite`); the other thirteen machine homes report `enable = false` with no key. The five homes belonging to other users (christophersmith, raquel, janettesmith, tara×2) get neither the CLI nor the worker.

**Checks.** `checks.aarch64-darwin.home-manager-crs58` — the check this change actually moves — green, and `home-path/bin/devin` is present in the built generation. `checks.aarch64-darwin.devin-worker-structural` and `checks.aarch64-darwin.gitleaks` green. Not run: the `x86_64-linux` copy of the home check, which needs a Linux builder; the six Linux hosts are covered at evaluation by the per-host derivation resolution above.
