### PR TITLE
feat(home): declarative ubuntu profile for the Devin sandbox

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -24,9 +24,15 @@ initialize: |
   printf 'accept-flake-config = true\nauto-allocate-uids = true\nextra-experimental-features = auto-allocate-uids cgroups\n' | sudo tee /etc/nix/nix.custom.conf
   sudo systemctl restart nix-daemon.service
 
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  nix develop --accept-flake-config --command just activate-home ubuntu
+
   # Agent commands run in non-interactive shells, which read neither
-  # /etc/bash.bashrc nor /etc/profile.d/nix.sh.
-  echo "BASH_ENV=/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" >> $ENVRC
+  # /etc/bash.bashrc nor /etc/profile.d/nix.sh. The Home Manager-managed
+  # wrapper sources nix-daemon.sh and, when SOPS_AGE_KEY_UBUNTU is present,
+  # seeds the age key file and re-runs the current Home Manager generation.
+  sed -i '/^BASH_ENV=/d' "$ENVRC" 2>/dev/null || true
+  echo "BASH_ENV=$HOME/.config/vanixiets/devin-bash-env.sh" >> "$ENVRC"
 
   # QEMU-flavor NixOS tests run as a nix build user inside the sandbox, and
   # nix-daemon drops supplementary groups for those users, so adding anyone to the
@@ -53,11 +59,11 @@ maintenance: |
   # .agents/ is gitignored, so a fresh clone carries none of the repo's skills, and
   # the devshell shellHook only composes AGENTS.md/CLAUDE.md - apm-skills-install is
   # what materializes .agents/skills/, which is the only place a harness discovers
-  # them. apm rewrites apm.lock.yaml's generated_at on every run, so the tracked file
-  # is put back afterwards; the snapshot is expected to start on a clean tree.
+  # them. Frozen installs skip the lockfile write when the assembled state is
+  # semantically equal, so preserve the tracked file around the install.
   cp apm.lock.yaml /tmp/apm.lock.yaml.pre-install
+  trap 'cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml' EXIT
   direnv exec . just agents-install
-  cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml
 knowledge:
   - name: lint
     contents: |
@@ -82,8 +88,11 @@ knowledge:
   - name: notes
     contents: |
       Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.
-      x86_64-linux only: darwinConfigurations, checks.aarch64-*, and `just activate*` cannot run here.
-      No age/sops keys are provisioned, so sops, clan vars, and secret-decrypting recipes fail by design.
+      x86_64-linux only: darwinConfigurations and checks.aarch64-* cannot run here.
+      `just activate-home ubuntu` is how the image is built. Secrets for the
+      ubuntu profile decrypt from `~/.config/sops/age/keys.txt`, seeded at
+      session start from the user-scoped Devin secret SOPS_AGE_KEY_UBUNTU (the
+      only secret); other sops/clan recipes still fail by design.
       The nix store grows quickly on the sandbox disk; reclaim with `direnv exec . just gc`.
       AGENTS.md, CLAUDE.md and .agents/skills/ are generated and gitignored: entering the
       devshell composes the first two, `just agents-install` deploys the skills. Never edit

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -65,6 +65,8 @@ maintenance: |
   cp apm.lock.yaml /tmp/apm.lock.yaml.pre-install
   trap 'cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml' EXIT
   direnv exec . just agents-install
+  cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml
+  trap - EXIT
 knowledge:
   - name: lint
     contents: |

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -59,8 +59,9 @@ maintenance: |
   # .agents/ is gitignored, so a fresh clone carries none of the repo's skills, and
   # the devshell shellHook only composes AGENTS.md/CLAUDE.md - apm-skills-install is
   # what materializes .agents/skills/, which is the only place a harness discovers
-  # them. Frozen installs skip the lockfile write when the assembled state is
-  # semantically equal, so preserve the tracked file around the install.
+  # them. `apm install --frozen` still rewrites apm.lock.yaml whenever the assembled
+  # state is not semantically equal to the file, so the tracked file is put back
+  # afterwards, on failure too; the snapshot is expected to start on a clean tree.
   cp apm.lock.yaml /tmp/apm.lock.yaml.pre-install
   trap 'cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml' EXIT
   direnv exec . just agents-install

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -12,6 +12,7 @@ keys:
   - &janettesmith-user age1mqfqckczkulpne7265j5cxn0pspdlxd3d0kav368u2c2fwknnc4qe27dec  # derived from SSH key via ssh-to-age
   - &christophersmith-user age1xz7gmqx7m0pn8u2nq8x05efq6dj52ym6c9gat5xj4am6x9sauq6sfzd2fn  # derived from SSH key via ssh-to-age
   - &tara-user age1krkf4ht5r2uufp0qkj6eu7pj9j04n7lz0tjlazmqzc3lhnjqt99sam42yp  # from sops-tara-user-ssh in Bitwarden
