### PR TITLE
fix(home): pass the configuration name to nh home switch

### DIFF
--- a/modules/home/app.nix
+++ b/modules/home/app.nix
@@ -66,23 +66,21 @@
                 fi
 
                 system="${system}"
-                # Full flake attribute path including activationPackage
-                # Format: flake#homeConfigurations."USERNAME@SYSTEM".activationPackage
-                config_path="homeConfigurations.\"$username@$system\".activationPackage"
+                config_name="$username@$system"
 
                 cat <<-EOF
                 	Activating home-manager configuration...
                 	  User:   $username
                 	  System: $system
                 	  Flake:  $flake
-                	  Config: $config_path
+                	  Config: homeConfigurations."$config_name"
 
                 	EOF
 
-                # Use full installable path (not -c flag) for nested structure
-                # Pass any additional arguments (like --dry, --verbose, etc.) to nh
-                # Always include --accept-flake-config for nh's internal nix calls
-                exec nh home switch "$flake#$config_path" --accept-flake-config "$@"
+                # nh rejects any attribute path below homeConfigurations.<name>; the
+                # configuration goes through --configuration, which nh checks against
+                # the flake and then extends to the activation package itself.
+                exec nh home switch "$flake" --configuration "$config_name" --accept-flake-config "$@"
               '';
             }
           );


### PR DESCRIPTION
nh rejects an installable whose homeConfigurations attribute path is longer
than the configuration name, aborting with "Attribute path is too specific"
(4.4.2, crates/nh-home/src/home.rs:280-290). The `home` app built exactly such
a path, so every invocation failed at argument validation before any
evaluation. The name belongs in --configuration, which
crates/nh-home/src/args.rs:60-64 documents as taking username@hostname.

nh 4.4.2 is the pinned version on aarch64-darwin as well, so this is not a
sandbox-only fault: `just activate-home` on stibnite hits the same rejection.

Cache coverage is unchanged. nh extends the configuration to the activation
package itself, and `.config.home.activationPackage.drvPath` equals
`homeConfigurations.<name>.activationPackage.drvPath` (both
/nix/store/9y2sjy6y...-home-manager-generation.drv when checked in the
sandbox), so the derivation built is the one CI already populated.