### PR TITLE
fix(home): skip the sops-nix unit restart when no age key is present

### DIFF
--- a/modules/home/README.md
+++ b/modules/home/README.md
@@ -44,8 +44,8 @@ A configuration that imports from a derivation can only be evaluated by a host t
 
 The `<aggregate>/tools.nix` files hold raw packages that no home-manager module owns yet; they are split into per-program files as modules are adopted.
 
-`users/ubuntu` is the profile activated inside a Devin sandbox VM, which has no systemd user manager and no AI secrets.
-Modules that start user services or read sops secrets fail there and must be overridable as described above.
+`users/ubuntu` is the profile activated inside a Devin sandbox VM, which has no AI secrets, and whose exec shells reach no systemd user manager while its snapshot builds do.
+Modules that start user services or read sops secrets fail there and must be overridable as described above; an activation must also succeed under a user manager with no key present, which is what `base/sops-install-without-systemd.nix` provides.
 
 ## Verification
 

--- a/modules/home/base/sops-install-without-systemd.nix
+++ b/modules/home/base/sops-install-without-systemd.nix
@@ -25,6 +25,12 @@
       );
 
       ageKeyFile = config.sops.age.keyFile;
+      systemctl = config.systemd.user.systemctlPath;
+
+      # A null key file means sops decrypts with something other than an age
+      # key, so the skip branch is never taken and the install decides.
+      ageKeyAbsent =
+        if ageKeyFile == null then "false" else "[[ ! -f ${lib.escapeShellArg ageKeyFile} ]]";
 
       # sops-install-secrets resolves $XDG_RUNTIME_DIR before it inspects any
       # path and fails when it is unset, so a profile that supplies one through
@@ -56,17 +62,6 @@
         # follows it keeps the surrounding block's indentation.
         + "  ";
 
-      # Interpolated as its own multi-line value rather than written inline in
-      # the activation string: nix strips a literal's common indentation before
-      # substitution and does not re-indent what it substitutes, so building the
-      # branch here is what lines it up with the `if` it extends.
-      # warnEcho rather than the sibling branch's verboseEcho: a profile whose
-      # secrets are not installed is worth seeing on every activation, not only a
-      # verbose one.
-      skipWhenKeyAbsent = lib.optionalString (ageKeyFile != null) ''
-        elif [[ ! -f ${lib.escapeShellArg ageKeyFile} ]]; then
-          warnEcho "sops-nix: no age key at ${ageKeyFile}; skipping secret installation until an activation runs with the key present"
-      '';
     in
     {
       options.sopsInstallWithoutSystemd.enable = lib.mkEnableOption ''
@@ -80,12 +75,6 @@
         are never installed. This option runs the same sops-nix install script
         directly instead.
 
-        The entry probes `systemctl --user is-system-running` first and does
-        nothing when a user manager is present, so enabling it on a NixOS
-        workstation is harmless. It has no effect on darwin, where sops-nix
-        already bootstraps its launchd agent from its own activation entry, and
-        none when no secrets are declared.
-
         An absent `sops.age.keyFile` is treated as the secrets coeffect not
         being present: the entry reports that it skipped the install and
         continues, so a profile can be activated where no key exists, as an
@@ -93,18 +82,34 @@
         runs and any failure is fatal. Activating again once the key is in place
         is what installs the secrets.
 
+        The entry probes `systemctl --user is-system-running` and, when a user
+        manager is present, restarts the sops-nix unit as sops-nix's own entry
+        would. That entry is replaced rather than left in place because it
+        restarts unconditionally, and a restart with no key present fails the
+        unit and with it the whole activation. Enabling this on a NixOS
+        workstation therefore changes nothing but the no-key case. It has no
+        effect on darwin, where sops-nix bootstraps its launchd agent from its
+        own entry, and none when no secrets are declared.
+
         The entry runs after `writeBoundary`. Activation entries that read the
         installed secrets should declare `entryAfter [ "sopsInstallWithoutSystemd" ]`
         rather than relying on entry order.
       '';
 
       config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux && config.sops.secrets != { }) {
-        home.activation.sopsInstallWithoutSystemd = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-          systemdStatus=$(${config.systemd.user.systemctlPath} --user is-system-running 2>&1 || true)
+        home.activation.sops-nix = lib.mkForce "";
 
-          if [[ $systemdStatus == 'running' || $systemdStatus == 'degraded' ]]; then
-            verboseEcho "sops-nix: user systemd manager is $systemdStatus; the sops-nix unit installs secrets"
-          ${skipWhenKeyAbsent}else
+        # warnEcho on the skip: a profile whose secrets are not installed is
+        # worth seeing on every activation, not only a verbose one.
+        home.activation.sopsInstallWithoutSystemd = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          systemdStatus=$(${systemctl} --user is-system-running 2>&1 || true)
+
+          if ${ageKeyAbsent}; then
+            warnEcho "sops-nix: no age key at ${toString ageKeyFile}; skipping secret installation until an activation runs with the key present"
+          elif [[ $systemdStatus == 'running' || $systemdStatus == 'degraded' ]]; then
+            verboseEcho "sops-nix: user systemd manager is $systemdStatus; restarting the sops-nix unit"
+            run ${systemctl} restart --user sops-nix
+          else
             verboseEcho "sops-nix: no user systemd manager; installing secrets directly"
             ${ensureRuntimeDir}run env ${environment} ${installScript}
           fi

--- a/modules/home/users/ubuntu/default.nix
+++ b/modules/home/users/ubuntu/default.nix
@@ -46,9 +46,10 @@ let
         LC_CTYPE = lib.mkForce "C.UTF-8";
       };
 
