### PR TITLE
fix(apps): reference seed-age-key through the per-system packages

### DIFF
--- a/modules/apps/bootstrap/home-bootstrap.nix
+++ b/modules/apps/bootstrap/home-bootstrap.nix
@@ -21,7 +21,12 @@
 { ... }:
 {
   perSystem =
-    { pkgs, lib, ... }:
+    {
+      config,
+      pkgs,
+      lib,
+      ...
+    }:
     {
       apps.home-bootstrap = {
         type = "app";
@@ -33,8 +38,14 @@
               pkgs.gnugrep
               pkgs.gnused
               # The seed step is shared with the ubuntu profile's session hook so
-              # that both normalize a rotated key the same way.
-              pkgs.seed-age-key
+              # that both normalize a rotated key the same way. Reached through
+              # config.packages rather than pkgs: the perSystem pkgs is
+              # `import nixpkgs { overlays = config.nixpkgsOverlays; }`
+              # (modules/nixpkgs/per-system.nix), and pkgs/by-name reaches a
+              # package set only through flake.overlays.default
+              # (modules/nixpkgs/compose.nix), which home and machine
+              # configurations apply but perSystem does not.
+              config.packages.seed-age-key
               # `nix` is in runtimeInputs for the same reason as bootstrap.nix:
               # the activation step shells out to `nix run <flake>#home`, and the
               # hermetic PATH would otherwise not carry a nix client. Both modes


### PR DESCRIPTION
The perSystem `pkgs` argument is `import nixpkgs { overlays =
config.nixpkgsOverlays; }` (modules/nixpkgs/per-system.nix:18-24), and that
list carries only the overlays under modules/nixpkgs/overlays. Packages from
pkgs/by-name reach a package set through flake.overlays.default, which
composes them on top of those overlays (modules/nixpkgs/compose.nix:31-39), and
that overlay is applied by home and machine configurations rather than by
perSystem. So `pkgs.seed-age-key` resolves inside a home-manager module, which
is why the ubuntu session hook works and stays as it is, and does not resolve
inside a perSystem app.

The app now reads config.packages, matching modules/apps/updates.nix and
modules/apps/apm-context-compile.nix.

The failure was not system-specific: apps.x86_64-linux and apps.aarch64-darwin
both aborted with "attribute 'seed-age-key' missing". It reached main because
no check covers apps, and because the `--help` run this was verified with had
been served from the flake evaluation cache; the same command with
--no-eval-cache reproduces the error. The following commit adds the check.