### PR TITLE
fix(devin): activate the home profile without secrets at snapshot build and reactivate at session start

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -28,14 +28,16 @@ initialize: |
   # Marks .envrc trusted so the maintenance step's `direnv exec .` calls work.
   direnv allow
 
-  # Seeds ~/.config/sops/age/keys.txt from the sandbox's SOPS_AGE_KEY secret and
-  # activates homeConfigurations."ubuntu@x86_64-linux". The key has to be in
-  # place before activation, because sops-nix decrypts the profile's secrets during
-  # it. One-shot: it exits non-zero on failure rather than retrying, so a broken
+  # Activates homeConfigurations."ubuntu@x86_64-linux" with no age key: snapshot
+  # builds run with no secrets injected, so base-sops reports that it is skipping
+  # the sops install and continues. The image therefore carries the generation's
+  # packages, files, and session variables but nothing decrypted. Secrets arrive at
+  # session start, where the profile is activated again over this warm store.
+  # One-shot: it exits non-zero on failure rather than retrying, so a broken
   # sandbox is visible here rather than in every later command.
   # `--flake .` overrides the app's published default so a branch under test
   # activates itself rather than main.
-  nix run --accept-flake-config .#home-bootstrap -- --flake .
+  nix run --accept-flake-config .#home-bootstrap -- --flake . --without-secrets
 
   # Agent commands run in non-interactive shells, which read neither
   # /etc/bash.bashrc nor /etc/profile.d/nix.sh, so nix and the home-manager
@@ -67,15 +69,19 @@ initialize: |
   sudo udevadm control --reload-rules
   sudo udevadm trigger --name-match=kvm --settle
 maintenance: |
+  # Session start is where SOPS_AGE_KEY exists, so this is where the key is seeded
+  # and the profile is activated again, which is what installs its secrets;
+  # initialize's activation deliberately installed none. The closure is already in
+  # the store, so this is a re-link plus a secret install rather than a build, and a
+  # sandbox resuming on a newer commit rebuilds only what that commit changed.
+  # Re-running is a no-op on the key file unless the secret rotated. Everything
+  # below can read the profile, so it runs first.
+  nix run --accept-flake-config .#home-bootstrap -- --flake .
+
   # Realize the devshell; its shellHook writes .pre-commit-config.yaml and installs the prek hooks.
   nix develop --accept-flake-config --command true
   # Warm the nix-direnv cache so later `direnv exec .` invocations skip flake evaluation.
   direnv allow
-
-  # A warm sandbox resumes on a newer commit than the one initialize activated, so
-  # re-run the bootstrap to bring the home-manager generation forward. Re-running is
-  # a no-op on the key file unless the secret rotated.
-  nix run --accept-flake-config .#home-bootstrap -- --flake .
 
   # `bun install` over the root workspace (packages/*), so packages/docs is covered;
   # incremental outside CI, unlike `bun run reinstall`, which maintenance forbids.
@@ -118,16 +124,19 @@ knowledge:
     contents: |
       Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.
       x86_64-linux only: darwinConfigurations and checks.aarch64-* cannot run here.
