### PR TITLE
fix(home): let terminal aggregate declare its own nix-index import

### DIFF
--- a/modules/home/core/nix-index.nix
+++ b/modules/home/core/nix-index.nix
@@ -1,9 +1,0 @@
-# nix-index-database home-manager module integration.
-{ ... }:
-{
-  flake.modules.homeManager.core =
-    { flake, ... }:
-    {
-      imports = [ flake.inputs.nix-index-database.homeModules.nix-index ];
-    };
-}

--- a/modules/home/terminal/nix-index.nix
+++ b/modules/home/terminal/nix-index.nix
@@ -1,8 +1,10 @@
 { ... }:
 {
   flake.modules.homeManager.terminal =
-    { ... }:
+    { flake, ... }:
     {
+      imports = [ flake.inputs.nix-index-database.homeModules.nix-index ];
+
       programs.nix-index = {
         enable = true;
         enableZshIntegration = true;


### PR DESCRIPTION
`modules/home/terminal/nix-index.nix` set `programs.nix-index.*` and
`programs.nix-index-database.comma.enable`, but the module declaring those
options was imported by `modules/home/core/nix-index.nix`, which contributed
nothing else. The `terminal` aggregate therefore carried an undeclared
dependency on `core`: a user whose `aggregates` listed `terminal` without
`core` failed to evaluate with "The option `programs.nix-index-database' does
not exist". Move the import into the file that configures it and drop the
core-side file, matching the arrangement already used by `base/sops.nix`,
`terminal/direnv.nix`, `core/lazyvim.nix`, `core/catppuccin.nix`,
`ai/worktrunk`, and `ai/hunk`, each of which imports its upstream home module
in the same file that configures it.

Commit 72c5fe2f9 on `devin/1788493067-devin-ubuntu-home-profile` worked around
this in the `ubuntu` user's `contentPrivate` and attributed the hand-import's
form to evaluation recursion. That recursion does not reproduce: the tree at
16c20d04f, immediately before it, evaluates
`homeConfigurations."ubuntu@x86_64-linux".activationPackage.drvPath` without
error, as does the same `imports = [ flake.inputs.… ]` form injected into
another user's `contentPrivate` on this base. The `flake` argument is a
home-manager `extraSpecialArgs` value resolved inside the home-manager
`evalModules` call, downstream of the flake-parts fixpoint that produces
`config.flake`, so reading `flake.inputs` there does not re-enter that
fixpoint. Reading the flake-parts `config.flake` from a module that also
defines `flake.*` would, which is the shape to avoid.

Existing configurations are unaffected: `home.packages` for
`crs58@aarch64-darwin` holds the same 327 packages, differing only in the
order of two adjacent entries, and the `home-files` build command is identical
once store hashes are normalized.

Depends-On: #2939