+  - &ubuntu-user age1mg67ytvlmsyj6a7hk7v0p905jydx4vd483yqqsejf0n0vncmhy4sgu43kj  # from devin-ubuntu-ssh in Bitwarden via ssh-to-age
 
   # Host keys (generated in Bitwarden, deployed to /etc/ssh/)
   - &stibnite age1a696klqy0s36a2pzlk6kyckp60k88qxcrsdh829dtk3xtc7sfs4scg05k0     # from sops-stibnite-ssh
@@ -79,6 +80,13 @@ creation_rules:
         - *admin
         - *dev
         - *janettesmith-user
+
+  - path_regex: secrets/home-manager/users/ubuntu/.*\.yaml$
+    key_groups:
+      - age:
+        - *admin
+        - *dev
+        - *ubuntu-user
 
   - path_regex: secrets/home-manager/users/christophersmith/.*\.yaml$
     key_groups:

--- a/modules/devshells/default.nix
+++ b/modules/devshells/default.nix
@@ -113,6 +113,7 @@
           pkgs.duckdb
           self'.packages.linear-cli
           self'.packages.mergify-cli-bin
+          inputs'.llm-agents.packages.apm
           inputs'.llm-agents.packages.openspec
         ]
         # buildbot-effects CLI for local dispatch of hercules-ci-effects

--- a/modules/home/app.nix
+++ b/modules/home/app.nix
@@ -66,9 +66,9 @@
                 fi
 
                 system="${system}"
-                # Full flake attribute path including activationPackage
-                # Format: flake#homeConfigurations."USERNAME@SYSTEM".activationPackage
-                config_path="homeConfigurations.\"$username@$system\".activationPackage"
+                # Format: flake#homeConfigurations."USERNAME@SYSTEM"
+                # nh appends config.home.activationPackage itself.
+                config_path="homeConfigurations.\"$username@$system\""
 
                 cat <<-EOF
                 	Activating home-manager configuration...
@@ -79,10 +79,10 @@
 
                 	EOF
 
-                # Use full installable path (not -c flag) for nested structure
+                # Select the configuration by name so nh can append its activation path.
                 # Pass any additional arguments (like --dry, --verbose, etc.) to nh
                 # Always include --accept-flake-config for nh's internal nix calls