-      `nix run .#home-bootstrap -- --flake .` is how the image is built: it seeds
-      ~/.config/sops/age/keys.txt from the user-scoped Devin secret
-      SOPS_AGE_KEY (the only secret) and then activates
-      homeConfigurations."ubuntu@x86_64-linux", the same generation
-      `just activate-home ubuntu` would build. It runs in initialize and again in
-      maintenance; run it by hand after pulling a commit that changes the ubuntu
-      profile. `--flake .` is what makes this checkout activate itself instead of
-      the app's published default, so a branch under test is what reaches the
-      generation. Any other repository's blueprint activates the same profile with
-      no checkout of this one via
+      homeConfigurations."ubuntu@x86_64-linux" is activated twice, split by whether
+      a secret is available. The snapshot build injects none, so initialize runs
+      `nix run .#home-bootstrap -- --flake . --without-secrets`, which activates the
+      generation and leaves its sops install skipped, so the image holds nothing
+      decrypted. Session start has the user-scoped Devin secret SOPS_AGE_KEY (the
+      only secret), so maintenance runs `nix run .#home-bootstrap -- --flake .`,
+      which seeds ~/.config/sops/age/keys.txt from it and activates again, installing
+      the secrets. That is the same generation `just activate-home ubuntu` would
+      build. Run the second form by hand after pulling a commit that changes the
+      ubuntu profile. `--flake .` is what makes this checkout supply the generation
+      instead of the app's published default, so a branch under test is what reaches
+      it. Any other repository's blueprint reaches the same profile with no checkout
+      of this one via
       `nix run --accept-flake-config github:cameronraysmith/vanixiets#home-bootstrap`,
       which requires nix installed by this repo's `make bootstrap` (it sets
       trusted-users, so the flake's substituters are then honored) and SOPS_AGE_KEY

--- a/modules/apps/bootstrap/home-bootstrap.nix
+++ b/modules/apps/bootstrap/home-bootstrap.nix
@@ -1,5 +1,14 @@
-# Flake app: seed a home-manager profile's age key and activate that profile
-# from a flake reference, with no checkout of this repository.
+# Flake app: activate a home-manager profile from a flake reference, seeding the
+# age key that decrypts its sops secrets where that key exists. No checkout of
+# this repository is required.
+#
+# The two modes are split by coeffect. Activation itself needs only network and
+# the binary cache; installing secrets additionally needs the age key, and
+# base-sops skips that step when the key file is absent. An image or snapshot
+# build has the first resource and not the second, so it runs --without-secrets
+# and the image carries the generation but nothing decrypted. A session start has
+# both, so it runs the default mode, which seeds the key and reactivates over a
+# store the earlier activation already warmed.
 #
 # This is an app rather than a home-manager activation script or a shell-profile
 # hook because it must run before any home-manager generation exists: the key it
@@ -25,10 +34,11 @@
               pkgs.gnused
               # `nix` is in runtimeInputs for the same reason as bootstrap.nix:
               # the activation step shells out to `nix run <flake>#home`, and the
-              # hermetic PATH would otherwise not carry a nix client.
+              # hermetic PATH would otherwise not carry a nix client. Both modes
+              # reach it.
               pkgs.nix
             ];
-            meta.description = "Seed a home-manager profile's age key from SOPS_AGE_KEY and activate the profile from a flake ref";
+            meta.description = "Activate a home-manager profile from a flake ref, seeding its age key from SOPS_AGE_KEY where one exists";
             text = builtins.readFile ./home-bootstrap.sh;
           }
         );

--- a/modules/apps/bootstrap/home-bootstrap.sh
+++ b/modules/apps/bootstrap/home-bootstrap.sh
@@ -14,15 +14,28 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage: home-bootstrap [--flake REF] [--user NAME] [--no-activate] [--help]
+       home-bootstrap --without-secrets [--flake REF] [--user NAME]
 
-Seeds the age key that decrypts a home-manager profile's sops secrets, then
-activates that profile. Needs no checkout: it reads everything it activates
-from the flake reference, which defaults to the published repository.
+Activates a home-manager profile, seeding the age key that decrypts its sops
+secrets when that key is available. Needs no checkout: it reads everything it
+activates from the flake reference, which defaults to the published repository.
+
+Two modes, split by whether the environment supplies the secret.
+
+The default mode requires a key, writes it, and activates. Secrets are
+installed during that activation. This is the session-start path.
+
+--without-secrets requires no key, writes none, and activates. The generation
+that lands carries the profile's packages, files, and session variables; the
+sops install step reports that it is skipping and continues, so nothing
+decrypted is produced. This is the image and snapshot build path, where no
+secret exists. An activation in the default mode must follow at session start;
+that is what installs the secrets.
 
 Runs once and exits: it never loops, retries, or writes a stamp file. Any
 failure exits non-zero.
 
