### PR TITLE
feat(home): add ubuntu profile for the Devin sandbox

### DIFF
--- a/modules/home/users/crs58/default.nix
+++ b/modules/home/users/crs58/default.nix
@@ -196,27 +196,7 @@ let
           '';
         };
 
-        # schpet/linear-cli inline-format credentials, rendered immutably from sops.
-        # Inline format: flat `<workspace> = "<api-key>"` keys plus a top-level
-        # `default = "<workspace>"` (see schpet credentials.ts hasInlineKeys /
-        # parseInlineCredentials). schpet uses XDG on darwin too (Deno reads
-        # XDG_CONFIG_HOME, else ~/.config), so no per-platform path conditional.
-        # Read-only (0400): switch profiles via `--workspace` / a `default` change,
-        # never via mutating `linear auth` commands which would clobber this file.
-        templates."linear-credentials.toml" = {
-          mode = "0400";
-          path = "${config.xdg.configHome}/linear/credentials.toml";
-          content = ''
-            default = "${config.sops.placeholder."linear-workspace-personal"}"
-
-            ${config.sops.placeholder."linear-workspace-personal"} = "${
-              config.sops.placeholder."linear-api-key-personal"
-            }"
-            ${config.sops.placeholder."linear-workspace-work"} = "${
-              config.sops.placeholder."linear-api-key-work"
-            }"
-          '';
-        };
+        templates."linear-credentials.toml" = flake.lib.mkLinearCredentialsTemplate config;
 
         # hindsight CLI credentials, rendered immutably from sops so the CLI
         # works without a `hindsight configure` step.

--- a/modules/home/users/linear-credentials.nix
+++ b/modules/home/users/linear-credentials.nix
@@ -1,0 +1,34 @@
+# schpet/linear-cli inline-format credentials, rendered immutably from sops.
+#
+# Inline format: flat `<workspace> = "<api-key>"` keys plus a top-level
+# `default = "<workspace>"` (see schpet credentials.ts hasInlineKeys /
+# parseInlineCredentials). schpet uses XDG on darwin too (Deno reads
+# XDG_CONFIG_HOME, else ~/.config), so no per-platform path conditional.
+# Read-only (0400): switch profiles via `--workspace` / a `default` change,
+# never via mutating `linear auth` commands which would clobber this file.
+#
+# Every value is a sops placeholder, so the template carries nothing
+# user-specific and every user declaring the four Linear secrets renders the
+# same file from their own ciphertext. Kept here rather than in an aggregate
+# because the credentials are identity-bound content, which `users/lib.nix`
+# assigns to `contentPrivate`; the call site sits beside the secret
+# declarations it depends on.
+{ ... }:
+{
+  # Takes the home-manager `config` of the user declaring
+  # `linear-{api-key,workspace}-{personal,work}`.
+  flake.lib.mkLinearCredentialsTemplate = config: {
+    mode = "0400";
+    path = "${config.xdg.configHome}/linear/credentials.toml";
+    content = ''
+      default = "${config.sops.placeholder."linear-workspace-personal"}"
+
+      ${config.sops.placeholder."linear-workspace-personal"} = "${
+        config.sops.placeholder."linear-api-key-personal"
+      }"
+      ${config.sops.placeholder."linear-workspace-work"} = "${
+        config.sops.placeholder."linear-api-key-work"
+      }"
+    '';
+  };
+}

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -1,0 +1,55 @@
+{
+  # OUTER: Flake-parts module signature
+  ...
+}:
+let
+  content =
+    {
+      # INNER: Home-manager module signature
+      config,
+      flake, # from extraSpecialArgs
+      ...
+    }:
+    {
+      home.stateVersion = "23.11";
+
+      # The sandbox runs standalone home-manager with no session bus and no
+      # systemd user manager, so sops-nix's user unit never starts and its
+      # secrets would never be installed.
+      sopsInstallWithoutSystemd.enable = true;
+
+      sops = {
+        defaultSopsFile = flake.inputs.self + "/secrets/home-manager/users/ubuntu/secrets.yaml";
+        secrets = {
+          # Git and jujutsu signing read the private key directly on Linux, and
+          # `development/radicle.nix` places it at ~/.radicle/keys/radicle.
+          ssh-signing-key = {
+            mode = "0400";
+          };
+          linear-api-key-personal = { };
+          linear-api-key-work = { };
+          linear-workspace-personal = { };
+          linear-workspace-work = { };
+        };
+
+        templates."linear-credentials.toml" = flake.lib.mkLinearCredentialsTemplate config;
+      };
+
+      # The other users render allowed_signers through a sops placeholder
+      # because their signing key's public half is itself withheld. This one is
+      # already published as a GitHub signing key, so it is written directly and
+      # costs no secret. `development/git.nix` points
+      # `gpg.ssh.allowedSignersFile` at this path.
+      xdg.configFile."git/allowed_signers".text = ''
+        ${flake.users.ubuntu.meta.email} namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBTeBMUfte7k9yugPtmVLJONiwxZtyoNotfwBOMAEHGz
+      '';
+
+      programs.git.settings = {
+        user.name = flake.users.ubuntu.meta.fullname;
+        user.email = flake.users.ubuntu.meta.email;
+      };
+    };
+in
+{
+  flake.users.ubuntu.contentPrivate = content;
+}