-                exec nh home switch "$flake#$config_path" --accept-flake-config "$@"
+                exec nh home switch "$flake" --configuration "$username@$system" --accept-flake-config "$@"
               '';
             }
           );

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -1,14 +1,18 @@
+{ inputs, ... }:
+let
+  nixIndexModule = inputs.nix-index-database.homeModules.nix-index;
+in
 {
   flake.users.ubuntu.contentPrivate =
     {
       config,
       pkgs,
       lib,
-      flake,
       ...
     }:
     let
       keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+      apm = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.apm;
       sopsEnvironment = lib.concatStringsSep " " (
         lib.mapAttrsToList (
           name: value: "${name}=${lib.escapeShellArg (toString value)}"
@@ -17,7 +21,7 @@
       sopsExecStart = lib.head config.systemd.user.services.sops-nix.Service.ExecStart;
     in
     {
-      imports = [ flake.inputs.nix-index-database.homeModules.nix-index ];
+      imports = [ nixIndexModule ];
 
       home.stateVersion = "26.11";
 
@@ -26,11 +30,11 @@
         pkgs.linear-cli
       ]
       ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-        flake.inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.apm
+        apm
       ];
 
       sops = {
-        defaultSopsFile = flake.inputs.self + "/secrets/home-manager/users/ubuntu/secrets.yaml";
+        defaultSopsFile = inputs.self + "/secrets/home-manager/users/ubuntu/secrets.yaml";
         age.keyFile = keyFile;
         secrets = {
           linear-api-key-personal = { };

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -1,0 +1,129 @@
+{
+  flake.users.ubuntu.contentPrivate =
+    {
+      config,
+      pkgs,
+      lib,
+      flake,
+      ...
+    }:
+    let
+      keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+      sopsEnvironment = lib.concatStringsSep " " (
+        lib.mapAttrsToList (
+          name: value: "${name}=${lib.escapeShellArg (toString value)}"
+        ) config.sops.environment
+      );
+      sopsExecStart = lib.head config.systemd.user.services.sops-nix.Service.ExecStart;
+    in
+    {
+      imports = [ flake.inputs.nix-index-database.homeModules.nix-index ];
+
+      home.stateVersion = "26.11";
+
+      home.packages = [
+        pkgs.just
+        pkgs.linear-cli
+      ]
+      ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+        flake.inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.apm
+      ];
+
+      sops = {
+        defaultSopsFile = flake.inputs.self + "/secrets/home-manager/users/ubuntu/secrets.yaml";
+        age.keyFile = keyFile;
+        secrets = {
+          linear-api-key-personal = { };
+          linear-api-key-work = { };
+        };
+        templates."linear-credentials.toml" = {
+          mode = "0400";
+          path = "${config.xdg.configHome}/linear/credentials.toml";
+          content = ''
+            default = "cameronraysmith"
+
+            cameronraysmith = "${config.sops.placeholder."linear-api-key-personal"}"
+            parametricbio = "${config.sops.placeholder."linear-api-key-work"}"
+          '';
+        };
+      };
+
+      home.activation.sopsNixWithoutSystemd =
+        lib.hm.dag.entryAfter
+          [
+            "sops-nix"
+            "writeBoundary"
+          ]
+          ''
+             systemdStatus=$(${config.systemd.user.systemctlPath} --user is-system-running 2>&1 || true)
+             if [[ $systemdStatus == running || $systemdStatus == degraded ]]; then
+               echo "sops-nix user systemd is active; no direct activation needed"
+             elif [[ -s "${keyFile}" ]]; then
+               runtimeDir="''${XDG_RUNTIME_DIR:-${config.xdg.stateHome}/sops-nix/runtime}"
+               if [[ -z ''${XDG_RUNTIME_DIR:-} ]]; then
+                 run mkdir -p -m 0700 "$runtimeDir"
+               fi
+            run env XDG_RUNTIME_DIR="$runtimeDir" ${sopsEnvironment} ${sopsExecStart}
+             else
+               echo "sops-nix fallback skipped: age key file is absent"
+             fi
+             unset systemdStatus
+          '';
+
+      xdg.configFile."vanixiets/devin-bash-env.sh".text = ''
+        if [ -n "''${VANIXIETS_DEVIN_BASH_ENV:-}" ]; then
+          return 0 2>/dev/null || exit 0
+        fi
+        export VANIXIETS_DEVIN_BASH_ENV=1
+
+        if [ -r /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        fi
+
+        for hmSessionVars in \
+          "$HOME/.local/state/nix/profiles/profile/etc/profile.d/hm-session-vars.sh" \
+          "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+        do
+          if [ -r "$hmSessionVars" ]; then
+            . "$hmSessionVars"
+            break
+          fi
+        done
+
+        case ":''${PATH:-}:" in
+          *":$HOME/.nix-profile/bin:"*) ;;
+          *) PATH="$HOME/.nix-profile/bin:''${PATH:-}"; export PATH ;;
+        esac
+
+        keyFile="${keyFile}"
+        if [ -n "''${SOPS_AGE_KEY_UBUNTU:-}" ] && [ ! -s "$keyFile" ]; then
+          (
+            umask 077
+            mkdir -p "$(dirname "$keyFile")"
+            printf '%s\n' "$SOPS_AGE_KEY_UBUNTU" > "$keyFile"
+          )
+
+          logFile="$HOME/.local/state/vanixiets/devin-reactivate.log"
+          mkdir -p "$(dirname "$logFile")"
+          activate=""
+          for homeManagerProfile in \
+            "$HOME/.local/state/nix/profiles/home-manager" \
+            "/nix/var/nix/profiles/per-user/$USER/home-manager"
+          do
+            if [ -x "$homeManagerProfile/activate" ]; then
+              activate="$homeManagerProfile/activate"
+              break
+            fi
+          done
+
+          if [ -n "$activate" ]; then
+            if ! "$activate" >> "$logFile" 2>&1; then
+              printf '%s\n' "home-manager reactivation failed; see $logFile" >&2
+            fi
+          else
+            printf '%s\n' "home-manager activation profile not found" >&2
+          fi
+        fi
+      '';
+    };
+}

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -100,12 +100,15 @@ in
         esac
 
         keyFile="${keyFile}"
-        if [ -n "''${SOPS_AGE_KEY_UBUNTU:-}" ] && [ ! -s "$keyFile" ]; then
-          (
-            umask 077
-            mkdir -p "$(dirname "$keyFile")"
-            printf '%s\n' "$SOPS_AGE_KEY_UBUNTU" > "$keyFile"
-          )
+        stamp="$HOME/.local/state/vanixiets/devin-reactivated"
+        if [ -n "''${SOPS_AGE_KEY_UBUNTU:-}" ] && [ ! -e "$stamp" ]; then
+          if [ ! -s "$keyFile" ]; then
+            (
+              umask 077
+              mkdir -p "$(dirname "$keyFile")"
+              printf '%s\n' "$SOPS_AGE_KEY_UBUNTU" > "$keyFile"
+            )
+          fi
 
           logFile="$HOME/.local/state/vanixiets/devin-reactivate.log"
           mkdir -p "$(dirname "$logFile")"
@@ -121,7 +124,9 @@ in
           done
 
           if [ -n "$activate" ]; then
-            if ! "$activate" >> "$logFile" 2>&1; then
+            if "$activate" >> "$logFile" 2>&1; then
+              : > "$stamp"
+            else
               printf '%s\n' "home-manager reactivation failed; see $logFile" >&2
             fi
           else

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -55,19 +55,19 @@
             "writeBoundary"
           ]
           ''
-             systemdStatus=$(${config.systemd.user.systemctlPath} --user is-system-running 2>&1 || true)
-             if [[ $systemdStatus == running || $systemdStatus == degraded ]]; then
-               echo "sops-nix user systemd is active; no direct activation needed"
-             elif [[ -s "${keyFile}" ]]; then
-               runtimeDir="''${XDG_RUNTIME_DIR:-${config.xdg.stateHome}/sops-nix/runtime}"
-               if [[ -z ''${XDG_RUNTIME_DIR:-} ]]; then
-                 run mkdir -p -m 0700 "$runtimeDir"
-               fi
-            run env XDG_RUNTIME_DIR="$runtimeDir" ${sopsEnvironment} ${sopsExecStart}
-             else
-               echo "sops-nix fallback skipped: age key file is absent"
-             fi
-             unset systemdStatus
+            systemdStatus=$(${config.systemd.user.systemctlPath} --user is-system-running 2>&1 || true)
+            if [[ $systemdStatus == running || $systemdStatus == degraded ]]; then
+              echo "sops-nix user systemd is active; no direct activation needed"
+            elif [[ -s "${keyFile}" ]]; then
+              runtimeDir="''${XDG_RUNTIME_DIR:-${config.xdg.stateHome}/sops-nix/runtime}"
+              if [[ -z ''${XDG_RUNTIME_DIR:-} ]]; then
+                run mkdir -p -m 0700 "$runtimeDir"
+              fi
+              run env XDG_RUNTIME_DIR="$runtimeDir" ${sopsEnvironment} ${sopsExecStart}
+            else
+              echo "sops-nix fallback skipped: age key file is absent"
+            fi
+            unset systemdStatus
           '';
 
       xdg.configFile."vanixiets/devin-bash-env.sh".text = ''

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -52,7 +52,7 @@ in
         };
       };
 
