### PR TITLE
secrets: add ubuntu-user recipient and home-manager secrets file

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -12,6 +12,7 @@ keys:
   - &janettesmith-user age1mqfqckczkulpne7265j5cxn0pspdlxd3d0kav368u2c2fwknnc4qe27dec  # derived from SSH key via ssh-to-age
   - &christophersmith-user age1xz7gmqx7m0pn8u2nq8x05efq6dj52ym6c9gat5xj4am6x9sauq6sfzd2fn  # derived from SSH key via ssh-to-age
   - &tara-user age1krkf4ht5r2uufp0qkj6eu7pj9j04n7lz0tjlazmqzc3lhnjqt99sam42yp  # from sops-tara-user-ssh in Bitwarden
+  - &ubuntu-user age1mg67ytvlmsyj6a7hk7v0p905jydx4vd483yqqsejf0n0vncmhy4sgu43kj  # from devin-ubuntu-ssh in Bitwarden via ssh-to-age
 
   # Host keys (generated in Bitwarden, deployed to /etc/ssh/)
   - &stibnite age1a696klqy0s36a2pzlk6kyckp60k88qxcrsdh829dtk3xtc7sfs4scg05k0     # from sops-stibnite-ssh
@@ -79,6 +80,13 @@ creation_rules:
         - *admin
         - *dev
         - *janettesmith-user
+
+  - path_regex: secrets/home-manager/users/ubuntu/.*\.yaml$
+    key_groups:
+      - age:
+        - *admin
+        - *dev
+        - *ubuntu-user
 
   - path_regex: secrets/home-manager/users/christophersmith/.*\.yaml$
     key_groups:

--- a/secrets/home-manager/users/ubuntu/secrets.yaml
+++ b/secrets/home-manager/users/ubuntu/secrets.yaml
@@ -1,0 +1,35 @@
+linear-api-key-personal: ENC[AES256_GCM,data:ipOEOuNW9xp1WAewBWL9btzHo/S0HSlyWwDkBgPULjuJS7VX3CIQC3SJZNALiViD,iv:ypu19g/AQ2Khhwb2sv7FEVPzE8dB4Xroo2Ni7/WtACg=,tag:Xq87hEGbY5nV5kXJvXUxug==,type:str]
+linear-api-key-work: ENC[AES256_GCM,data:e7NM52oKWeDKuCUwCMBsDid00QM5Rb1pxrS7eo1xI3AGagApPEHaRvPGB3qc0Boh,iv:jmuK5+v8oH+jVOLOUtDdI2dEW5qwkAY+UhfG9VtP0sc=,tag:cX/d3Y0PzEKmjT6MdXkqTQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSZG9CWHlXTWszVWtSeUdn
+            cFpkRjh2VktLL29KejFQM200MVRsZXVBbVhZCkJTMVc0bHdZNHJScmJadE4rWmdH
+            QytpY3hOd0pGNzF5emkvT25DZE9aVDgKLS0tIHFnVTN4ckFXcUtZWWtXRXYzZ1FN
+            Tm80TVcvRzhqLzZWTGxvSVVhRGQ1dkUKue9stAje9EHJMt6cG2uP73tYryDE3nFt
+            pKTbb8A2Lw2tSlSfTS9jKtLYO9eh8TPEIRdw2RrbfTSK5F00O82ucw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vy7wsnf8eg5229evq3ywup285jzk9cntsx5hhddjtwsjh0kf4c6s9fmalv
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSZWVRVkxBM0lHeEhtVGxQ
+            d0FxN09sTUtGN2xyQ1JDRVBwTUhtckhNenhnCk5UVUgwZTZjZHkrZWFHcUY1bUVx
+            WnV3MnhTTWJwK1JiL0JXSDNxRDZlNEkKLS0tIFFhemY1c2JSU3JDOHJWcUpJZStJ
+            ZVhMR2R0SUNyaVVkMGZFSm1LM2VGNXcKWkPAKoZiPfCsJGSHZdfHKepFFJhIXfhp
+            Hkg0w1jlHeLWd4Z3o4/gC0KeshVqVT8buPKMPLOdeMAhx2qQ9t+QUw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1js028xag70wpwpp47elpq50mjjv7zn7sxuwuhk8yltkjzqzdvq5qq8w8cy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiOUpPbDA1UDY5bUlmTTdq
+            anJrWjUydEZhT0E5cGQwTlpMTkZOaDJxUUVFClMwM3djektaczMrbG82QW1zbGky
+            YVNUZW9RKzdVM0I0TzFJS3Vnb1ZwTk0KLS0tIE1zcjFZdW5xTDlub3I4eGl3YzV0
+            SmI5c2ZoZ1o4OTFDdTBPOGlXOEloNTQKExj8ebDmC27SYvhJwj0anOJjDO4+6N3y
+            dzl+XGkjaRGgYhG2PUwgKVKF+2xornG7gKcRIHmoCDdUgkkzNAvkXw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1mg67ytvlmsyj6a7hk7v0p905jydx4vd483yqqsejf0n0vncmhy4sgu43kj
+    lastmodified: "2026-09-04T03:39:15Z"
+    mac: ENC[AES256_GCM,data:XnaoH2gdnjfGjzi+JH+4Y8Tk/M0MG4wncFYcYW0f3L2zNhVcDSifBz85fOC3yInyN1T9zGAKCTb6uGv7LqnpvQ/4FwD/UtzYzTWuOpFd59DJqGdrqXBC5ZDcCKQw7YHs2OV8lEBug9ZyU1aBhQ7ST/opz93HG5GDhHKSsVdn368=,iv:ZRNNjkV5W9DSzJHW1D4vFHKZ35pE0/klSJGZW/ukWzA=,tag:U8B/IahRuF3kltCALEGTrQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
The `ubuntu-user` age identity is derived from the `devin-ubuntu-ssh` key in
Bitwarden and is the identity the `devin-bootstrap` app seeds into a sandbox,
so the creation rule for `secrets/home-manager/users/ubuntu/` grants it
alongside the admin and dev keys, matching every other per-user rule.

The encrypted file carries `linear-api-key-personal` and
`linear-api-key-work`. The profile also declares `ssh-signing-key`,
`linear-workspace-personal`, and `linear-workspace-work`, whose values are
added out of band; sops-nix validates every declared key against this file when
the manifest is built, so the generation does not build until they are present.

Depends-On: #2943