-      # The sandbox runs standalone home-manager with no session bus and no
-      # systemd user manager, so sops-nix's user unit never starts and its
-      # secrets would never be installed.
+      # Devin's exec shells reach no systemd user manager, so sops-nix's user
+      # unit never starts there and secrets are installed directly. Its snapshot
+      # builds do run under one, with no key, and the same option keeps that
+      # activation from failing on the unit.
       sopsInstallWithoutSystemd.enable = true;
 
       sops = {


### PR DESCRIPTION
## Summary

Devin snapshot build `sbj-171f39c38806462a82cc0f7a3f7f7106` failed in `home-bootstrap --without-secrets` with

```
Job for sops-nix.service failed because the control process exited with error code.
```

Cause: the build sandbox now runs home-manager under a systemd user manager (the 2026-09-05 build of the same `main` had none and passed; `sbj-6816492d4e3442d0b08f2ad2f3e3612c` shows the identical failure on pre-stack `main`, so the recent aggregate stack did not introduce it).
With a manager answering `is-system-running`, sops-nix's own `home.activation.sops-nix` entry runs `systemctl restart --user sops-nix` unconditionally; with no age key the unit exits 1 (`cannot read keyfile .../age/keys.txt`) and the activation with it.
`sopsInstallWithoutSystemd` promised "no key → warn and continue", but only implemented it on its no-manager branch.

Change in `modules/home/base/sops-install-without-systemd.nix`, active only where the option is enabled on Linux with secrets declared:

```nix
home.activation.sops-nix = lib.mkForce "";   # upstream entry retired

# sopsInstallWithoutSystemd, one decision:
if [[ ! -f $ageKeyFile ]]; then        warnEcho "... skipping secret installation ..."
elif manager running|degraded; then    run systemctl restart --user sops-nix
else                                   run env $sopsEnvironment $installScript
fi
```

The herdr `no herdr server is running` line in the same log is the `config.toml` `onChange` reload hook, which ends in `|| true`; it is noise, not the failure, and is left alone.

## Verification

Reproduced and fixed on a Devin VM with `user@1000.service` started and `XDG_RUNTIME_DIR=/run/user/1000`, running `nix run --accept-flake-config .#home-bootstrap -- --flake . --without-secrets`:

| user manager | age key | before | after |
|---|---|---|---|
| running | absent (snapshot case) | exit 1, unit failed | exit 0, skip warning |
| running | present | exit 0 | exit 0, `sops-nix.service` `Result=success`, secrets regenerated |
| unreachable | present | exit 0 | exit 0, direct install |
| unreachable | absent | exit 0 | exit 0 |

`nix flake check` and `just lint` pass; the activation package built from this branch is byte-identical to the one exercised above.

Not verified here: an actual snapshot build from this branch. That is the authoritative check and needs the merge plus a rebuild.

Link to Devin session: https://app.devin.ai/sessions/a940684e0e14430f82ed19713c2d0385
Open in Devin Desktop: https://app.devin.ai/desktop/session/a940684e0e14430f82ed19713c2d0385?variant=devin
Requested by: @cameronraysmith