### PR TITLE
feat(apps): bootstrap a home profile from a remote flake ref

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -24,9 +24,35 @@ initialize: |
   printf 'accept-flake-config = true\nauto-allocate-uids = true\nextra-experimental-features = auto-allocate-uids cgroups\n' | sudo tee /etc/nix/nix.custom.conf
   sudo systemctl restart nix-daemon.service
 
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  # Marks .envrc trusted so the maintenance step's `direnv exec .` calls work.
+  direnv allow
+
+  # Seeds ~/.config/sops/age/keys.txt from the sandbox's SOPS_AGE_KEY secret and
+  # activates homeConfigurations."ubuntu@x86_64-linux". The key has to be in
+  # place before activation, because sops-nix decrypts the profile's secrets during
+  # it. One-shot: it exits non-zero on failure rather than retrying, so a broken
+  # sandbox is visible here rather than in every later command.
+  # `--flake .` overrides the app's published default so a branch under test
+  # activates itself rather than main.
+  nix run --accept-flake-config .#home-bootstrap -- --flake .
+
   # Agent commands run in non-interactive shells, which read neither
-  # /etc/bash.bashrc nor /etc/profile.d/nix.sh.
-  echo "BASH_ENV=/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" >> $ENVRC
+  # /etc/bash.bashrc nor /etc/profile.d/nix.sh, so nix and the home-manager
+  # session variables have to be sourced from the per-shell env file.
+  # Appended only once: initialize runs per fresh sandbox, but a re-run would
+  # otherwise grow the file without bound.
+  : "${ENVRC:?ENVRC is unset; Devin normally provides it and these lines have nowhere to go}"
+  if ! grep -q 'hm-session-vars.sh' "$ENVRC" 2>/dev/null; then
+  cat >> "$ENVRC" <<'ENVRC_LINES'
+  if [ -r /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  fi
+  if [ -r "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh" ]; then
+    . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+  fi
+  ENVRC_LINES
+  fi
 
   # QEMU-flavor NixOS tests run as a nix build user inside the sandbox, and
   # nix-daemon drops supplementary groups for those users, so adding anyone to the
@@ -45,6 +71,12 @@ maintenance: |
   nix develop --accept-flake-config --command true
   # Warm the nix-direnv cache so later `direnv exec .` invocations skip flake evaluation.
   direnv allow
+
+  # A warm sandbox resumes on a newer commit than the one initialize activated, so
+  # re-run the bootstrap to bring the home-manager generation forward. Re-running is
+  # a no-op on the key file unless the secret rotated.
+  nix run --accept-flake-config .#home-bootstrap -- --flake .
+
   # `bun install` over the root workspace (packages/*), so packages/docs is covered;
   # incremental outside CI, unlike `bun run reinstall`, which maintenance forbids.
   # Playwright browsers come from the devshell's PLAYWRIGHT_BROWSERS_PATH, not a download.
@@ -53,11 +85,14 @@ maintenance: |
   # .agents/ is gitignored, so a fresh clone carries none of the repo's skills, and
   # the devshell shellHook only composes AGENTS.md/CLAUDE.md - apm-skills-install is
   # what materializes .agents/skills/, which is the only place a harness discovers
-  # them. apm rewrites apm.lock.yaml's generated_at on every run, so the tracked file
-  # is put back afterwards; the snapshot is expected to start on a clean tree.
+  # them. `apm install --frozen` still rewrites apm.lock.yaml whenever the assembled
+  # state is not semantically equal to the file, so the tracked file is put back
+  # afterwards, on failure too; the snapshot is expected to start on a clean tree.
   cp apm.lock.yaml /tmp/apm.lock.yaml.pre-install
+  trap 'cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml' EXIT
   direnv exec . just agents-install
   cp /tmp/apm.lock.yaml.pre-install apm.lock.yaml
+  trap - EXIT
 knowledge:
   - name: lint
     contents: |
@@ -82,8 +117,22 @@ knowledge:
   - name: notes
     contents: |
       Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.
-      x86_64-linux only: darwinConfigurations, checks.aarch64-*, and `just activate*` cannot run here.
-      No age/sops keys are provisioned, so sops, clan vars, and secret-decrypting recipes fail by design.
+      x86_64-linux only: darwinConfigurations and checks.aarch64-* cannot run here.
+      `nix run .#home-bootstrap -- --flake .` is how the image is built: it seeds
+      ~/.config/sops/age/keys.txt from the user-scoped Devin secret
+      SOPS_AGE_KEY (the only secret) and then activates
+      homeConfigurations."ubuntu@x86_64-linux", the same generation
+      `just activate-home ubuntu` would build. It runs in initialize and again in
+      maintenance; run it by hand after pulling a commit that changes the ubuntu
+      profile. `--flake .` is what makes this checkout activate itself instead of
+      the app's published default, so a branch under test is what reaches the
+      generation. Any other repository's blueprint activates the same profile with
+      no checkout of this one via
+      `nix run --accept-flake-config github:cameronraysmith/vanixiets#home-bootstrap`,
+      which requires nix installed by this repo's `make bootstrap` (it sets
+      trusted-users, so the flake's substituters are then honored) and SOPS_AGE_KEY
+      in the environment. Secrets for that profile decrypt from the seeded key;
+      other sops/clan recipes still fail by design.
       The nix store grows quickly on the sandbox disk; reclaim with `direnv exec . just gc`.
       AGENTS.md, CLAUDE.md and .agents/skills/ are generated and gitignored: entering the
       devshell composes the first two, `just agents-install` deploys the skills. Never edit

--- a/modules/apps/bootstrap/home-bootstrap.nix
+++ b/modules/apps/bootstrap/home-bootstrap.nix
@@ -1,0 +1,37 @@
+# Flake app: seed a home-manager profile's age key and activate that profile
+# from a flake reference, with no checkout of this repository.
+#
+# This is an app rather than a home-manager activation script or a shell-profile
+# hook because it must run before any home-manager generation exists: the key it
+# writes is what lets sops-nix decrypt the profile's secrets during the very
+# activation it then performs. A home-manager-generated hook that re-enters
+# activation is a fixpoint with no fixed point on first run.
+#
+# One-shot: no stamp file, no retry loop, no backgrounding. Idempotent, so a
+# warm-start path can re-run it to pick up a rotated secret and a newer commit.
+{ ... }:
+{
+  perSystem =
+    { pkgs, lib, ... }:
+    {
+      apps.home-bootstrap = {
+        type = "app";
+        program = lib.getExe (
+          pkgs.writeShellApplication {
+            name = "home-bootstrap";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.gnused
+              # `nix` is in runtimeInputs for the same reason as bootstrap.nix:
+              # the activation step shells out to `nix run <flake>#home`, and the
+              # hermetic PATH would otherwise not carry a nix client.
+              pkgs.nix
+            ];
+            meta.description = "Seed a home-manager profile's age key from SOPS_AGE_KEY and activate the profile from a flake ref";
+            text = builtins.readFile ./home-bootstrap.sh;
+          }
+        );
+      };
+    };
+}