-Key source (first found):
+Key source in the default mode (first found):
   SOPS_AGE_KEY            environment variable
   SOPS_AGE_KEY_FILE       path to a file holding the key
 
@@ -31,12 +44,15 @@ rewritten when its content differs, so a rotated secret is detected and a
 stable one is left alone.
 
 Options:
-  --flake REF     Flake reference to activate from
-                  (default: github:cameronraysmith/vanixiets).
-                  The ref floats; github:cameronraysmith/vanixiets/<rev> pins it.
-  --user NAME     home-manager user to activate (default: ubuntu).
-  --no-activate   Seed the key and exit without activating home-manager.
-  -h, --help      Print this message.
+  --flake REF        Flake reference to activate from
+                     (default: github:cameronraysmith/vanixiets).
+                     The ref floats; github:cameronraysmith/vanixiets/<rev>
+                     pins it.
+  --user NAME        home-manager user to activate (default: ubuntu).
+  --without-secrets  Activate without seeding a key, for an environment that
+                     has none.
+  --no-activate      Seed the key and exit without activating home-manager.
+  -h, --help         Print this message.
 
 Example, from a hosted agent sandbox with no checkout of this repository:
   SOPS_AGE_KEY=... nix run --accept-flake-config \
@@ -47,6 +63,7 @@ EOF
 activate=1
 flake='github:cameronraysmith/vanixiets'
 user='ubuntu'
+without_secrets=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -72,6 +89,10 @@ while [ $# -gt 0 ]; do
       user="$2"
       shift 2
       ;;
+    --without-secrets)
+      without_secrets=1
+      shift
+      ;;
     --no-activate)
       activate=0
       shift
@@ -84,57 +105,67 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "${without_secrets}" -eq 1 ] && [ "${activate}" -eq 0 ]; then
+  printf 'error: --without-secrets and --no-activate together leave nothing to do\n\n' >&2
+  usage >&2
+  exit 2
+fi
+
 printf 'home-bootstrap: user=%s flake=%s\n' "${user}" "${flake}"
 
-# home-manager's xdg.configHome defaults to ${home.homeDirectory}/.config and
-# ignores the ambient XDG_CONFIG_HOME (home-manager modules/misc/xdg/default.nix),
-# so base-sops resolves sops.age.keyFile from HOME. Deriving it from
-# XDG_CONFIG_HOME here would put the key somewhere sops-nix does not read.
-key_file="${HOME}/.config/sops/age/keys.txt"
+if [ "${without_secrets}" -eq 1 ]; then
+  printf 'seeding no age key (--without-secrets); the profile activates and its sops install step skips\n'
+else
+  # home-manager's xdg.configHome defaults to ${home.homeDirectory}/.config and
+  # ignores the ambient XDG_CONFIG_HOME (home-manager modules/misc/xdg/default.nix),
+  # so base-sops resolves sops.age.keyFile from HOME. Deriving it from
+  # XDG_CONFIG_HOME here would put the key somewhere sops-nix does not read.
+  key_file="${HOME}/.config/sops/age/keys.txt"
 
-if [ -n "${SOPS_AGE_KEY:-}" ]; then
-  key_source='SOPS_AGE_KEY'
-  key_body="${SOPS_AGE_KEY}"
-elif [ -n "${SOPS_AGE_KEY_FILE:-}" ]; then
-  key_source="${SOPS_AGE_KEY_FILE}"
-  if [ ! -s "${SOPS_AGE_KEY_FILE}" ]; then
-    printf 'error: SOPS_AGE_KEY_FILE names a missing or empty file: %s\n\n' \
-      "${SOPS_AGE_KEY_FILE}" >&2
+  if [ -n "${SOPS_AGE_KEY:-}" ]; then
+    key_source='SOPS_AGE_KEY'
+    key_body="${SOPS_AGE_KEY}"
+  elif [ -n "${SOPS_AGE_KEY_FILE:-}" ]; then
+    key_source="${SOPS_AGE_KEY_FILE}"
+    if [ ! -s "${SOPS_AGE_KEY_FILE}" ]; then
+      printf 'error: SOPS_AGE_KEY_FILE names a missing or empty file: %s\n\n' \
+        "${SOPS_AGE_KEY_FILE}" >&2
+      usage >&2
+      exit 1
+    fi
+    key_body="$(cat -- "${SOPS_AGE_KEY_FILE}")"
+  else
+    printf 'error: no age key source; set SOPS_AGE_KEY or SOPS_AGE_KEY_FILE\n\n' >&2
     usage >&2
     exit 1
   fi
