### PR TITLE
feat(checks): evaluate and build every flake app per system

### DIFF
--- a/modules/checks/apps.nix
+++ b/modules/checks/apps.nix
@@ -1,0 +1,40 @@
+# Realization check for every flake app on the current system.
+#
+# `nix flake check` evaluates apps, but nixbot builds only checks.<system>, so
+# an app that fails to evaluate reaches main without any check going red. That
+# happened: an app referenced a pkgs/by-name package through the perSystem
+# `pkgs`, which does not carry flake.overlays.default, and the first sandbox
+# build was where it surfaced.
+#
+# One derivation rather than one per app: the programs are the whole content, so
+# a per-app split would multiply derivations without isolating anything a
+# failing build message does not already name.
+{ ... }:
+{
+  perSystem =
+    { self', pkgs, ... }:
+    {
+      # Referencing each program in the environment puts it in this derivation's
+      # build closure, so evaluating the check forces every app's expression and
+      # building it realizes every app's program.
+      checks.apps-build =
+        pkgs.runCommand "apps-build"
+          {
+            programs = builtins.attrValues (builtins.mapAttrs (_: app: app.program) self'.apps);
+            passthru.meta.description = "Every flake app on this system evaluates and its program realizes";
+          }
+          ''
+            status=0
+            for program in $programs; do
+              if [ ! -x "$program" ]; then
+                printf 'app program is not executable: %s\n' "$program" >&2
+                status=1
+              fi
+            done
+            if [ "$status" -ne 0 ]; then
+              exit 1
+            fi
+            printf '%s\n' $programs > "$out"
+          '';
+    };
+}


### PR DESCRIPTION
`nix flake check` evaluates apps, but nixbot builds only checks.<system>, so an
app that fails to evaluate reached main with every check green. The preceding
commit fixes the app that did; this makes the class visible.

checks.apps-build names every `apps.<system>.*` program in its environment, so
the closure covers all of them: evaluating the check forces each app's
expression and building it realizes each app's program. On x86_64-linux that is
49 apps, home-bootstrap included.

One derivation rather than one per app, unlike checks/packages.nix: an app's
program is its whole content, so splitting would multiply derivations without
isolating anything the failing build output does not already name.

Verified severe. With the preceding commit's fix reverted and this check left in
place, `nix eval .#checks.x86_64-linux.apps-build.drvPath` aborts with
"attribute 'seed-age-key' missing" at home-bootstrap.nix:37; with the fix
restored it evaluates and builds.

Depends-On: #2951