-      home.activation.sopsNixWithoutSystemd =
+      home.activation.sopsNixWithoutSystemd = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
         lib.hm.dag.entryAfter
           [
             "sops-nix"
@@ -72,7 +72,8 @@ in
               echo "sops-nix fallback skipped: age key file is absent"
             fi
             unset systemdStatus
-          '';
+          ''
+      );
 
       xdg.configFile."vanixiets/devin-bash-env.sh".text = ''
         if [ -n "''${VANIXIETS_DEVIN_BASH_ENV:-}" ]; then
@@ -101,36 +102,39 @@ in
 
         keyFile="${keyFile}"
         stamp="$HOME/.local/state/vanixiets/devin-reactivated"
-        if [ -n "''${SOPS_AGE_KEY_UBUNTU:-}" ] && [ ! -e "$stamp" ]; then
-          if [ ! -s "$keyFile" ]; then
+        if [ -n "''${SOPS_AGE_KEY_UBUNTU:-}" ]; then
+          if [ ! -s "$keyFile" ] || [ "$(cat "$keyFile")" != "$SOPS_AGE_KEY_UBUNTU" ]; then
             (
               umask 077
               mkdir -p "$(dirname "$keyFile")"
               printf '%s\n' "$SOPS_AGE_KEY_UBUNTU" > "$keyFile"
             )