-  key_body="$(cat -- "${SOPS_AGE_KEY_FILE}")"
-else
-  printf 'error: no age key source; set SOPS_AGE_KEY or SOPS_AGE_KEY_FILE\n\n' >&2
-  usage >&2
-  exit 1
-fi
 
-# Trailing whitespace is stripped per line, and command substitution drops the
-# trailing newlines, so `desired` is the exact byte sequence written below minus
-# its final newline. The comparison against the existing file is then between
-# two identically normalized values. Comparing a raw secret against
-# "$(cat "$key_file")" instead would report a difference on every run whenever
-# the secret carries a trailing newline, rewriting the key each time.
-desired="$(printf '%s\n' "${key_body}" | sed 's/[[:space:]]*$//')"
+  # Trailing whitespace is stripped per line, and command substitution drops the
+  # trailing newlines, so `desired` is the exact byte sequence written below minus
+  # its final newline. The comparison against the existing file is then between
+  # two identically normalized values. Comparing a raw secret against
+  # "$(cat "$key_file")" instead would report a difference on every run whenever
+  # the secret carries a trailing newline, rewriting the key each time.
+  desired="$(printf '%s\n' "${key_body}" | sed 's/[[:space:]]*$//')"
 
-if ! printf '%s\n' "${desired}" | grep -q '^AGE-SECRET-KEY-'; then
-  printf 'error: value from %s contains no AGE-SECRET-KEY- line\n' "${key_source}" >&2
-  exit 1
-fi
+  if ! printf '%s\n' "${desired}" | grep -q '^AGE-SECRET-KEY-'; then
+    printf 'error: value from %s contains no AGE-SECRET-KEY- line\n' "${key_source}" >&2
+    exit 1
+  fi
 
-if [ -f "${key_file}" ] && [ "$(cat -- "${key_file}")" = "${desired}" ]; then
-  printf 'age key at %s already matches %s\n' "${key_file}" "${key_source}"
-else
-  mkdir -p "$(dirname "${key_file}")"
-  (
-    umask 077
-    printf '%s\n' "${desired}" > "${key_file}.new"
-  )
-  mv -f "${key_file}.new" "${key_file}"
-  printf 'wrote age key to %s from %s\n' "${key_file}" "${key_source}"
+  if [ -f "${key_file}" ] && [ "$(cat -- "${key_file}")" = "${desired}" ]; then
+    printf 'age key at %s already matches %s\n' "${key_file}" "${key_source}"
+  else
+    mkdir -p "$(dirname "${key_file}")"
+    (
+      umask 077
+      printf '%s\n' "${desired}" > "${key_file}.new"
+    )
+    mv -f "${key_file}.new" "${key_file}"
+    printf 'wrote age key to %s from %s\n' "${key_file}" "${key_source}"
+  fi
+  chmod 600 "${key_file}"
 fi
-chmod 600 "${key_file}"
 
 if [ "${activate}" -eq 0 ]; then
   printf 'skipping home-manager activation (--no-activate)\n'

--- a/modules/home/base/sops-install-without-systemd.nix
+++ b/modules/home/base/sops-install-without-systemd.nix
@@ -23,6 +23,20 @@
       environment = lib.concatStringsSep " " (
         lib.mapAttrsToList (name: value: "'${name}=${value}'") config.sops.environment
       );
