### PR TITLE
fix(home): state catppuccin auto-enrollment wherever the module is imported

### DIFF
--- a/modules/home/core/catppuccin.nix
+++ b/modules/home/core/catppuccin.nix
@@ -8,9 +8,23 @@
   # deduplicates on `key` and an anonymous import is assigned a fresh one, and
   # the second application redefines the tmux plugin. Exporting one value with
   # an explicit key makes the two imports collapse into one.
+  #
+  # Every importer states its enrollment choice, because the upstream module
+  # warns until `catppuccin.autoEnable` carries a definition at any priority
+  # other than the option default's 1500 (<catppuccin>/modules/global.nix:20,
+  # 92). mkDefault is priority 1000, so it silences the warning while `core`'s
+  # normal-priority `true` below still wins.
   flake.lib.catppuccinHomeModule = {
     key = "vanixiets/catppuccin-home-module";
-    imports = [ inputs.catppuccin.homeModules.catppuccin ];
+    imports = [
+      inputs.catppuccin.homeModules.catppuccin
+      (
+        { config, lib, ... }:
+        {
+          catppuccin.autoEnable = lib.mkDefault config.catppuccin.enable;
+        }
+      )
+    ];
   };
 
   flake.modules.homeManager.core =


### PR DESCRIPTION
The upstream module warns until `catppuccin.autoEnable` carries a definition
at any priority other than the option default's 1500
(<catppuccin>/modules/global.nix:20 computes autoEnabledSet from
options.catppuccin.autoEnable.highestPrio; :92 gates the warning on it). Only
`core` set the option, so any aggregate that imports the module without core
evaluated with the warning. The ubuntu profile is the one that does: `shell`
pulls the module in through the shared keyed value for tmux theming, and
`config.warnings` for ubuntu@x86_64-linux held exactly that message.

The shared value now carries `autoEnable = lib.mkDefault config.catppuccin.enable`,
so every importer states the enrollment choice by construction. mkDefault is
priority 1000, which is enough to silence the warning and still lose to core's
normal-priority `true`. Referencing config does not recurse: autoEnabledSet
reads definition priorities, not the option's value.

Nothing else moves. Across all nineteen homeConfigurations the warning count is
now zero, every core-carrying user keeps enable and autoEnable true, and ubuntu
keeps both false. For ubuntu@x86_64-linux, crs58@aarch64-darwin and
crs58@x86_64-linux the package multiset, home.file names, xdg.configFile names,
tmux plugin list and tmux extraConfig are byte-identical before and after.

Depends-On: #2949