+            rm -f "$stamp"
           fi
 
-          logFile="$HOME/.local/state/vanixiets/devin-reactivate.log"
-          mkdir -p "$(dirname "$logFile")"
-          activate=""
-          for homeManagerProfile in \
-            "$HOME/.local/state/nix/profiles/home-manager" \
-            "/nix/var/nix/profiles/per-user/$USER/home-manager"
-          do
-            if [ -x "$homeManagerProfile/activate" ]; then
-              activate="$homeManagerProfile/activate"
-              break
-            fi
-          done
+          if [ ! -e "$stamp" ]; then
+            logFile="$HOME/.local/state/vanixiets/devin-reactivate.log"
+            mkdir -p "$(dirname "$logFile")"
+            activate=""
+            for homeManagerProfile in \
+              "$HOME/.local/state/nix/profiles/home-manager" \
+              "/nix/var/nix/profiles/per-user/$USER/home-manager"
+            do
+              if [ -x "$homeManagerProfile/activate" ]; then
+                activate="$homeManagerProfile/activate"
+                break
+              fi
+            done
 
-          if [ -n "$activate" ]; then
-            if "$activate" >> "$logFile" 2>&1; then
-              : > "$stamp"
+            if [ -n "$activate" ]; then
+              if "$activate" >> "$logFile" 2>&1; then
+                : > "$stamp"
+              else
+                printf '%s\n' "home-manager reactivation failed; see $logFile" >&2
+              fi
             else
-              printf '%s\n' "home-manager reactivation failed; see $logFile" >&2
+              printf '%s\n' "home-manager activation profile not found" >&2
             fi
-          else
-            printf '%s\n' "home-manager activation profile not found" >&2
           fi
         fi
       '';

--- a/modules/home/users/ubuntu/meta.nix
+++ b/modules/home/users/ubuntu/meta.nix
@@ -1,0 +1,17 @@
+{ config, ... }:
+{
+  flake.users.ubuntu = {
+    meta = {
+      username = "ubuntu";
+      fullname = "Cameron Smith";
+      email = "cameron.ray.smith@gmail.com";
+      githubUser = "cameronraysmith";
+      sopsAgeKeyId = null;
+      sshKeys = [ ];
+    };
+    aggregates = with config.flake.modules.homeManager; [
+      base-sops
+      terminal
+    ];
+  };
+}