--- a/modules/apps/bootstrap/home-bootstrap.sh
+++ b/modules/apps/bootstrap/home-bootstrap.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Env-or-file contract, mirroring modules/apps/cluster/k3d-bootstrap-secrets.sh:
+#   SOPS_AGE_KEY        (env)  age secret key for the profile being activated
+#   SOPS_AGE_KEY_FILE   (path) a file holding the same value
+#
+# The env branch is the sandbox pathway: a hosted agent environment exposes its
+# secrets in the environment. The file branch exists so the app can be exercised
+# outside such an environment without putting a key in a shell history or
+# process table.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: home-bootstrap [--flake REF] [--user NAME] [--no-activate] [--help]
+
+Seeds the age key that decrypts a home-manager profile's sops secrets, then
+activates that profile. Needs no checkout: it reads everything it activates
+from the flake reference, which defaults to the published repository.
+
+Runs once and exits: it never loops, retries, or writes a stamp file. Any
+failure exits non-zero.
+
+Key source (first found):
+  SOPS_AGE_KEY            environment variable
+  SOPS_AGE_KEY_FILE       path to a file holding the key
+
+The key is written to ~/.config/sops/age/keys.txt at mode 0600, and only
+rewritten when its content differs, so a rotated secret is detected and a
+stable one is left alone.
+
+Options:
+  --flake REF     Flake reference to activate from
+                  (default: github:cameronraysmith/vanixiets).
+                  The ref floats; github:cameronraysmith/vanixiets/<rev> pins it.
+  --user NAME     home-manager user to activate (default: ubuntu).
+  --no-activate   Seed the key and exit without activating home-manager.
+  -h, --help      Print this message.
+
+Example, from a hosted agent sandbox with no checkout of this repository:
+  SOPS_AGE_KEY=... nix run --accept-flake-config \
+    github:cameronraysmith/vanixiets#home-bootstrap
+EOF
+}
+
+activate=1
+flake='github:cameronraysmith/vanixiets'
+user='ubuntu'
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --flake)
+      if [ $# -lt 2 ]; then
+        printf 'error: --flake requires a value\n\n' >&2
+        usage >&2
+        exit 2
+      fi
+      flake="$2"
+      shift 2
+      ;;
+    --user)
+      if [ $# -lt 2 ]; then
+        printf 'error: --user requires a value\n\n' >&2
+        usage >&2
+        exit 2
+      fi
+      user="$2"
+      shift 2
+      ;;
+    --no-activate)
+      activate=0
+      shift
+      ;;
+    *)
+      printf 'error: unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+printf 'home-bootstrap: user=%s flake=%s\n' "${user}" "${flake}"
+
+# home-manager's xdg.configHome defaults to ${home.homeDirectory}/.config and
+# ignores the ambient XDG_CONFIG_HOME (home-manager modules/misc/xdg/default.nix),
+# so base-sops resolves sops.age.keyFile from HOME. Deriving it from
+# XDG_CONFIG_HOME here would put the key somewhere sops-nix does not read.
+key_file="${HOME}/.config/sops/age/keys.txt"
+
+if [ -n "${SOPS_AGE_KEY:-}" ]; then
+  key_source='SOPS_AGE_KEY'
+  key_body="${SOPS_AGE_KEY}"
+elif [ -n "${SOPS_AGE_KEY_FILE:-}" ]; then
+  key_source="${SOPS_AGE_KEY_FILE}"
+  if [ ! -s "${SOPS_AGE_KEY_FILE}" ]; then
+    printf 'error: SOPS_AGE_KEY_FILE names a missing or empty file: %s\n\n' \
+      "${SOPS_AGE_KEY_FILE}" >&2
+    usage >&2
+    exit 1
+  fi
+  key_body="$(cat -- "${SOPS_AGE_KEY_FILE}")"
+else
+  printf 'error: no age key source; set SOPS_AGE_KEY or SOPS_AGE_KEY_FILE\n\n' >&2
+  usage >&2
+  exit 1
+fi
+
+# Trailing whitespace is stripped per line, and command substitution drops the
+# trailing newlines, so `desired` is the exact byte sequence written below minus
+# its final newline. The comparison against the existing file is then between
+# two identically normalized values. Comparing a raw secret against
+# "$(cat "$key_file")" instead would report a difference on every run whenever
+# the secret carries a trailing newline, rewriting the key each time.
+desired="$(printf '%s\n' "${key_body}" | sed 's/[[:space:]]*$//')"
+
+if ! printf '%s\n' "${desired}" | grep -q '^AGE-SECRET-KEY-'; then
+  printf 'error: value from %s contains no AGE-SECRET-KEY- line\n' "${key_source}" >&2
+  exit 1
+fi
+
+if [ -f "${key_file}" ] && [ "$(cat -- "${key_file}")" = "${desired}" ]; then
+  printf 'age key at %s already matches %s\n' "${key_file}" "${key_source}"
+else
+  mkdir -p "$(dirname "${key_file}")"
+  (
+    umask 077
+    printf '%s\n' "${desired}" > "${key_file}.new"
+  )
+  mv -f "${key_file}.new" "${key_file}"
+  printf 'wrote age key to %s from %s\n' "${key_file}" "${key_source}"
+fi
+chmod 600 "${key_file}"
+
+if [ "${activate}" -eq 0 ]; then
+  printf 'skipping home-manager activation (--no-activate)\n'
+  exit 0
+fi
+
+# Goes through the `home` app rather than calling nh directly, so the activation
+# is the one `just activate-home` performs.
+exec nix --accept-flake-config run "${flake}#home" -- "${user}" "${flake}"