+
+      ageKeyFile = config.sops.age.keyFile;
+
+      # Interpolated as its own multi-line value rather than written inline in
+      # the activation string: nix strips a literal's common indentation before
+      # substitution and does not re-indent what it substitutes, so building the
+      # branch here is what lines it up with the `if` it extends.
+      # warnEcho rather than the sibling branch's verboseEcho: a profile whose
+      # secrets are not installed is worth seeing on every activation, not only a
+      # verbose one.
+      skipWhenKeyAbsent = lib.optionalString (ageKeyFile != null) ''
+        elif [[ ! -f ${lib.escapeShellArg ageKeyFile} ]]; then
+          warnEcho "sops-nix: no age key at ${ageKeyFile}; skipping secret installation until an activation runs with the key present"
+      '';
     in
     {
       options.sopsInstallWithoutSystemd.enable = lib.mkEnableOption ''
@@ -42,6 +56,13 @@
         already bootstraps its launchd agent from its own activation entry, and
         none when no secrets are declared.
 
+        An absent `sops.age.keyFile` is treated as the secrets coeffect not
+        being present: the entry reports that it skipped the install and
+        continues, so a profile can be activated where no key exists, as an
+        image or snapshot build must be. Where the key file exists the install
+        runs and any failure is fatal. Activating again once the key is in place
+        is what installs the secrets.
+
         The entry runs after `writeBoundary`. Activation entries that read the
         installed secrets should declare `entryAfter [ "sopsInstallWithoutSystemd" ]`
         rather than relying on entry order.
@@ -53,7 +74,7 @@
 
           if [[ $systemdStatus == 'running' || $systemdStatus == 'degraded' ]]; then
             verboseEcho "sops-nix: user systemd manager is $systemdStatus; the sops-nix unit installs secrets"
-          else
+          ${skipWhenKeyAbsent}else
             verboseEcho "sops-nix: no user systemd manager; installing secrets directly"
             run env ${environment} ${installScript}
           fi

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -7,11 +7,17 @@ let
     {
       # INNER: Home-manager module signature
       config,
+      lib,
       flake, # from extraSpecialArgs
       ...
     }:
     {
       home.stateVersion = "23.11";
+
+      # Devin owns ~/.bashrc and ~/.bash_profile and rewrites them at session
+      # start, and agent shells are non-interactive, so home-manager's bash
+      # configuration is unreachable here and only collides with them.
+      programs.bash.enable = lib.mkForce false;
 
       # The sandbox runs standalone home-manager with no session bus and no
       # systemd user manager, so sops-nix's user unit never starts and its


### PR DESCRIPTION
Devin builds the machine snapshot by running the blueprint's initialize phase
with no secrets injected; secrets reach the sandbox only at session time. The
home-bootstrap call in initialize therefore had no age key to seed and exited
with "no age key source".

Activation and secret installation have different coeffects. Building and
activating the generation needs only network and the binary cache; installing
secrets additionally needs the key. base-sops now treats an absent
sops.age.keyFile as that resource being unavailable: it reports one line saying
the install is skipped until an activation runs with the key, and continues.
Where the key file exists the install runs and any failure remains fatal.

home-bootstrap gains --without-secrets, which requires and writes no key and
activates anyway. The image therefore carries the generation's packages, files,
and session variables and never holds decrypted material. The blueprint's
initialize uses it; maintenance keeps the full call, ahead of every step that
reads the profile, and runs where the key is present, so activation there is a
re-link plus a secret install rather than a build.

The ubuntu profile also disables home-manager's bash module: Devin rewrites
~/.bashrc and ~/.bash_profile at every session start, and home-manager's own
copies of ~/.bashrc, ~/.bash_profile and ~/.profile would otherwise abort
activation through checkLinkTargets. ~/.zshenv stays managed; Devin does not
own it.

sops-nix's own Linux activation entry needs no change: with no user systemd
manager it takes its else branch and only echoes, never touching the key.

Depends-On: #2947