--- a/secrets/home-manager/users/ubuntu/secrets.yaml
+++ b/secrets/home-manager/users/ubuntu/secrets.yaml
@@ -1,0 +1,35 @@
+linear-api-key-personal: ENC[AES256_GCM,data:ipOEOuNW9xp1WAewBWL9btzHo/S0HSlyWwDkBgPULjuJS7VX3CIQC3SJZNALiViD,iv:ypu19g/AQ2Khhwb2sv7FEVPzE8dB4Xroo2Ni7/WtACg=,tag:Xq87hEGbY5nV5kXJvXUxug==,type:str]
+linear-api-key-work: ENC[AES256_GCM,data:e7NM52oKWeDKuCUwCMBsDid00QM5Rb1pxrS7eo1xI3AGagApPEHaRvPGB3qc0Boh,iv:jmuK5+v8oH+jVOLOUtDdI2dEW5qwkAY+UhfG9VtP0sc=,tag:cX/d3Y0PzEKmjT6MdXkqTQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSZG9CWHlXTWszVWtSeUdn
+            cFpkRjh2VktLL29KejFQM200MVRsZXVBbVhZCkJTMVc0bHdZNHJScmJadE4rWmdH
+            QytpY3hOd0pGNzF5emkvT25DZE9aVDgKLS0tIHFnVTN4ckFXcUtZWWtXRXYzZ1FN
+            Tm80TVcvRzhqLzZWTGxvSVVhRGQ1dkUKue9stAje9EHJMt6cG2uP73tYryDE3nFt
+            pKTbb8A2Lw2tSlSfTS9jKtLYO9eh8TPEIRdw2RrbfTSK5F00O82ucw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vy7wsnf8eg5229evq3ywup285jzk9cntsx5hhddjtwsjh0kf4c6s9fmalv
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSZWVRVkxBM0lHeEhtVGxQ
+            d0FxN09sTUtGN2xyQ1JDRVBwTUhtckhNenhnCk5UVUgwZTZjZHkrZWFHcUY1bUVx
+            WnV3MnhTTWJwK1JiL0JXSDNxRDZlNEkKLS0tIFFhemY1c2JSU3JDOHJWcUpJZStJ
+            ZVhMR2R0SUNyaVVkMGZFSm1LM2VGNXcKWkPAKoZiPfCsJGSHZdfHKepFFJhIXfhp
+            Hkg0w1jlHeLWd4Z3o4/gC0KeshVqVT8buPKMPLOdeMAhx2qQ9t+QUw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1js028xag70wpwpp47elpq50mjjv7zn7sxuwuhk8yltkjzqzdvq5qq8w8cy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiOUpPbDA1UDY5bUlmTTdq
+            anJrWjUydEZhT0E5cGQwTlpMTkZOaDJxUUVFClMwM3djektaczMrbG82QW1zbGky
+            YVNUZW9RKzdVM0I0TzFJS3Vnb1ZwTk0KLS0tIE1zcjFZdW5xTDlub3I4eGl3YzV0
+            SmI5c2ZoZ1o4OTFDdTBPOGlXOEloNTQKExj8ebDmC27SYvhJwj0anOJjDO4+6N3y
+            dzl+XGkjaRGgYhG2PUwgKVKF+2xornG7gKcRIHmoCDdUgkkzNAvkXw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1mg67ytvlmsyj6a7hk7v0p905jydx4vd483yqqsejf0n0vncmhy4sgu43kj
+    lastmodified: "2026-09-04T03:39:15Z"
+    mac: ENC[AES256_GCM,data:XnaoH2gdnjfGjzi+JH+4Y8Tk/M0MG4wncFYcYW0f3L2zNhVcDSifBz85fOC3yInyN1T9zGAKCTb6uGv7LqnpvQ/4FwD/UtzYzTWuOpFd59DJqGdrqXBC5ZDcCKQw7YHs2OV8lEBug9ZyU1aBhQ7ST/opz93HG5GDhHKSsVdn368=,iv:ZRNNjkV5W9DSzJHW1D4vFHKZ35pE0/klSJGZW/ukWzA=,tag:U8B/IahRuF3kltCALEGTrQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
## Summary

Adds a standalone home-manager profile for the Devin sandbox user (`flake.users.ubuntu`, so `homeConfigurations."ubuntu@x86_64-linux"` and the `home-manager-ubuntu` check appear through the existing discovery), and makes the image build activate it once from `.devin/blueprint.yaml`. Every session then reaches a fully configured state from exactly one Devin user-scoped secret, `SOPS_AGE_KEY_UBUNTU`; the `LINEAR_API_KEY_*` secrets become redundant once this is deployed.

How the two phases work with one key:

```
snapshot build (no secrets):   just activate-home ubuntu
  sops-nix hm module: no user systemd -> logs and continues; manifest check only needs ciphertext
  home.activation.sopsNixWithoutSystemd: key file absent -> notice, exit 0
  writes ~/.config/vanixiets/devin-bash-env.sh; blueprint points BASH_ENV at it

session start (SOPS_AGE_KEY_UBUNTU in env): first non-interactive bash sources the wrapper
  [ -n SOPS_AGE_KEY_UBUNTU ] && [ ! -s ~/.config/sops/age/keys.txt ]
    -> umask 077; write key; run ~/.local/state/nix/profiles/home-manager/activate
  sopsNixWithoutSystemd: key present, user systemd absent
    -> env XDG_RUNTIME_DIR=${xdg.stateHome}/sops-nix/runtime <sops.environment> <sops-nix-user ExecStart>
    -> ~/.config/linear/credentials.toml (0400) rendered from secrets/home-manager/users/ubuntu/secrets.yaml
```

Design points not obvious from the code:

- Profile = `base-sops` + `terminal` aggregates plus a private module. `core`, `development`, `shell`, `ai`, `packages`, `tools/agents-md` are excluded because they consume other secrets (ssh signing key, atuin, MCP keys); `terminal` needs `nix-index-database`, normally supplied by `core`, so the profile imports it directly.
- The pinned `sops-install-secrets` calls `RuntimeDir()` in user mode regardless of path overrides (sops-nix `main.go:1331`, `linux.go:14`), so the fallback hook supplies `XDG_RUNTIME_DIR` under HM state. Decrypted secrets land on disk instead of tmpfs; the rendered credentials file is on disk anyway and no key is ever in the image.
- The key stays a file (sops-nix reads `sops.age.keyFile` into `SOPS_AGE_KEY_FILE`); the env var is only the transport from Devin into the session, and its non-canonical name keeps it away from CLIs that read `SOPS_AGE_KEY`.
- `.#home` app: nh 4.4.2 rejects `homeConfigurations.<name>.activationPackage` ("Attribute path is too specific", `nh-home/src/home.rs:279`) and a bare `homeConfigurations."u@s"` installable also failed type-checking, so the app now passes the flake plus `--configuration "$username@$system"`. This also fixes `just activate-home <user>` for any standalone user.
- `.sops.yaml`: new `&ubuntu-user` recipient (age key derived with `ssh-to-age` from the Bitwarden `devin-ubuntu-ssh` key) and a rule for `secrets/home-manager/users/ubuntu/`; the secrets file was encrypted to admin, dev, ubuntu-user with public recipients only.
- Blueprint: activation moves into `initialize` after the nix-daemon restart; the `BASH_ENV` line is rewritten idempotently; `apm install --frozen` keeps its lockfile backup but restores via an `EXIT` trap because the pinned apm still writes the lockfile when the assembled state differs (`install/phases/lockfile.py:530`). Skill materialization stays in the blueprint rather than an activation hook because it mutates the checkout and needs network; the tradeoff is two owners (profile + blueprint).
- `apm` added to the devshell (D5).

Requirements and the assumptions discharging them:

- Build with no key succeeds — discharged: sops-nix Linux hook skips when `systemctl --user is-system-running` is not running/degraded, verified on this VM (`sops-nix fallback skipped: age key file is absent`).
- One key decrypts all profile secrets — discharged: with `SOPS_AGE_KEY_UBUNTU` in the environment of a fresh `env -i … BASH_ENV=<wrapper> bash`, the wrapper wrote `keys.txt` (0600), re-ran `activate`, `sopsNixWithoutSystemd` rendered `~/.config/linear/credentials.toml` (0400), and a later env-free shell got `linear auth list` with both workspaces and `linear --workspace parametricbio auth whoami` resolving. The `LINEAR_API_KEY_*` Devin secrets can be deleted after the snapshot is rebuilt.
- Reactivation is idempotent and retried — discharged by HM's `writeBoundary` handling of `oldGenPath == newGenPath`; the wrapper is gated on a success stamp (`~/.local/state/vanixiets/devin-reactivated`, written only after `activate` exits 0), so a failed activation is retried by the next shell rather than silenced by the existing key file. Key rotation: the wrapper rewrites the key file and clears the stamp whenever `SOPS_AGE_KEY_UBUNTU` differs from the file's content (verified locally: dummy key → rewrite + failed activation, real key → rewrite + successful activation + `linear auth list`).
- The ubuntu profile evaluates on Darwin too (`homeConfigurations."ubuntu@aarch64-darwin"` is emitted for every system) — discharged by gating the `sopsNixWithoutSystemd` hook on `isLinux`; `nix eval` of the Darwin activationPackage drvPath succeeds.
- Snapshot behaviour of the new blueprint — **undischarged**: the blueprint edits were reasoned from source and this VM, not from a fresh snapshot build.

Verified here: V3 as above; `nix build .#homeConfigurations."ubuntu@x86_64-linux".activationPackage`; `just activate-home ubuntu` with no key; `env -i … BASH_ENV=~/.config/vanixiets/devin-bash-env.sh bash -c 'command -v linear apm just direnv'` lists all four; `just lint` passes; tree clean.


Link to Devin session: https://app.devin.ai/sessions/a2d8493b4f0f443581a8b510ab915dc4
Open in Devin Desktop: https://app.devin.ai/desktop/session/a2d8493b4f0f443581a8b510ab915dc4?variant=devin
Requested by: @cameronraysmith