--- a/modules/home/users/ubuntu/meta.nix
+++ b/modules/home/users/ubuntu/meta.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+{
+  flake.users.ubuntu = {
+    meta = {
+      username = "ubuntu";
+      fullname = "Cameron Smith";
+      email = "cameron.ray.smith@gmail.com";
+      githubUser = "cameronraysmith";
+      # `hm-sops-bridge` is a NixOS module and this profile never runs under
+      # NixOS: the sandbox receives its age key from the `devin-bootstrap` app
+      # instead, so there is no bridge deployment to name.
+      sopsAgeKeyId = null;
+      sshKeys = [ ];
+    };
+
+    # The account exists only inside a hosted x86_64-linux sandbox, so the
+    # darwin entry would be a configuration nobody can activate.
+    systems = [ "x86_64-linux" ];
+
+    aggregates = with config.flake.modules.homeManager; [
+      base-sops
+      development
+      shell
+      terminal
+    ];
+  };
+}


### PR DESCRIPTION
The `ubuntu` account exists only inside a hosted Devin sandbox, so
`systems = [ "x86_64-linux" ]` keeps `homeConfigurations` and the per-user
activation check to the one platform that can activate it, and
`sopsAgeKeyId = null` declines the `hm-sops-bridge` pathway, which is NixOS-only:
the age key reaches the sandbox through the `devin-bootstrap` app instead.

Four aggregates — `base-sops`, `development`, `shell`, `terminal` — carry every
package and program, so `contentPrivate` holds only what `users/lib.nix` assigns
to that slot: identity and secret-bearing content. Nothing is hand-listed, and
no activation hook, shell-profile wrapper, or stamp file appears here; the
sandbox's bootstrap effects live in the flake app that the blueprint calls.

`sopsInstallWithoutSystemd.enable` is what installs the secrets: standalone
home-manager runs in the sandbox with no session bus and no systemd user
manager, so sops-nix's user unit never starts.

Signing follows the standard Linux path rather than anything sandbox-specific.
`development/git.nix` already selects `sops.secrets.ssh-signing-key` as the
signing key on Linux and `development/radicle.nix` places it at
~/.radicle/keys/radicle; declaring the secret is all this profile does. Its
public half is already published as a GitHub signing key, so allowed_signers is
written directly instead of through a sops placeholder as the other users' are,
and costs no secret.

The Linear credentials template moves to
`flake.lib.mkLinearCredentialsTemplate`. Every value in it is a sops
placeholder, so the two call sites were byte-identical rather than merely
similar, and a second copy would have drifted from the first. crs58's rendered
template is unchanged.

Depends-On: #2946