### PR TITLE
feat(home): gate homeConfigurations emission on a per-user systems list

### DIFF
--- a/modules/checks/home.nix
+++ b/modules/checks/home.nix
@@ -8,9 +8,9 @@
 #
 # Iterates every user emitted into `homeConfigurations` for the current system
 # — including aliases (e.g. cameron) materialized by `aliases-fold.nix` — by
-# filtering `flake.users` to those with non-empty `aggregates`. Single source
-# of truth: drift between `configurations.nix`'s emission rule and this check
-# set is impossible.
+# filtering `flake.users` to those with non-empty `aggregates` whose `systems`
+# covers this system. Single source of truth: drift between
+# `configurations.nix`'s emission rule and this check set is impossible.
 #
 # Binds the activationPackage directly (no overrideAttrs wrapper). A prior
 # revision wrapped it with overrideAttrs to add a cosmetic meta.description,
@@ -29,7 +29,9 @@
   perSystem =
     { system, ... }:
     let
-      enumerableUsers = lib.attrNames (lib.filterAttrs (_: u: u.aggregates != [ ]) config.flake.users);
+      enumerableUsers = lib.attrNames (
+        lib.filterAttrs (_: u: u.aggregates != [ ] && lib.elem system u.systems) config.flake.users
+      );
     in
     {
       checks = lib.listToAttrs (

--- a/modules/checks/structure/flake-shape.nix
+++ b/modules/checks/structure/flake-shape.nix
@@ -69,7 +69,7 @@
           let
             enumerableUsers = lib.attrNames (lib.filterAttrs (_: u: u.aggregates != [ ]) config.flake.users);
             expectedKeys = lib.naturalSort (
-              lib.concatMap (u: map (s: "${u}@${s}") config.systems) enumerableUsers
+              lib.concatMap (u: map (s: "${u}@${s}") config.flake.users.${u}.systems) enumerableUsers
             );
           in
           mkCheck {

--- a/modules/home/configurations.nix
+++ b/modules/home/configurations.nix
@@ -17,7 +17,7 @@ let
         value = config.flake.lib.mkHome {
           inherit user system;
         };
-      }) config.systems
+      }) config.flake.users.${user}.systems
     ) enumerableUserNames
   );
 
@@ -39,7 +39,7 @@ let
             user = aliasName;
             inherit system;
           };
-        }) config.systems
+        }) config.flake.users.${aliasName}.systems
       )
     ) (lib.attrsToList config.flake.userAliases)
   );

--- a/modules/home/users/aliases-fold.nix
+++ b/modules/home/users/aliases-fold.nix
@@ -17,6 +17,7 @@
         username = alias;
       };
       aggregates = config.flake.users.${target}.aggregates;
+      systems = config.flake.users.${target}.systems;
       contentPrivate = config.flake.users.${target}.contentPrivate;
       # mkForce on identity setters: the canonical default identity (synthesized
       # in `users/lib.nix` from the attribute key) sets

--- a/modules/home/users/lib.nix
+++ b/modules/home/users/lib.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
   # Synthesize a home-manager identity module fragment from a username,
   # parameterized over whether the setters use `lib.mkDefault` (canonical
@@ -23,6 +23,8 @@ let
         if pkgs.stdenv.isDarwin then "/Users/${config.home.username}" else "/home/${config.home.username}"
       );
     };
+
+  flakeSystems = config.systems;
 in
 {
   config.flake.lib.mkUserIdentity = mkUserIdentity;
@@ -35,7 +37,8 @@ in
       Each user provides identity metadata under `meta` and a list of
       capability-aggregate home-manager modules under `aggregates`. The
       `homeConfigurations` flake output is emitted only for users whose
-      `aggregates` is non-empty (conservative auto-discovery).
+      `aggregates` is non-empty (conservative auto-discovery), and only
+      for the systems listed in `systems`.
     '';
     default = { };
     type = lib.types.attrsOf (
@@ -78,6 +81,19 @@ in
                   `users.users.<u>.openssh.authorizedKeys.keys` setters.
                 '';
               };
+            };
+            systems = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = flakeSystems;
+              defaultText = lib.literalExpression "config.systems";
+              description = ''
+                Systems for which this user's
+                `homeConfigurations."<user>@<system>"` entry is emitted, and
+                for which the per-user home-manager activation check is
+                wired. Defaults to every system the flake builds for;
+                narrow it for a user whose profile only makes sense on a
+                subset (e.g. a Linux-only agent sandbox account).
+              '';
             };
             aggregates = lib.mkOption {
               type = lib.types.listOf lib.types.deferredModule;

--- a/modules/home/users/lib.test.nix
+++ b/modules/home/users/lib.test.nix
@@ -1,0 +1,77 @@
+# nix-unit invariants for the `flake.users.<u>.systems` field declared in
+# modules/home/users/lib.nix.
+#
+# Evaluates the submodule against a stub two-system flake and asserts both
+# the default (every system the flake builds for) and the narrowing case,
+# including the `<user>@<system>` key set that `configurations.nix` and
+# `modules/checks/home.nix` derive from it. Catches a regression where the
+# field stops being honoured and every user is emitted for every system.
+{ config, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.eval-users-lib = config.flake.lib.mkEvalCheck pkgs {
+        name = "users-lib";
+        testFile = pkgs.writeText "users-lib.tests.nix" ''
+          let
+            lib = import ${pkgs.path}/lib;
+
+            usersOption =
+              (import ${./lib.nix} {
+                inherit lib;
+                config.systems = [
+                  "aarch64-darwin"
+                  "x86_64-linux"
+                ];
+              }).options.flake.users;
+
+            meta = {
+              username = "stub";
+              fullname = "Stub User";
+              email = "stub@example.com";
+            };
+
+            users =
+              (lib.evalModules {
+                modules = [
+                  { options.users = usersOption; }
+                  {
+                    users.unrestricted.meta = meta;
+                    users.restricted = {
+                      inherit meta;
+                      systems = [ "x86_64-linux" ];
+                    };
+                  }
+                ];
+              }).config.users;
+          in
+          {
+            testDefaultIsEveryFlakeSystem = {
+              expr = users.unrestricted.systems;
+              expected = [
+                "aarch64-darwin"
+                "x86_64-linux"
+              ];
+            };
+
+            testExplicitListNarrowsSystems = {
+              expr = users.restricted.systems;
+              expected = [ "x86_64-linux" ];
+            };
+
+            testEmissionKeysOmitUnlistedSystem = {
+              expr = lib.naturalSort (
+                lib.concatMap (u: map (s: "''${u}@''${s}") users.''${u}.systems) (lib.attrNames users)
+              );
+              expected = [
+                "restricted@x86_64-linux"
+                "unrestricted@aarch64-darwin"
+                "unrestricted@x86_64-linux"
+              ];
+            };
+          }
+        '';
+      };
+    };
+}


### PR DESCRIPTION
`configurations.nix` mapped every `flake.users` entry over `config.systems`,
so a user whose profile only makes sense on one platform still got a phantom
`homeConfigurations."<user>@<system>"` entry on every other one, kept
evaluable by hand-rolled `isLinux` guards inside the user's own modules.

`flake.users.<u>.systems` defaults to `config.systems`, so every existing
user is unaffected, and the two consumers that enumerate users per system —
the activation-package checks in `modules/checks/home.nix` and the shape
expectation in `structure/flake-shape.nix` — read the same field, leaving no
way for the emission rule and the check set to diverge.