### PR TITLE
feat(home): browser terminal for the sandbox; herdr as its own aggregate; aspects charter

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -130,6 +130,11 @@ knowledge:
   - name: startup
     contents: |
       direnv exec . just docs-dev  # astro dev server for packages/docs
+  - name: terminal
+    contents: |
+      Ensure the user has access to an interactive terminal shell regardless of built-in Editor state: after the ubuntu profile is activated, start `browser-terminal` in the background (`setsid browser-terminal > logs/browser-terminal.log 2>&1 &` from the repository, or with `nohup`) and expose port 7681 through the app-preview tunnel (the `browser_preview` tool). It serves ttyd with herdr as the entrypoint; the xterm.js font list is set client-side in the wrapper because browser glyph rendering uses the user's fonts, not this VM's.
+      setsid browser-terminal > logs/browser-terminal.log 2>&1 &   # from the repository root, after activation
+      browser_preview 7681                                          # expose the port through the app-preview tunnel
   - name: notes
     contents: |
       Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -132,15 +132,17 @@ knowledge:
       direnv exec . just docs-dev  # astro dev server for packages/docs
   - name: terminal
     contents: |
-      Ensure the user has access to an interactive terminal shell regardless of
-      built-in Editor state: after the ubuntu profile is activated, start
-      `browser-terminal` in the background and expose port 7681 through the
-      app-preview tunnel (the browser_preview tool), from the repository root:
+      At session start, after the ubuntu profile is activated, start
+      `browser-terminal` in the background from the repository root and expose
+      port 7681 with the browser_preview tool, so the user has an interactive
+      shell regardless of the built-in editor's state:
       mkdir -p logs && setsid browser-terminal > logs/browser-terminal.log 2>&1 &
-      It serves ttyd with herdr as the entrypoint. Start it on demand only: it is
-      writable and unauthenticated behind the tunnel. The xterm.js font list is
-      set in the wrapper because the browser renders glyphs with the user's own
-      fonts, not this VM's.
+      Only a session starts it; initialize and maintenance never do, since they
+      run during image builds with no tunnel. It serves ttyd with herdr as the
+      entrypoint, binds 127.0.0.1 (override with BROWSER_TERMINAL_INTERFACE), is
+      writable, and has no authentication of its own: the authenticated preview
+      tunnel is the access control. The xterm.js font list is set in the wrapper
+      because the browser renders glyphs with the user's own fonts, not this VM's.
   - name: notes
     contents: |
       Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -132,9 +132,15 @@ knowledge:
       direnv exec . just docs-dev  # astro dev server for packages/docs
   - name: terminal
     contents: |
-      Ensure the user has access to an interactive terminal shell regardless of built-in Editor state: after the ubuntu profile is activated, start `browser-terminal` in the background (`setsid browser-terminal > logs/browser-terminal.log 2>&1 &` from the repository, or with `nohup`) and expose port 7681 through the app-preview tunnel (the `browser_preview` tool). It serves ttyd with herdr as the entrypoint; the xterm.js font list is set client-side in the wrapper because browser glyph rendering uses the user's fonts, not this VM's.
-      setsid browser-terminal > logs/browser-terminal.log 2>&1 &   # from the repository root, after activation
-      browser_preview 7681                                          # expose the port through the app-preview tunnel
+      Ensure the user has access to an interactive terminal shell regardless of
+      built-in Editor state: after the ubuntu profile is activated, start
+      `browser-terminal` in the background and expose port 7681 through the
+      app-preview tunnel (the browser_preview tool), from the repository root:
+      mkdir -p logs && setsid browser-terminal > logs/browser-terminal.log 2>&1 &
+      It serves ttyd with herdr as the entrypoint. Start it on demand only: it is
+      writable and unauthenticated behind the tunnel. The xterm.js font list is
+      set in the wrapper because the browser renders glyphs with the user's own
+      fonts, not this VM's.
   - name: notes
     contents: |
       Run everything through `direnv exec . <cmd>` (or `nix develop -c`): just/prek/bun exist only in the devshell.