### PR DESCRIPTION
Seeding the age key and activating home-manager is a bootstrap step, not a
home-manager-managed one. The key that lets sops-nix decrypt a profile's
secrets must exist before the activation that consumes it, so a generated
shell-profile hook that re-enters activation has no fixed point on first run,
and wiring one through BASH_ENV puts an unrequested effect into every
non-interactive agent command. An app placed beside setup-user keeps the effect
at the caller's boundary, where it was asked for.

The app needs no checkout. It takes `--flake REF`, defaulting to
github:cameronraysmith/vanixiets, and `--user NAME`, defaulting to ubuntu, so
`nix run github:cameronraysmith/vanixiets#home-bootstrap` is the whole
invocation from an environment that has nix and SOPS_AGE_KEY and nothing else.
The ref floats; github:cameronraysmith/vanixiets/<rev> pins it. This
repository's own blueprint passes `--flake .` in both initialize and
maintenance, so a branch under test activates itself rather than main.

It runs once and exits: no stamp file, no retry loop, no `|| true` on the
activation. It takes the key from SOPS_AGE_KEY or SOPS_AGE_KEY_FILE, mirroring
the env-or-file contract in k3d-bootstrap-secrets, normalizes trailing
whitespace before comparing against the existing keys.txt so a rotated secret
is detected and a stable one leaves the file untouched, and writes mode 0600.
Activation goes through the `home` app and therefore `nh home switch`, the same
path as `just activate-home`. Re-running it is what brings a warm sandbox's
home-manager generation forward, which maintenance previously never did.

The blueprint's $ENVRC addition shrinks to sourcing nix-daemon.sh and
hm-session-vars.sh, and guards on $ENVRC being set.

Depends-On: #2941