### PR TITLE
fix(home): let shell and development declare their own upstream imports

### DIFF
--- a/modules/home/core/catppuccin.nix
+++ b/modules/home/core/catppuccin.nix
@@ -1,11 +1,22 @@
 # Catppuccin theme configuration
 # Extracted from vanixiets/modules/home/all/terminal/default.nix lines 302-303
-{ ... }:
+{ inputs, ... }:
 {
+  # Two aggregates need the upstream module: `core` sets the global theme
+  # below, and `shell/tmux.nix` sets `catppuccin.tmux`. Importing the same
+  # attrset module from both files applies it twice, because the module system
+  # deduplicates on `key` and an anonymous import is assigned a fresh one, and
+  # the second application redefines the tmux plugin. Exporting one value with
+  # an explicit key makes the two imports collapse into one.
+  flake.lib.catppuccinHomeModule = {
+    key = "vanixiets/catppuccin-home-module";
+    imports = [ inputs.catppuccin.homeModules.catppuccin ];
+  };
+
   flake.modules.homeManager.core =
     { flake, ... }:
     {
-      imports = [ flake.inputs.catppuccin.homeModules.catppuccin ];
+      imports = [ flake.lib.catppuccinHomeModule ];
 
       # Global catppuccin theme enable
       # Individual programs (tmux, bat, etc.) will use this theme automatically

--- a/modules/home/core/lazyvim.nix
+++ b/modules/home/core/lazyvim.nix
@@ -1,9 +1,0 @@
-# LazyVim home-manager module integration.
-{ ... }:
-{
-  flake.modules.homeManager.core =
-    { flake, ... }:
-    {
-      imports = [ flake.inputs.lazyvim-nix.homeManagerModules.default ];
-    };
-}

--- a/modules/home/development/neovim/default.nix
+++ b/modules/home/development/neovim/default.nix
@@ -10,6 +10,8 @@
         ...
       }:
       {
+        imports = [ flake.inputs.lazyvim-nix.homeManagerModules.default ];
+
         programs.lazyvim = {
           enable = true;
 

--- a/modules/home/shell/tmux.nix
+++ b/modules/home/shell/tmux.nix
@@ -35,6 +35,8 @@
         };
       in
       {
+        imports = [ flake.lib.catppuccinHomeModule ];
+
         catppuccin.tmux = {
           enable = true;
           extraConfig = ''


### PR DESCRIPTION
`85703a246` moved the nix-index-database import into the file that configures
it, removing `terminal`'s undeclared dependency on `core`. Two more of the same
shape remained, and both bite a user whose `aggregates` list omits `core`:
`shell/tmux.nix` sets `catppuccin.tmux` and `development/neovim` sets
`programs.lazyvim`, while `core/catppuccin.nix` and `core/lazyvim.nix` held the
imports declaring those options. Evaluating a `shell`-without-`core` profile
failed with "The option `catppuccin' does not exist", and a
`development`-without-`core` one with "The option `programs.lazyvim' does not
exist".

`core/lazyvim.nix` contributed nothing but the import, so it moves into
`development/neovim/default.nix` and the file is deleted, exactly as
`core/nix-index.nix` did.

Catppuccin cannot move the same way: `core/catppuccin.nix` also sets the global
`catppuccin.enable`/`autoEnable`/`flavor`, so both aggregates need the upstream
module and neither may own it alone. Importing the same attrset module from two
files applies it twice — the module system deduplicates on `key`, and an
anonymous import is assigned a fresh one — which conflicts on the tmux plugin
definition. `flake.lib.catppuccinHomeModule` wraps the import behind one
explicit key, so the two imports collapse into a single application.

Existing configurations are unaffected: `crs58@aarch64-darwin` yields the same
327 packages, the same `home.file` attribute set, and the same `sops.secrets`
and rendered `sops.templates` as before.

Depends-On: #2942