--- a/modules/home/README.md
+++ b/modules/home/README.md
@@ -1,0 +1,78 @@
+---
+title: Home-manager aspects
+created: 2026-09-04
+---
+
+## Home-manager aspects
+
+Every `.nix` file under this directory is a flake-parts module that contributes `deferredModule` values to `flake.modules.homeManager.<aggregate>`.
+A directory is an aggregate: one user-facing capability, named for what a user gets (`shell`, `development`, `herdr`), never for how it is declared.
+A user is composed by listing aggregates in `flake.users.<name>.aggregates` (`users/<name>/meta.nix`); `configurations.nix` and `mk-home.nix` turn that list into one `homeConfigurations` output per declared system.
+This is the dendritic pattern from `github:mightyiam/dendritic`: a file is one feature across every configuration that wants it, the path names the feature, and merging by aggregate name replaces import lists.
+
+## Contract
+
+One aggregate, one capability, one secret posture.
+If part of an aggregate needs a sops secret and part does not, split it, so that a user who lacks the secret can still import the secret-free part.
+`ai` needs secrets and `herdr` does not, so `herdr` is its own aggregate although the tool is used alongside AI agents.
+
+Prefer the home-manager module to the raw package.
+`home.packages = [ pkgs.x ]` records only that `x` is installed; `programs.x` records its configuration surface, shell integration, and environment, at the same line count.
+A raw package is acceptable only when no `programs.*` or `services.*` module exists for it; it then lives in the aggregate that consumes it, in a file named for the package.
+
+Configure at the consumer.
+Fonts belong beside the terminal emulators that render them, and a wrapper's flags belong in the wrapper's module.
+Nothing goes into a shared package list on the grounds that several aggregates might want it.
+
+Per-user exceptions are overrides, not omissions.
+A user who cannot run one module of an aggregate imports the aggregate and disables that module with `lib.mkForce` in `users/<name>/default.nix`, keeping the rest of the capability.
+`users/ubuntu` does this for `programs.bash.enable` and `services.ssh-agent.enable`.
+
+Reusable options and shared data are named deferred modules or `flake.lib` values, never `_name.nix` files pulled in through `imports`; `core/catppuccin.nix` shows the pattern.
+Den and `flake-file` are not adopted here.
+
+## Hazards
+
+Adding a file activates it on the next evaluation; there is no registration step.
+An untracked file is invisible to `nix flake check`, so run `git add` before evaluating.
+
+A user's evaluated package set is a contract for that user.
+Moving a declaration between files must not change `home.packages` for any user unless the change is the point; the structure checks under `modules/checks/` catch accidental drift.
+
+`users/ubuntu` is the profile activated inside a Devin sandbox VM, which has no systemd user manager and no AI secrets.
+Modules that start user services or read sops secrets fail there and must be overridable as described above.
+
+## Verification
+
+```bash
+direnv exec . nix flake check --accept-flake-config
+nix eval --accept-flake-config --json '.#homeConfigurations."crs58@x86_64-linux".config.home.packages' --apply 'ps: builtins.sort builtins.lessThan (map (p: p.name) ps)'
+nix build --accept-flake-config '.#homeConfigurations."ubuntu@x86_64-linux".activationPackage'
+```
+
+The first is the closure operator every change must pass.
+The second is the per-user package contract; compare it against the base branch for any change that claims to be a relocation.
+The third builds the sandbox profile that the Devin snapshot activates.
+
+## Children
+
+- `ai/` — agent tooling that needs sops secrets (cognee, opencode, moshi, devin); indexed by its own README.
+- `base/` — sops-nix wiring, including activation without systemd.
+- `core/` — fontconfig, XDG, Catppuccin, session variables, SSH, Bitwarden; imported by every user.
+- `development/` — editors (LazyVim neovim, helix), version control (git, jujutsu, radicle), terminal emulators (ghostty), and their configuration.
+- `herdr/` — the herdr terminal multiplexer, secret-free.
+- `modules/` — option-declaring home-manager modules consumed by aggregates (`agents-md`).
+- `packages/` — raw package lists not yet attached to the aggregate that consumes them.
+- `shell/` — bash, fish, atuin, tmux, zellij, yazi, session path.
+- `terminal/` — terminal utilities with `programs.*` modules (bat, btop, fzf, zoxide, and others) and the browser terminal wrapper for the sandbox.
+- `tools/` — operator tooling (nix helpers, gpg, awscli, k9s, texlive, typst, repository sync).
+- `users/` — identity, aggregate lists, and per-user overrides; `lib.nix` declares `flake.users`.
+
+Top-level files: `app.nix` (the `home-bootstrap` app), `configurations.nix`, `mk-home.nix`.
+
+## References
+
+`github:mightyiam/dendritic` states the pattern.
+`github:drupol/infra` shows feature ownership carried through: fifteen `programs.*` and thirteen `services.*` declarations against nine raw packages, each raw package inside the feature that uses it.
+`github:GaetanLePage/nix-config` injects `core` into every home host and keeps each secret inside the feature that reads it.
+To read them locally, acquire each with `ghq` as the `dependency-source-acquisition` skill describes.

--- a/modules/home/README.md
+++ b/modules/home/README.md
@@ -17,7 +17,7 @@ If part of an aggregate needs a sops secret and part does not, split it, so that
 `ai` needs secrets and `herdr` does not, so `herdr` is its own aggregate although the tool is used alongside AI agents.
 
 Prefer the home-manager module to the raw package.
-`home.packages = [ pkgs.x ]` records only that `x` is installed; `programs.x` records its configuration surface, shell integration, and environment, at the same line count.
+`home.packages = [ pkgs.x ]` records only that `x` is installed; `programs.x` records its configuration surface, shell integration, and environment.
 A raw package is acceptable only when no `programs.*` or `services.*` module exists for it; it then lives in the aggregate that consumes it, in a file named for the package.
 
 Configure at the consumer.
@@ -29,7 +29,7 @@ A user who cannot run one module of an aggregate imports the aggregate and disab
 `users/ubuntu` does this for `programs.bash.enable` and `services.ssh-agent.enable`.
 
 Reusable options and shared data are named deferred modules or `flake.lib` values, never `_name.nix` files pulled in through `imports`; `core/catppuccin.nix` shows the pattern.
-Den and `flake-file` are not adopted here.
+Neither Den (drupol's aspect framework over dendritic flake-parts) nor `flake-file` (generating `flake.nix` from modules) is adopted here; both are evaluated in `github:drupol/infra`.
 
 ## Hazards
 
@@ -37,7 +37,7 @@ Adding a file activates it on the next evaluation; there is no registration step
 An untracked file is invisible to `nix flake check`, so run `git add` before evaluating.
 
 A user's evaluated package set is a contract for that user.
-Moving a declaration between files must not change `home.packages` for any user unless the change is the point; the structure checks under `modules/checks/` catch accidental drift.
+Moving a declaration between files must not change `home.packages` for any user unless the change is the point; compare the sorted package names before and after with the `nix eval` command under Verification; a check that pins them per user arrives with the dissolution of `packages/`.
 
 `users/ubuntu` is the profile activated inside a Devin sandbox VM, which has no systemd user manager and no AI secrets.
 Modules that start user services or read sops secrets fail there and must be overridable as described above.
@@ -46,8 +46,8 @@ Modules that start user services or read sops secrets fail there and must be ove
 
 ```bash
 direnv exec . nix flake check --accept-flake-config
-nix eval --accept-flake-config --json '.#homeConfigurations."crs58@x86_64-linux".config.home.packages' --apply 'ps: builtins.sort builtins.lessThan (map (p: p.name) ps)'
-nix build --accept-flake-config '.#homeConfigurations."ubuntu@x86_64-linux".activationPackage'
+direnv exec . nix eval --accept-flake-config --json '.#homeConfigurations."crs58@x86_64-linux".config.home.packages' --apply 'ps: builtins.sort builtins.lessThan (map (p: p.name) ps)'
+direnv exec . nix build --accept-flake-config '.#homeConfigurations."ubuntu@x86_64-linux".activationPackage'
 ```
 
 The first is the closure operator every change must pass.
@@ -60,19 +60,19 @@ The third builds the sandbox profile that the Devin snapshot activates.
 - `base/` — sops-nix wiring, including activation without systemd.
 - `core/` — fontconfig, XDG, Catppuccin, session variables, SSH, Bitwarden; imported by every user.
 - `development/` — editors (LazyVim neovim, helix), version control (git, jujutsu, radicle), terminal emulators (ghostty), and their configuration.
-- `herdr/` — the herdr terminal multiplexer, secret-free.
+- `herdr/` — the herdr terminal multiplexer and `browser-terminal`, its ttyd front end for the sandbox; secret-free.
 - `modules/` — option-declaring home-manager modules consumed by aggregates (`agents-md`).
 - `packages/` — raw package lists not yet attached to the aggregate that consumes them.
 - `shell/` — bash, fish, atuin, tmux, zellij, yazi, session path.
-- `terminal/` — terminal utilities with `programs.*` modules (bat, btop, fzf, zoxide, and others) and the browser terminal wrapper for the sandbox.
+- `terminal/` — terminal utilities with `programs.*` modules (bat, btop, fzf, zoxide, and others).
 - `tools/` — operator tooling (nix helpers, gpg, awscli, k9s, texlive, typst, repository sync).
 - `users/` — identity, aggregate lists, and per-user overrides; `lib.nix` declares `flake.users`.
 
-Top-level files: `app.nix` (the `home-bootstrap` app), `configurations.nix`, `mk-home.nix`.
+Top-level files: `app.nix` (the `home` app, an `nh`-based `home-switch`), `configurations.nix`, `mk-home.nix`; `home-bootstrap` lives in `modules/apps/bootstrap/`.
 
 ## References
 
 `github:mightyiam/dendritic` states the pattern.
-`github:drupol/infra` shows feature ownership carried through: fifteen `programs.*` and thirteen `services.*` declarations against nine raw packages, each raw package inside the feature that uses it.
+`github:drupol/infra` shows feature ownership carried through: nearly every tool is enabled through its `programs.*` or `services.*` module, and each of the few raw packages sits inside the feature that uses it.
 `github:GaetanLePage/nix-config` injects `core` into every home host and keeps each secret inside the feature that reads it.
 To read them locally, acquire each with `ghq` as the `dependency-source-acquisition` skill describes.

--- a/modules/home/ai/README.md
+++ b/modules/home/ai/README.md
@@ -26,4 +26,4 @@ Verify an edit against the source tree and treat delivered content as generated 
 
 Harness-specific modules, each configuring one agent's settings, hooks, MCP servers, and wrappers: `atomic/`, `claude-code/`, `codex/`, `firstmate/`, `omp/`, `opencode/`, `pi/`.
 
-Supporting tools these harnesses invoke: `cognee/` (memory layer), `herdr/` and `moshi/` (session multiplexing), `hunk/` and `tuicr/` (interactive diff review), `worktrunk/` (worktree management).
+Supporting tools these harnesses invoke: `cognee/` (memory layer), `moshi/` (session multiplexing), `hunk/` and `tuicr/` (interactive diff review), `worktrunk/` (worktree management).

--- a/modules/home/development/gh-dash.nix
+++ b/modules/home/development/gh-dash.nix
@@ -27,7 +27,7 @@
     # under missingkey=error. So the target is the checkout-independent
     # `owner/repo#N` form tuicr accepts (src/app/init.rs).
     #
-    # `htab` (modules/home/ai/herdr) is the herdr analogue of `tmux new-window`:
+    # `htab` (modules/home/herdr) is the herdr analogue of `tmux new-window`:
     # it creates the tab, runs the command in it over the socket, and exits, so
     # gh-dash's tea.ExecProcess resumes immediately. The command runs under
     # `$SHELL -c` (internal/shell/shell.go), so it stays free of substitutions

--- a/modules/home/herdr/browser-terminal.nix
+++ b/modules/home/herdr/browser-terminal.nix
@@ -1,0 +1,33 @@
+{ ... }:
+{
+  flake.modules.homeManager.herdr =
+    { config, pkgs, ... }:
+    let
+      # xterm.js renders in the browser and resolves fontFamily against the fonts
+      # installed on the client machine, so Nerd Font glyphs (private-use
+      # codepoints) render only if the client has one of these families. Fonts
+      # installed in this profile do not reach the browser.
+      fontFamily = "MonaspiceNe Nerd Font Mono, MonaspiceNe NF, Inconsolata Nerd Font Mono, Symbols Nerd Font Mono, Menlo, monospace";
+      browser-terminal = pkgs.writeShellApplication {
+        name = "browser-terminal";
+        runtimeInputs = [
+          pkgs.ttyd
+          config.programs.herdr.package
+        ];
+        text = ''
+          export COLORTERM=truecolor
+          exec ttyd \
+            -p "''${BROWSER_TERMINAL_PORT:-7681}" \
+            -i "''${BROWSER_TERMINAL_INTERFACE:-127.0.0.1}" \
+            -W \
+            -t fontSize=14 \
+            -t 'theme={"background":"#181818"}' \
+            -t 'fontFamily=${fontFamily}' \
+            herdr
+        '';
+      };
+    in
+    {
+      home.packages = [ browser-terminal ];
+    };
+}

--- a/modules/home/herdr/default.nix
+++ b/modules/home/herdr/default.nix
@@ -1,6 +1,6 @@
 { ... }:
 {
-  flake.modules.homeManager.ai =
+  flake.modules.homeManager.herdr =
     {
       pkgs,
       lib,

--- a/modules/home/packages/development-packages.nix
+++ b/modules/home/packages/development-packages.nix
@@ -91,7 +91,6 @@
           git-revise
           git-xet
           gitmux
-          ttyd
           d2
           graphviz
           jc

--- a/modules/home/terminal/ttyd.nix
+++ b/modules/home/terminal/ttyd.nix
@@ -1,41 +1,8 @@
 { ... }:
 {
   flake.modules.homeManager.terminal =
+    { pkgs, ... }:
     {
-      config,
-      lib,
-      pkgs,
-      ...
-    }:
-    let
-      # xterm.js renders in the browser and resolves fontFamily against the fonts
-      # installed on the client machine, so Nerd Font glyphs (private-use
-      # codepoints) render only if the client has one of these families. Fonts
-      # installed in this profile do not reach the browser.
-      fontFamily = "MonaspiceNe Nerd Font Mono, MonaspiceNe NF, Inconsolata Nerd Font Mono, Symbols Nerd Font Mono, Menlo, monospace";
-      browser-terminal = pkgs.writeShellApplication {
-        name = "browser-terminal";
-        runtimeInputs = [
-          pkgs.ttyd
-          config.programs.herdr.package
-        ];
-        text = ''
-          export COLORTERM=truecolor
-          exec ttyd \
-            -p "''${BROWSER_TERMINAL_PORT:-7681}" \
-            -i 0.0.0.0 \
-            -W \
-            -t fontSize=14 \
-            -t 'theme={"background":"#181818"}' \
-            -t 'fontFamily=${fontFamily}' \
-            herdr
-        '';
-      };
-    in
-    lib.mkIf config.programs.herdr.enable {
-      home.packages = [
-        pkgs.ttyd
-        browser-terminal
-      ];
+      home.packages = [ pkgs.ttyd ];
     };
 }

--- a/modules/home/terminal/ttyd.nix
+++ b/modules/home/terminal/ttyd.nix
@@ -1,0 +1,41 @@
+{ ... }:
+{
+  flake.modules.homeManager.terminal =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      # xterm.js renders in the browser and resolves fontFamily against the fonts
+      # installed on the client machine, so Nerd Font glyphs (private-use
+      # codepoints) render only if the client has one of these families. Fonts
+      # installed in this profile do not reach the browser.
+      fontFamily = "MonaspiceNe Nerd Font Mono, MonaspiceNe NF, Inconsolata Nerd Font Mono, Symbols Nerd Font Mono, Menlo, monospace";
+      browser-terminal = pkgs.writeShellApplication {
+        name = "browser-terminal";
+        runtimeInputs = [
+          pkgs.ttyd
+          config.programs.herdr.package
+        ];
+        text = ''
+          export COLORTERM=truecolor
+          exec ttyd \
+            -p "''${BROWSER_TERMINAL_PORT:-7681}" \
+            -i 0.0.0.0 \
+            -W \
+            -t fontSize=14 \
+            -t 'theme={"background":"#181818"}' \
+            -t 'fontFamily=${fontFamily}' \
+            herdr
+        '';
+      };
+    in
+    lib.mkIf config.programs.herdr.enable {
+      home.packages = [
+        pkgs.ttyd
+        browser-terminal
+      ];
+    };
+}

--- a/modules/home/users/crs58/meta.nix
+++ b/modules/home/users/crs58/meta.nix
@@ -17,6 +17,7 @@
       ai
       core
       development
+      herdr
       packages
       shell
       terminal

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -34,6 +34,10 @@ let
       # configuration is unreachable here and only collides with them.
       programs.bash.enable = lib.mkForce false;
 
+      # `core/bitwarden.nix` starts ssh-agent as a systemd user service on
+      # Linux, and the sandbox has no systemd user manager to run it.
+      services.ssh-agent.enable = lib.mkForce false;
+
       # The sandbox runs standalone home-manager with no session bus and no
       # systemd user manager, so sops-nix's user unit never starts and its
       # secrets would never be installed.

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -38,6 +38,14 @@ let
       # Linux, and the sandbox has no systemd user manager to run it.
       services.ssh-agent.enable = lib.mkForce false;
 
+      # The sandbox image ships only the C.UTF-8 locale, so core's en_US.UTF-8
+      # would make every shell warn from hm-session-vars.sh.
+      home.sessionVariables = {
+        LANG = lib.mkForce "C.UTF-8";
+        LC_ALL = lib.mkForce "C.UTF-8";
+        LC_CTYPE = lib.mkForce "C.UTF-8";
+      };
+
       # The sandbox runs standalone home-manager with no session bus and no
       # systemd user manager, so sops-nix's user unit never starts and its
       # secrets would never be installed.

--- a/modules/home/users/ubuntu/meta.nix
+++ b/modules/home/users/ubuntu/meta.nix
@@ -19,7 +19,9 @@
 
     aggregates = with config.flake.modules.homeManager; [
       base-sops
+      core
       development
+      herdr
       shell
       terminal
     ];


### PR DESCRIPTION
## Summary

PR-A of a three-PR stack (A: sandbox terminal → B: dissolve `packages` → C: module adoption). Tracked in Linear as CAM-44.

The Devin sandbox's built-in editor hangs in the browser-to-VM tunnel while the VM-side server stays healthy, so the sandbox needs an interactive terminal that does not depend on it. This PR provides one declaratively and, in doing so, fixes two aggregate-boundary defects it exposed.

- `modules/home/README.md` (new): the home-manager aspects index and the aggregate contract that PR-B and PR-C are verified against — one directory = one user-facing capability, one secret posture; module over raw package; configure at the consumer; per-user exceptions are `lib.mkForce` overrides, not omitted aggregates; no Den/`flake-file`, no `_*.nix` escape modules.
- `herdr` split out of `ai` into `modules/home/herdr/` (`git mv`, aggregate key `ai` → `herdr`): it reads no secret, so a user without the AI secrets can import it. `crs58` imports both; its package set is unchanged except `+browser-terminal`.
- `modules/home/herdr/browser-terminal.nix`: `writeShellApplication` around `ttyd -W … herdr`, port 7681, bind `127.0.0.1` (override `BROWSER_TERMINAL_INTERFACE`/`BROWSER_TERMINAL_PORT`), `COLORTERM=truecolor`. It lives in `herdr` because it consumes both `herdr` and `ttyd`. The xterm.js `fontFamily` list is pinned in the wrapper because the browser resolves it against the *client's* fonts; Nerd Font glyphs are private-use codepoints and never come from fonts installed in this profile.
- `modules/home/terminal/ttyd.nix`: raw `pkgs.ttyd`, unconditional, replacing the line in `packages/development-packages.nix` so users importing `terminal` without `herdr` keep it (verified: `christophersmith`, `tara` package sets identical to main).
- `users/ubuntu` imports `core` + `herdr` and overrides what the sandbox cannot run: `services.ssh-agent.enable = mkForce false` (no systemd user manager) and `LANG/LC_ALL/LC_CTYPE = mkForce "C.UTF-8"` (the image's glibc has only `C.utf8`; `core`'s `en_US.UTF-8` made every shell warn).
- `.devin/blueprint.yaml` knowledge item `terminal`: a session starts `browser-terminal` and exposes 7681 through the authenticated preview tunnel; initialize/maintenance never do (no tunnel during image builds); the tunnel is the access control.

Verification: `nix flake check`, `just lint`, statix/deadnix, `browser-terminal` derivation built (shellcheck), `ubuntu@x86_64-linux` activationPackage built; sorted `home.packages` names vs `main`: crs58 `+browser-terminal`; ubuntu `+browser-terminal +htab +herdr +ttyd +2 fontconfig dirs`; christophersmith/tara no change. Activated on the Devin VM and confirmed through the preview tunnel: ttyd → herdr → fish, Nerd Font glyphs render, `nvim` works.

Link to Devin session: https://app.devin.ai/sessions/a940684e0e14430f82ed19713c2d0385
Open in Devin Desktop: https://app.devin.ai/desktop/session/a940684e0e14430f82ed19713c2d0385?variant=devin
Requested by: @cameronraysmith